### PR TITLE
fix: tenant disk hygiene and 5GB Blueprint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 from contextlib import asynccontextmanager
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -123,6 +124,9 @@ async def _lifespan(_app: FastAPI):
         print(f"[avery-seed] {seed_result}", flush=True)
 
         _tenants.manager().load_from_disk()
+        prune = _tenants.prune_preexisting_tenant_dirs(settings._base.tenants_root)
+        if prune.get("removed") or prune.get("errors"):
+            print(f"[tenants] prune preexisting {prune}", flush=True)
         loaded = _tenants.manager().all_tenants()
         print(
             f"[tenants] loaded {len(loaded)} tenants: "
@@ -530,6 +534,46 @@ def _rss_mb() -> float | None:
     return None
 
 
+def _volume_stats() -> dict:
+    """Used/free bytes for the tenant volume (or wiki root in OSS mode).
+
+    ``shutil.disk_usage`` reports the backing filesystem. On Render that
+    is the ``wiki-tenants`` mount when ``TENANTS_ROOT=/app/tenants``.
+    Locally it is the whole disk — still better than a silent 1 GB ceiling.
+    """
+    root = (
+        settings._base.tenants_root
+        if not settings.single_tenant_mode
+        else settings.wiki_root
+    )
+    probe = root if root.exists() else root.parent
+    try:
+        usage = shutil.disk_usage(probe)
+    except OSError:
+        return {}
+    stats: dict = {
+        "disk_total_bytes": usage.total,
+        "disk_used_bytes": usage.used,
+        "disk_free_bytes": usage.free,
+    }
+    if settings.single_tenant_mode or not settings._base.tenants_root.exists():
+        return stats
+    dirs = [
+        entry
+        for entry in settings._base.tenants_root.iterdir()
+        if entry.is_dir() and not entry.name.startswith(".")
+    ]
+    stats["tenant_dir_count"] = len(dirs)
+    stats["preexisting_dir_count"] = sum(
+        1 for entry in dirs if _tenants.is_preexisting_tenant_id(entry.name)
+    )
+    try:
+        stats["tenant_count"] = len(_tenants.manager().all_tenants())
+    except Exception:  # noqa: BLE001 — healthz must never 500
+        pass
+    return stats
+
+
 @app.get("/healthz")
 def healthz() -> dict:
     payload: dict = {
@@ -540,6 +584,7 @@ def healthz() -> dict:
     rss = _rss_mb()
     if rss is not None:
         payload["rss_mb"] = rss
+    payload.update(_volume_stats())
     if not settings.single_tenant_mode:
         try:
             warm = _tenants.manager().indexed_tenant_ids()

--- a/backend/app/persistence.py
+++ b/backend/app/persistence.py
@@ -596,8 +596,8 @@ def bootstrap_tenant(tenant: "Tenant") -> dict:
       * If wiki_root is already a git repo with matching remote: fetch +
         fast-forward, no destructive ops.
       * If wiki_root exists but isn't a git repo (user has un-synced local
-        content): move it aside to ``<wiki_root>.preexisting`` and clone.
-        Always non-destructive — local content is preserved.
+        content): move it aside to ``<wiki_root>.preexisting`` and clone
+        ``--depth 1``. Always non-destructive — local content is preserved.
       * If clone returns an empty repo: initialize the working tree as a
         fresh git repo, write .gitignore, commit any existing wiki/raw
         content, push to seed the remote.
@@ -651,7 +651,7 @@ def bootstrap_tenant(tenant: "Tenant") -> dict:
     # Try to clone. If the remote is empty, this returns 0 with a warning,
     # and we still end up with an initialized .git dir.
     rc, out = _run_git(
-        ["clone", "--branch", branch, remote_url, str(root)],
+        ["clone", "--depth", "1", "--branch", branch, remote_url, str(root)],
         cwd=Path("/tmp"),
         timeout=120,
     )
@@ -660,7 +660,7 @@ def bootstrap_tenant(tenant: "Tenant") -> dict:
         # specifying a branch (lets git init the working tree from HEAD,
         # which on empty remotes just makes an empty .git).
         rc2, out2 = _run_git(
-            ["clone", remote_url, str(root)],
+            ["clone", "--depth", "1", remote_url, str(root)],
             cwd=Path("/tmp"),
             timeout=120,
         )

--- a/backend/app/tenants.py
+++ b/backend/app/tenants.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import threading
 import time
 from contextvars import ContextVar
@@ -43,6 +44,38 @@ from .config import settings
 
 if TYPE_CHECKING:
     from .wiki import WikiIndex
+
+
+# Connect-repo stashes a non-git wiki_root as ``<id>.preexisting`` before
+# clone. Those dirs keep tenant.json, so a naive disk scan registered them
+# as extra tenants and doubled volume use. They are leftovers, not tenants.
+PREEXISTING_SUFFIX = ".preexisting"
+
+
+def is_preexisting_tenant_id(tenant_id: str) -> bool:
+    return tenant_id.endswith(PREEXISTING_SUFFIX)
+
+
+def prune_preexisting_tenant_dirs(root: Path) -> dict:
+    """Delete leftover ``*.preexisting`` stash directories under ``root``.
+
+    Call at process startup only. ``bootstrap_tenant`` uses the same
+    suffix as a mid-request stash; pruning while a clone is in flight
+    would drop that content.
+    """
+    removed = []
+    errors = []
+    if not root.exists():
+        return {"removed": removed, "errors": errors}
+    for entry in list(root.iterdir()):
+        if not entry.is_dir() or not is_preexisting_tenant_id(entry.name):
+            continue
+        try:
+            shutil.rmtree(entry)
+            removed.append(entry.name)
+        except OSError as exc:
+            errors.append({"name": entry.name, "error": str(exc)})
+    return {"removed": removed, "errors": errors}
 
 
 # Cap how many per-tenant WikiIndex objects we keep warm. Each index holds
@@ -306,6 +339,8 @@ class TenantManager:
                 if root.exists():
                     for entry in sorted(root.iterdir()):
                         if not entry.is_dir() or entry.name.startswith("."):
+                            continue
+                        if is_preexisting_tenant_id(entry.name):
                             continue
                         meta_path = entry / _TENANT_META_FILE
                         if not meta_path.exists():

--- a/backend/tests/test_hosted_multitenant.py
+++ b/backend/tests/test_hosted_multitenant.py
@@ -300,6 +300,17 @@ def test_tenants_public_list_excludes_default(multi_tenant_app):
     assert "default" not in ids
 
 
+def test_healthz_reports_tenant_volume(multi_tenant_app):
+    r = multi_tenant_app.get("/healthz")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["tenant_count"] == 2
+    assert data["tenant_dir_count"] == 2
+    assert data["preexisting_dir_count"] == 0
+    assert data["disk_total_bytes"] > 0
+    assert data["disk_free_bytes"] >= 0
+
+
 def test_tenant_metadata_endpoint(multi_tenant_app):
     r = multi_tenant_app.get("/tenants/alice")
     assert r.status_code == 200

--- a/backend/tests/test_persistence_tenant.py
+++ b/backend/tests/test_persistence_tenant.py
@@ -675,3 +675,31 @@ def test_pull_share_tokens_substantive_mint_still_blocks(
     assert result.get("ok") is False, result
     assert result.get("action") == "dirty", result
     assert not (wiki_root / "remote-page.md").exists()
+
+
+def test_bootstrap_tenant_clone_is_shallow(tmp_path: Path, monkeypatch):
+    """connect-repo must shallow-clone onto the tenant volume."""
+    bare = tmp_path / "remote.git"
+    bare.mkdir()
+    _init_bare(bare)
+    _seed_remote(bare, tmp_path)
+
+    from app import persistence as _persistence
+
+    recorded = []
+    real_run = _persistence._run_git
+
+    def _capture(args, **kwargs):
+        recorded.append(list(args))
+        return real_run(args, **kwargs)
+
+    monkeypatch.setattr(_persistence, "_run_git", _capture)
+    _patch_remote_url(monkeypatch, bare)
+    wiki_root = tmp_path / "tenant-shallow"
+    tenant = _make_tenant("shallow", wiki_root, bare)
+
+    result = _persistence.bootstrap_tenant(tenant)
+    assert result["ok"] is True, result
+    clones = [args for args in recorded if args and args[0] == "clone"]
+    assert clones, recorded
+    assert clones[0][:3] == ["clone", "--depth", "1"]

--- a/backend/tests/test_query_and_ingest.py
+++ b/backend/tests/test_query_and_ingest.py
@@ -146,3 +146,6 @@ def test_healthz_reports_page_count(client):
     assert data["status"] == "ok"
     # The owner-visible page count includes private pages too.
     assert data["page_count"] >= 4
+    assert data["disk_total_bytes"] > 0
+    assert data["disk_used_bytes"] >= 0
+    assert data["disk_free_bytes"] >= 0

--- a/backend/tests/test_tenant_disk_hygiene.py
+++ b/backend/tests/test_tenant_disk_hygiene.py
@@ -10,9 +10,7 @@ import json
 from dataclasses import replace
 from pathlib import Path
 
-from app.config import settings
 from app.tenants import (
-    TenantManager,
     is_preexisting_tenant_id,
     prune_preexisting_tenant_dirs,
 )
@@ -43,15 +41,24 @@ def test_preexisting_id_helper() -> None:
 
 
 def test_load_from_disk_skips_preexisting(tmp_path: Path, monkeypatch) -> None:
+    # Patch the settings object TenantManager actually reads. A module-level
+    # ``from app.config import settings`` can be stale after hosted tests
+    # reload config (CI order: this file runs after test_hosted_multitenant).
+    from app import tenants as tenants_mod
+
     _write_tenant(tmp_path, "alice")
     leftover = _write_tenant(tmp_path, "alice.preexisting")
     orphan = _write_tenant(tmp_path, "plttn.preexisting")
     monkeypatch.setattr(
-        settings,
+        tenants_mod.settings,
         "_base",
-        replace(settings._base, single_tenant_mode=False, tenants_root=tmp_path),
+        replace(
+            tenants_mod.settings._base,
+            single_tenant_mode=False,
+            tenants_root=tmp_path,
+        ),
     )
-    mgr = TenantManager()
+    mgr = tenants_mod.TenantManager()
     mgr.load_from_disk()
     ids = {tenant.id for tenant in mgr.all_tenants()}
     assert ids == {"alice"}

--- a/backend/tests/test_tenant_disk_hygiene.py
+++ b/backend/tests/test_tenant_disk_hygiene.py
@@ -1,0 +1,71 @@
+"""Tenant-volume hygiene: skip/prune ``*.preexisting``, healthz disk.
+
+Connect-repo stashes a non-git wiki_root as ``<id>.preexisting``. Those
+dirs keep ``tenant.json``, so a naive scan registered them as tenants
+and doubled disk use. They are leftovers, not tenants.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+from app.config import settings
+from app.tenants import (
+    TenantManager,
+    is_preexisting_tenant_id,
+    prune_preexisting_tenant_dirs,
+)
+
+
+def _write_tenant(root: Path, tenant_id: str) -> Path:
+    dest = root / tenant_id
+    dest.mkdir()
+    (dest / "tenant.json").write_text(
+        json.dumps(
+            {
+                "id": tenant_id,
+                "display_name": tenant_id,
+                "gh_login": tenant_id,
+                "visibility": "public",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return dest
+
+
+def test_preexisting_id_helper() -> None:
+    assert is_preexisting_tenant_id("alice.preexisting")
+    assert is_preexisting_tenant_id("plttn.preexisting")
+    assert not is_preexisting_tenant_id("alice")
+    assert not is_preexisting_tenant_id("preexisting")
+
+
+def test_load_from_disk_skips_preexisting(tmp_path: Path, monkeypatch) -> None:
+    _write_tenant(tmp_path, "alice")
+    leftover = _write_tenant(tmp_path, "alice.preexisting")
+    orphan = _write_tenant(tmp_path, "plttn.preexisting")
+    monkeypatch.setattr(
+        settings,
+        "_base",
+        replace(settings._base, single_tenant_mode=False, tenants_root=tmp_path),
+    )
+    mgr = TenantManager()
+    mgr.load_from_disk()
+    ids = {tenant.id for tenant in mgr.all_tenants()}
+    assert ids == {"alice"}
+    assert leftover.is_dir()
+    assert orphan.is_dir()
+
+
+def test_prune_preexisting_removes_stash_dirs(tmp_path: Path) -> None:
+    live = _write_tenant(tmp_path, "alice")
+    leftover = _write_tenant(tmp_path, "alice.preexisting")
+    orphan = _write_tenant(tmp_path, "plttn.preexisting")
+    result = prune_preexisting_tenant_dirs(tmp_path)
+    assert set(result["removed"]) == {"alice.preexisting", "plttn.preexisting"}
+    assert result["errors"] == []
+    assert live.is_dir()
+    assert not leftover.exists()
+    assert not orphan.exists()

--- a/render.yaml
+++ b/render.yaml
@@ -66,18 +66,17 @@ services:
     # that needs to outlive the container. Do NOT mount at `/app` (it
     # would shadow the baked-in application code at /app/backend) or at
     # `/app/wiki` (that's just the unused default-tenant fallback, which
-    # the image re-seeds from wiki-demo/ on every boot). 1 GB is the
-    # current dashboard size — not a markdown-era "3000x footprint".
-    # Connect-repo does a full tenant git clone onto this volume; leftover
-    # ``*.preexisting`` stash dirs used to register as extra tenants.
-    # Grow the live disk in the Render dashboard first, then bump
-    # ``sizeGB`` so Blueprint does not drift. Do not claim a grow here.
+    # the image re-seeds from wiki-demo/ on every boot). 5 GB matches
+    # the hosted wiki-tenants volume. Connect-repo shallow-clones onto
+    # this mount; leftover ``*.preexisting`` stash dirs are not tenants.
+    # Keep ``sizeGB`` in lockstep with the live Render disk so Blueprint
+    # does not shrink or drift.
     # Single-tenant OSS self-hosters on free tier: delete this whole
     # block (see the header).
     disk:
       name: wiki-tenants
       mountPath: /app/tenants
-      sizeGB: 1
+      sizeGB: 5
     # The Dockerfile's CMD runs uvicorn directly. The Avery-tenant seed
     # is handled inside the FastAPI app's lifespan hook
     # (app/avery_seed.py::auto_seed_if_missing) the first time the

--- a/render.yaml
+++ b/render.yaml
@@ -67,7 +67,11 @@ services:
     # would shadow the baked-in application code at /app/backend) or at
     # `/app/wiki` (that's just the unused default-tenant fallback, which
     # the image re-seeds from wiki-demo/ on every boot). 1 GB is the
-    # smallest tier and is ~3000x our current content footprint.
+    # current dashboard size — not a markdown-era "3000x footprint".
+    # Connect-repo does a full tenant git clone onto this volume; leftover
+    # ``*.preexisting`` stash dirs used to register as extra tenants.
+    # Grow the live disk in the Render dashboard first, then bump
+    # ``sizeGB`` so Blueprint does not drift. Do not claim a grow here.
     # Single-tenant OSS self-hosters on free tier: delete this whole
     # block (see the header).
     disk:


### PR DESCRIPTION
## Summary
- Skip and prune leftover `*.preexisting` tenant dirs; shallow-clone on connect-repo; report used/free and tenant counts on `/healthz`.
- Bump `render.yaml` `wiki-tenants` `sizeGB` 1 → 5 so Blueprint matches the live disk grow.

## Test plan
- [x] `pytest` hygiene + healthz + shallow-clone + existing gitignore clone (8 passed)
- [ ] Confirm Render disk `wiki-tenants` shows 5 GB after dashboard grow
- [ ] After merge, `/healthz` on hosted includes `disk_*` and `tenant_count`
- [ ] Public `/tenants` no longer lists `*.preexisting` rows