### PR TITLE
fix: close hosted over-share and tenant authz holes

### DIFF
--- a/HOSTED_DEPLOYMENT.md
+++ b/HOSTED_DEPLOYMENT.md
@@ -67,7 +67,7 @@ In the Render dashboard for the FastAPI service, set:
 ```bash
 # Multi-tenant mode
 SINGLE_TENANT_MODE=0
-TENANTS_ROOT=/var/data/tenants         # persistent disk path
+TENANTS_ROOT=/app/tenants              # must match render.yaml disk mountPath
 
 # Session cookie
 SESSION_SECRET=<openssl rand -hex 32>
@@ -82,23 +82,26 @@ GITHUB_OAUTH_REDIRECT_URL=https://api.portablellm.wiki/auth/github/callback
 PUBLIC_BASE_URL=https://portablellm.wiki
 CORS_ORIGINS=https://portablellm.wiki
 
-# Default tier for new pages (private is safer; public makes onboarding
-# feel snappier because newly-drafted pages show up to anonymous viewers
-# right away)
-DEFAULT_TIER=public
+# Default tier for new pages. Private so nothing is public until the
+# owner promotes it. Avery demo pages stay public via the seeder.
+DEFAULT_TIER=private
 
 # Anthropic + OpenAI keys: still shared in v1.0. v1.1 adds per-tenant
 # BYO LLM keys.
 ANTHROPIC_API_KEY=<key>
 ```
 
-`OWNER_TOKEN` is **not used** in hosted mode — each tenant is "the
-owner" of their own wiki by virtue of a valid session for their
-`tenant_id`. You can leave it unset.
+`OWNER_TOKEN` is **not a master key** in hosted mode — it must not
+unlock another tenant's `/owner/*` routes. Each tenant is owned by a
+matching session cookie or that tenant's private personal-LLM share
+token. You can leave `OWNER_TOKEN` unset.
 
-Make sure the Render disk is mounted at `/var/data` (the default for
-Render persistent disks) so `TENANTS_ROOT=/var/data/tenants` survives
-restarts.
+Make sure the Render disk `mountPath` is `/app/tenants` so
+`TENANTS_ROOT=/app/tenants` survives restarts (see `render.yaml`).
+
+Sign-out and switch-account in the nav must **POST** (`POST /auth/logout`,
+`POST /auth/switch-account`). GET on those paths does not clear the
+session.
 
 ### 4. Vercel: frontend env vars
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,7 +15,9 @@ WIKI_ROOT=/Users/me/my-wiki
 # requires `Authorization: Bearer <OWNER_TOKEN>`. Generate one with:
 #   openssl rand -hex 32
 # On Render, `render.yaml` sets `generateValue: true` so this is auto-filled.
-OWNER_TOKEN=change-me-to-a-long-random-string
+# Leave empty here; do not commit a real token or the example placeholder.
+# Single-tenant boot refuses OWNER_TOKEN=change-me-to-a-long-random-string.
+OWNER_TOKEN=
 
 # ---------------------------------------------------------------------------
 # Tier model
@@ -90,7 +92,9 @@ PUBLIC_BASE_URL=http://localhost:3000
 #   1. Create an empty private repo, e.g. "my-wiki" on github.com.
 #   2. Generate a PAT at https://github.com/settings/tokens?type=beta
 #      with "Contents: read & write" scope, repo-scoped to that one repo.
-#   3. Set WIKI_GIT_REMOTE to the clone URL with the PAT embedded:
+#   3. Set WIKI_GIT_REMOTE to the clone URL. Embedding a PAT in the URL
+#      is discouraged — prefer a separate token env / git credential
+#      helper when you can. The PAT-in-URL form still works:
 # WIKI_GIT_REMOTE=https://USER:PAT@github.com/USER/my-wiki.git
 # WIKI_GIT_BRANCH=main
 # WIKI_GIT_USER_NAME=Portable LLM Wiki Bot

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,7 +35,7 @@ COPY scripts /app/scripts
 
 # Default env (override at deploy time)
 ENV WIKI_ROOT=/app/wiki \
-    DEFAULT_TIER=public \
+    DEFAULT_TIER=private \
     PUBLIC_BASE_URL=http://localhost:8000 \
     CORS_ORIGINS=http://localhost:3000 \
     PYTHONUNBUFFERED=1

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -140,7 +140,13 @@ def viewer_from_header(authorization: str | None) -> Viewer:
     if len(parts) != 2 or parts[0].lower() != "bearer":
         return PUBLIC_VIEWER
     token = parts[1].strip()
-    if settings.owner_token and hmac.compare_digest(token, settings.owner_token):
+    # Hosted OWNER_TOKEN is not a master key across tenants. OSS
+    # single-tenant still treats the env token as the owner credential.
+    if (
+        settings.single_tenant_mode
+        and settings.owner_token
+        and hmac.compare_digest(token, settings.owner_token)
+    ):
         return Viewer(tier="private", is_owner=True, label="owner")
     # Static SHARE_TOKENS env var (legacy v0 mechanism)
     tiers = _share_tokens()
@@ -240,13 +246,32 @@ def require_owner(
     a real owner from doing owner-only operations.
     """
     v = viewer_from_header(authorization)
-    if v.is_owner:
-        return v
-    session_owner = _session_owner_viewer(request)
-    if session_owner is not None:
-        return session_owner
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Owner token required",
-        headers={"WWW-Authenticate": "Bearer"},
-    )
+    if not v.is_owner:
+        session_owner = _session_owner_viewer(request)
+        if session_owner is not None:
+            v = session_owner
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Owner token required",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+    _reject_demo_writes()
+    return v
+
+
+def _reject_demo_writes() -> None:
+    """Demo tenants (Avery) are read-only — no owner mutations."""
+    if settings.single_tenant_mode:
+        return
+    try:
+        from . import tenants as _tenants
+
+        current = _tenants.current_tenant_or_none()
+    except Exception:  # noqa: BLE001
+        return
+    if current is not None and current.is_demo:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="demo tenant is read-only",
+        )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -107,6 +107,20 @@ class Settings:
         raise AttributeError(name)
 
 
+_PLACEHOLDER_OWNER_TOKENS = frozenset({"change-me-to-a-long-random-string"})
+
+
+def _load_owner_token(single_tenant_mode: bool) -> str:
+    """Read OWNER_TOKEN. Refuse the documented example placeholder in OSS."""
+    token = os.environ.get("OWNER_TOKEN", "").strip()
+    if single_tenant_mode and token in _PLACEHOLDER_OWNER_TOKENS:
+        raise RuntimeError(
+            "OWNER_TOKEN is still the example placeholder. Generate a real "
+            "token with: openssl rand -hex 32"
+        )
+    return token
+
+
 def _load_settings() -> Settings:
     raw_root = os.environ.get("WIKI_ROOT", "").strip()
     if not raw_root:
@@ -161,7 +175,7 @@ def _load_settings() -> Settings:
         default_wiki_root=root,
         tenants_root=tenants_root,
         single_tenant_mode=single_tenant_mode,
-        owner_token=os.environ.get("OWNER_TOKEN", "").strip(),
+        owner_token=_load_owner_token(single_tenant_mode),
         default_tier=default_tier,
         anthropic_api_key=os.environ.get("ANTHROPIC_API_KEY") or None,
         # Default to the top of ANTHROPIC_FALLBACK_CHAIN in llm.py. If this

--- a/backend/app/direct_drafter.py
+++ b/backend/app/direct_drafter.py
@@ -609,6 +609,7 @@ async def draft_starter_pages(
         prompt=prompt,
         source_label=source_label,
         tenant=tenant,
+        force_tier="private",
     )
 
 

--- a/backend/app/direct_linter.py
+++ b/backend/app/direct_linter.py
@@ -69,6 +69,7 @@ from .orchestrator import (
     _load_jobs,
     _lock,
     _save_jobs,
+    stamp_tenant_id,
 )
 
 
@@ -349,6 +350,7 @@ def _create_running_job(worker_name: str, swarm_id: str, log_path: Path) -> Trac
         artifacts_path=str(
             settings.wiki_root / ".lint" / swarm_id / f"{worker_name}.json"
         ),
+        tenant_id=stamp_tenant_id(),
     )
     job.status = "running"
     with _lock:

--- a/backend/app/drafter.py
+++ b/backend/app/drafter.py
@@ -30,6 +30,7 @@ from .orchestrator import (
     _save_jobs,
     _lock,
     build_worker_cmd,
+    stamp_tenant_id,
 )
 
 
@@ -270,6 +271,7 @@ def _spawn_drafter_job(
         cwd=cwd,
         log_path=str(log_path),
         artifacts_path=target_rel,
+        tenant_id=stamp_tenant_id(),
     )
 
     proc = subprocess.Popen(

--- a/backend/app/hosted_routes.py
+++ b/backend/app/hosted_routes.py
@@ -480,8 +480,18 @@ async def github_callback(
         raise HTTPException(status_code=502, detail=f"github oauth failed: {exc.message}") from exc
 
     tenant_id = gh_user.login.lower()
+    if tenant_id in tenants.RESERVED_TENANT_IDS:
+        raise HTTPException(
+            status_code=403,
+            detail="this GitHub login is reserved and cannot be bound",
+        )
     mgr = tenants.manager()
     tenant = mgr.get(tenant_id)
+    if tenant is not None and tenant.is_demo:
+        raise HTTPException(
+            status_code=403,
+            detail="demo tenant cannot be bound or overwritten",
+        )
     if tenant is None:
         tenant = mgr.provision_local(
             tenant_id,
@@ -650,46 +660,22 @@ def auth_logout(request: Request) -> dict:
 
 
 @router.get("/auth/logout")
-def auth_logout_redirect(request: Request, return_to: str = "") -> RedirectResponse:
-    """Clear the session cookie and bounce back to the frontend.
+def auth_logout_get_rejected() -> JSONResponse:
+    """GET must not clear the session (logout CSRF). Nav must POST.
 
-    Same effect as POST /auth/logout but reachable from a plain
-    ``<a href>`` so the nav menu "Sign out" works without JavaScript.
-    ``return_to`` is validated against the same allow-list OAuth uses,
-    so this can't be abused as an open redirect.
-
-    Landing-page choice: the fallback target is the frontend ROOT (``/``),
-    not ``/welcome``. The welcome page is fundamentally a signed-in
-    onboarding step — if it gets visited anonymously (which signing out
-    produces), it renders a "we can't finish signing you in / cookie
-    didn't make it back" error that's both wrong and alarming for the
-    user who just deliberately signed out. Landing on the public
-    homepage instead reads as a clean sign-off.
+    A crafted ``<img src>`` or prefetch of GET /auth/logout used to sign
+    the victim out. POST /auth/logout is the only path that clears the
+    cookie. The frontend nav must use a form POST or fetch, not ``<a href>``.
     """
     _require_hosted_mode()
-    if hasattr(request, "session"):
-        request.session.clear()
-    # _safe_redirect returns _default_return_to() (= /welcome) when the
-    # given target fails the allow-list, which is the WRONG default for
-    # logout. So we resolve sign-out's own default first (root), then
-    # only run _safe_redirect when an explicit return_to was passed.
-    if return_to:
-        target = _safe_redirect(return_to)
-        # _safe_redirect's "rejected" sentinel is _default_return_to()
-        # (= /welcome). If we got that back from a return_to that the
-        # caller bothered to specify, it was probably the www/apex
-        # mismatch — but either way, prefer root over /welcome for
-        # the post-logout case.
-        if target == _default_return_to():
-            target = _logout_default_landing()
-    else:
-        target = _logout_default_landing()
-    # Reanchor onto PUBLIC_BASE_URL if the caller passed a bare path —
-    # /auth/logout lives on api.portablellm.wiki, but the user wants to
-    # land back on portablellm.wiki.
-    if target.startswith("/") and settings.public_base_url:
-        target = settings.public_base_url.rstrip("/") + target
-    return RedirectResponse(url=target, status_code=302)
+    return JSONResponse(
+        status_code=405,
+        content={
+            "ok": False,
+            "detail": "Use POST /auth/logout to sign out. GET does not clear the session.",
+        },
+        headers={"Allow": "POST"},
+    )
 
 
 def _logout_default_landing() -> str:
@@ -780,12 +766,26 @@ async def owner_delete_account(request: Request) -> JSONResponse:
 
 
 @router.get("/auth/switch-account")
+def auth_switch_account_get_rejected() -> JSONResponse:
+    """GET must not clear the session. Nav must POST /auth/switch-account."""
+    _require_hosted_mode()
+    return JSONResponse(
+        status_code=405,
+        content={
+            "ok": False,
+            "detail": "Use POST /auth/switch-account. GET does not clear the session.",
+        },
+        headers={"Allow": "POST"},
+    )
+
+
+@router.post("/auth/switch-account")
 def auth_switch_account(
     request: Request, return_to: str = ""
 ) -> RedirectResponse:
     """Clear our session and immediately kick off the GitHub OAuth flow.
 
-    UX: the nav's "Switch GitHub account" menu action lands here. We
+    UX: the nav's "Switch GitHub account" menu action POSTs here. We
     can't drive GitHub itself to ``prompt=select_account`` (the GitHub
     OAuth provider doesn't support it the way Google's does), so the
     real switch happens at github.com — whichever account the user is
@@ -793,11 +793,8 @@ def auth_switch_account(
     want a different one, they sign out of github.com first or open
     incognito; the menu copy explains this.
 
-    Implementation note: we used to drive this from the client with a
-    two-hop chain (``/auth/logout?return_to=<encoded /auth/github/login
-    URL>``), but ``_safe_redirect`` rightly rejects API-origin return
-    targets to keep itself a tight open-redirect guard. Doing the
-    clear+redirect server-side is both cleaner and immune to that.
+    GET is rejected (does not clear the session) so a CSRF-via-GET
+    cannot sign the user out. The frontend nav must POST.
     """
     _require_hosted_mode()
     _require_oauth_config()
@@ -1233,9 +1230,9 @@ class AssembleRequest(BaseModel):
     somewhere before drafting.
     """
 
-    answers: list[AssembleAnswer] = Field(default_factory=list)
-    text_sources: list[AssembleTextSource] = Field(default_factory=list)
-    urls: list[AssembleUrlSource] = Field(default_factory=list)
+    answers: list[AssembleAnswer] = Field(default_factory=list, max_length=8)
+    text_sources: list[AssembleTextSource] = Field(default_factory=list, max_length=8)
+    urls: list[AssembleUrlSource] = Field(default_factory=list, max_length=5)
     # Same toggle the existing text/URL onboarding endpoints expose. Self-
     # hosters with Puppetmaster get the agentic path; the hosted product
     # falls through to the direct-LLM drafter inside the same helper.
@@ -1897,14 +1894,12 @@ async def github_push_webhook(request: Request) -> dict:
     repo = payload.get("repository") or {}
     full_name = str(repo.get("full_name") or "")
     tenant = _tenant_for_repo(full_name)
-    if tenant is None:
-        # Unknown repo — nothing we manage. 404 so GitHub's webhook
-        # delivery log shows it as unrouted rather than silently OK.
-        raise HTTPException(status_code=404, detail="no tenant for repo")
-
     signature = request.headers.get("X-Hub-Signature-256", "")
-    if not _verify_github_signature(tenant.gh_webhook_secret, raw_body, signature):
-        raise HTTPException(status_code=401, detail="bad signature")
+    secret = tenant.gh_webhook_secret if tenant is not None else ""
+    # Unknown repo and bad/missing HMAC share one status so existence
+    # is not distinguishable. Empty secret fails closed.
+    if tenant is None or not _verify_github_signature(secret, raw_body, signature):
+        raise HTTPException(status_code=401, detail="unauthorized")
 
     # Ping (sent on hook creation) — acknowledge, no work.
     if event == "ping":
@@ -2472,16 +2467,16 @@ def onboarding_cleanup_imports(request: Request) -> dict:
 
 @router.get("/tenants")
 def list_tenants() -> dict:
-    """Public list of tenants whose ``visibility`` is ``public`` or ``unlisted``.
+    """Public list of tenants whose ``visibility`` is ``public``.
 
-    Used by the landing page to show ``portablellm.wiki/<user>`` examples and
-    by the demo experience to discover Avery.
+    Unlisted wikis are reachable by direct URL (GET /tenants/{id}) but
+    must not appear in the directory. Private tenants 404 on GET by id.
     """
     if settings.single_tenant_mode:
         return {"tenants": []}
     out = []
     for t in tenants.manager().all_tenants():
-        if t.visibility not in ("public", "unlisted"):
+        if t.visibility != "public":
             continue
         out.append(
             {
@@ -2514,3 +2509,36 @@ def get_tenant_public(tenant_id: str) -> dict:
         "created_at": t.created_at,
         "visibility": t.visibility,
     }
+
+
+class TenantVisibilityBody(BaseModel):
+    visibility: str = Field(..., min_length=1, max_length=16)
+
+
+@router.patch("/owner/tenant/visibility")
+@router.post("/owner/tenant/visibility")
+def owner_set_tenant_visibility(
+    request: Request,
+    body: TenantVisibilityBody,
+) -> dict:
+    """Owner-only visibility setter, scoped to the current tenant."""
+    from .auth import require_owner
+
+    _require_hosted_mode()
+    require_owner(request, request.headers.get("authorization"))
+    vis = body.visibility.strip().lower()
+    if vis not in tenants.VALID_VISIBILITY:
+        raise HTTPException(
+            status_code=400,
+            detail="visibility must be public, unlisted, or private",
+        )
+    tenant = tenants.current_tenant_or_none()
+    if tenant is None or tenant.id == "default":
+        user = _session_user(request)
+        if user:
+            tenant = tenants.manager().get(user["tenant_id"])
+    if tenant is None:
+        raise HTTPException(status_code=404, detail="no current tenant")
+    tenant.visibility = vis
+    tenant._persist()
+    return {"ok": True, "id": tenant.id, "visibility": tenant.visibility}

--- a/backend/app/lint_swarm.py
+++ b/backend/app/lint_swarm.py
@@ -56,6 +56,7 @@ class LintSwarmRecord:
     worker_kinds: dict[str, str] = field(default_factory=dict)  # tracking_id -> kind
     status: str = "running"  # running | done | error
     ended_at: Optional[str] = None
+    tenant_id: Optional[str] = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -345,6 +346,7 @@ def _spawn_worker(
         cwd=cwd,
         log_path=str(log_path),
         artifacts_path=output_file,
+        tenant_id=orchestrator.stamp_tenant_id(),
     )
 
     proc = subprocess.Popen(
@@ -403,6 +405,7 @@ def start_lint_swarm(workers: Optional[list[str]] = None) -> LintSwarmRecord:
         artifacts_dir=str(artifacts_dir),
         worker_tracking_ids=[],
         worker_kinds={},
+        tenant_id=orchestrator.stamp_tenant_id(),
     )
 
     use_direct_fallback = False
@@ -477,16 +480,32 @@ def start_lint_swarm(workers: Optional[list[str]] = None) -> LintSwarmRecord:
 # ---------------------------------------------------------------------------
 
 
+def _swarm_visible(rec: LintSwarmRecord) -> bool:
+    if rec.tenant_id:
+        return orchestrator.job_visible_to_current(rec.tenant_id, rec.artifacts_dir)
+    # Legacy records: visible only when artifacts live under this tenant's wiki.
+    root = Path(orchestrator._scope_wiki_root()).resolve()
+    try:
+        Path(rec.artifacts_dir).resolve().relative_to(root)
+        return True
+    except (ValueError, OSError):
+        return False
+
+
 def get_swarm(swarm_id: str) -> Optional[LintSwarmRecord]:
     with _swarm_lock:
-        return _load_swarms().get(swarm_id)
+        rec = _load_swarms().get(swarm_id)
+    if rec is None or not _swarm_visible(rec):
+        return None
+    return rec
 
 
 def list_swarms(limit: int = 25) -> list[LintSwarmRecord]:
     with _swarm_lock:
         recs = list(_load_swarms().values())
-    recs.sort(key=lambda r: r.started_at, reverse=True)
-    return recs[:limit]
+    visible = [r for r in recs if _swarm_visible(r)]
+    visible.sort(key=lambda r: r.started_at, reverse=True)
+    return visible[:limit]
 
 
 def _read_worker_artifact(artifacts_dir: Path, worker_name: str) -> dict:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -551,47 +551,24 @@ def _volume_stats() -> dict:
         usage = shutil.disk_usage(probe)
     except OSError:
         return {}
-    stats: dict = {
+    return {
         "disk_total_bytes": usage.total,
         "disk_used_bytes": usage.used,
         "disk_free_bytes": usage.free,
     }
-    if settings.single_tenant_mode or not settings._base.tenants_root.exists():
-        return stats
-    dirs = [
-        entry
-        for entry in settings._base.tenants_root.iterdir()
-        if entry.is_dir() and not entry.name.startswith(".")
-    ]
-    stats["tenant_dir_count"] = len(dirs)
-    stats["preexisting_dir_count"] = sum(
-        1 for entry in dirs if _tenants.is_preexisting_tenant_id(entry.name)
-    )
-    try:
-        stats["tenant_count"] = len(_tenants.manager().all_tenants())
-    except Exception:  # noqa: BLE001 — healthz must never 500
-        pass
-    return stats
 
 
 @app.get("/healthz")
 def healthz() -> dict:
+    """Public liveness. No tenant identities, wiki_root, or tenant counts."""
     payload: dict = {
         "status": "ok",
-        "wiki_root": str(settings.wiki_root),
         "page_count": len(index.all_pages()),
     }
     rss = _rss_mb()
     if rss is not None:
         payload["rss_mb"] = rss
     payload.update(_volume_stats())
-    if not settings.single_tenant_mode:
-        try:
-            warm = _tenants.manager().indexed_tenant_ids()
-            payload["indexed_tenants"] = len(warm)
-            payload["indexed_tenant_ids"] = warm[:20]
-        except Exception:  # noqa: BLE001 — healthz must never 500
-            pass
     return payload
 
 

--- a/backend/app/orchestrator.py
+++ b/backend/app/orchestrator.py
@@ -234,6 +234,7 @@ class TrackedJob:
     exit_code: Optional[int] = None
     summary: Optional[str] = None
     artifacts_path: Optional[str] = None
+    tenant_id: Optional[str] = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -271,16 +272,65 @@ def _update(tracking_id: str, **fields) -> None:
         _save_jobs(jobs)
 
 
+def stamp_tenant_id() -> Optional[str]:
+    """Tenant id to stamp on a new job/swarm for the current request."""
+    try:
+        from . import tenants as _tenants
+
+        current = _tenants.current_tenant_or_none()
+        if current is not None:
+            return current.id
+    except Exception:  # noqa: BLE001
+        pass
+    if settings.single_tenant_mode:
+        return "default"
+    return None
+
+
+def _scope_wiki_root() -> str:
+    return str(settings.wiki_root)
+
+
+def _paths_match(left: str, right: str) -> bool:
+    if not left or not right:
+        return False
+    if left == right:
+        return True
+    try:
+        return Path(left).resolve() == Path(right).resolve()
+    except OSError:
+        return False
+
+
+def job_visible_to_current(tenant_id: Optional[str], cwd: str) -> bool:
+    """Whether a job/swarm record is visible to the current tenant.
+
+    Stamped ``tenant_id`` must match. Legacy records with a missing
+    tenant_id are visible only when ``cwd`` matches this tenant's
+    wiki_root; otherwise they stay hidden.
+    """
+    current_id = stamp_tenant_id()
+    if tenant_id:
+        return bool(current_id) and tenant_id == current_id
+    return _paths_match(cwd, _scope_wiki_root())
+
+
 def get_job(tracking_id: str) -> Optional[TrackedJob]:
     with _lock:
-        return _load_jobs().get(tracking_id)
+        job = _load_jobs().get(tracking_id)
+    if job is None:
+        return None
+    if not job_visible_to_current(job.tenant_id, job.cwd):
+        return None
+    return job
 
 
 def list_jobs(limit: int = 50) -> list[TrackedJob]:
     with _lock:
         jobs = list(_load_jobs().values())
-    jobs.sort(key=lambda j: j.started_at, reverse=True)
-    return jobs[:limit]
+    visible = [j for j in jobs if job_visible_to_current(j.tenant_id, j.cwd)]
+    visible.sort(key=lambda j: j.started_at, reverse=True)
+    return visible[:limit]
 
 
 def _ingest_prompt(raw_rel_path: str, note: str) -> str:
@@ -417,6 +467,7 @@ def start_import_job(raw_rel_path: str, kind: str, note: str = "") -> TrackedJob
         started_at=datetime.now(timezone.utc).isoformat(),
         cwd=cwd,
         log_path=str(log_path),
+        tenant_id=stamp_tenant_id(),
     )
 
     try:
@@ -564,6 +615,7 @@ def start_ingest_job(raw_rel_path: str, note: str = "") -> TrackedJob:
         started_at=datetime.now(timezone.utc).isoformat(),
         cwd=cwd,
         log_path=str(log_path),
+        tenant_id=stamp_tenant_id(),
     )
 
     try:

--- a/backend/app/rate_limit.py
+++ b/backend/app/rate_limit.py
@@ -236,6 +236,9 @@ def _is_llm_targeted_path(path: str) -> bool:
 _LLM_SYNTHESIS_PREFIXES: tuple[str, ...] = (
     "/wiki/query",
     "/wiki/chat",  # covers /wiki/chat and /wiki/chat/stream
+    "/onboarding/import-url",
+    "/onboarding/import-text",
+    "/onboarding/assemble",
 )
 
 

--- a/backend/app/tenants.py
+++ b/backend/app/tenants.py
@@ -29,6 +29,9 @@ so existing handlers don't need to change their signatures.
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
 import json
 import os
 import shutil
@@ -41,6 +44,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from .config import settings
+
+# GitHub logins that must never become a provisioned / OAuth-bound tenant.
+# ``avery`` is the public demo; ``default`` is the unused fallback record.
+RESERVED_TENANT_IDS = frozenset({"avery", "default"})
+VALID_VISIBILITY = ("public", "unlisted", "private")
+
+# Prefix for secrets encrypted into tenant.json. Dual-read: values without
+# this prefix are treated as legacy plaintext and re-encrypted on persist.
+_SECRET_AT_REST_PREFIX = "enc:v1:"
 
 if TYPE_CHECKING:
     from .wiki import WikiIndex
@@ -125,7 +137,7 @@ class Tenant:
     updated_at: str = ""
     # Misc
     is_demo: bool = False  # read-only public demo tenants (e.g. Avery)
-    visibility: str = "public"  # public | unlisted | private
+    visibility: str = "unlisted"  # public | unlisted | private
 
     # Lazy-loaded wiki index for this tenant; not serialized to disk.
     _index: Optional["WikiIndex"] = field(default=None, repr=False, compare=False)
@@ -230,6 +242,10 @@ class Tenant:
             "visibility": self.visibility,
         }
 
+    def _persist(self) -> None:
+        """Write this tenant's metadata to disk (secrets encrypted)."""
+        _manager._persist(self)
+
 
 # ---------------------------------------------------------------------------
 # Request-scoped tenant context (one entry per HTTP request)
@@ -300,6 +316,75 @@ def set_current_tenant(tenant: Tenant) -> _TenantContextManager:
 _TENANT_META_FILE = "tenant.json"
 
 
+def _secret_key_material() -> bytes:
+    """32-byte key from SESSION_SECRET (hosted) or OWNER_TOKEN (OSS)."""
+    if not settings.single_tenant_mode:
+        raw = (settings.session_secret or "").strip()
+    else:
+        raw = (settings.owner_token or "").strip()
+    if not raw:
+        raw = (settings.session_secret or settings.owner_token or "").strip()
+    if not raw:
+        return b""
+    return hashlib.sha256(b"plw-tenant-at-rest-v1:" + raw.encode("utf-8")).digest()
+
+
+def _keystream(key: bytes, nonce: bytes, length: int) -> bytes:
+    out = bytearray()
+    counter = 0
+    while len(out) < length:
+        block = hashlib.sha256(key + nonce + counter.to_bytes(8, "big")).digest()
+        out.extend(block)
+        counter += 1
+    return bytes(out[:length])
+
+
+def encrypt_tenant_secret(plaintext: str) -> str:
+    """Encrypt a tenant secret for tenant.json. Empty / already-encrypted pass through."""
+    if not plaintext:
+        return ""
+    if plaintext.startswith(_SECRET_AT_REST_PREFIX):
+        return plaintext
+    key = _secret_key_material()
+    if not key:
+        return plaintext
+    nonce = os.urandom(16)
+    raw = plaintext.encode("utf-8")
+    stream = _keystream(key, nonce, len(raw))
+    ct = bytes(a ^ b for a, b in zip(raw, stream))
+    tag = hmac.new(key, nonce + ct, hashlib.sha256).digest()
+    blob = base64.urlsafe_b64encode(nonce + tag + ct).decode("ascii")
+    return _SECRET_AT_REST_PREFIX + blob
+
+
+def decrypt_tenant_secret(value: str) -> str:
+    """Decrypt an enc:v1: blob, or return plaintext unchanged (dual-read)."""
+    if not value:
+        return ""
+    if not value.startswith(_SECRET_AT_REST_PREFIX):
+        return value
+    key = _secret_key_material()
+    if not key:
+        return ""
+    try:
+        blob = base64.urlsafe_b64decode(value[len(_SECRET_AT_REST_PREFIX) :].encode("ascii"))
+        nonce, tag, ct = blob[:16], blob[16:48], blob[48:]
+        expected = hmac.new(key, nonce + ct, hashlib.sha256).digest()
+        if not hmac.compare_digest(tag, expected):
+            return ""
+        stream = _keystream(key, nonce, len(ct))
+        return bytes(a ^ b for a, b in zip(ct, stream)).decode("utf-8")
+    except Exception:  # noqa: BLE001 — corrupt blob ⇒ empty, never raise
+        return ""
+
+
+def _normalize_visibility(raw: object) -> str:
+    vis = str(raw or "").strip().lower()
+    if vis in VALID_VISIBILITY:
+        return vis
+    return "public"
+
+
 class TenantManager:
     """In-memory registry of tenants, persisted to disk as JSON.
 
@@ -361,17 +446,18 @@ class TenantManager:
             display_name=str(data.get("display_name", "")),
             gh_login=str(data.get("gh_login", "")),
             gh_user_id=int(data.get("gh_user_id", 0) or 0),
-            gh_token=str(data.get("gh_token", "")),
+            gh_token=decrypt_tenant_secret(str(data.get("gh_token", ""))),
             gh_repo=str(data.get("gh_repo", "")),
             gh_default_branch=str(data.get("gh_default_branch", "main")) or "main",
-            gh_webhook_secret=str(data.get("gh_webhook_secret", "")),
+            gh_webhook_secret=decrypt_tenant_secret(str(data.get("gh_webhook_secret", ""))),
             git_last_synced_at=float(data.get("git_last_synced_at", 0) or 0),
             git_last_error=str(data.get("git_last_error", "")),
             git_pushes_made=int(data.get("git_pushes_made", 0) or 0),
             created_at=str(data.get("created_at", "")),
             updated_at=str(data.get("updated_at", "")),
             is_demo=bool(data.get("is_demo", False)),
-            visibility=str(data.get("visibility", "public")) or "public",
+            # Missing field on old tenant.json stays public (back-compat).
+            visibility=_normalize_visibility(data.get("visibility", "public")),
         )
 
     # ---------- lookups ----------
@@ -476,14 +562,8 @@ class TenantManager:
             "display_name": tenant.display_name,
             "gh_login": tenant.gh_login,
             "gh_user_id": tenant.gh_user_id,
-            # NOTE: writing the OAuth token to disk in plaintext is a v1.0
-            # shortcut. v1.1 must encrypt or move to a secret store. Render
-            # disk is already private but multi-tenant means we don't want
-            # an accidental ``ls`` to leak someone else's token.
-            "gh_token": tenant.gh_token,
-            # Webhook secret: same sensitivity class as the token. Stays
-            # on disk (gitignored via tenant.json) and never goes to_dict.
-            "gh_webhook_secret": tenant.gh_webhook_secret,
+            "gh_token": encrypt_tenant_secret(tenant.gh_token),
+            "gh_webhook_secret": encrypt_tenant_secret(tenant.gh_webhook_secret),
             "gh_repo": tenant.gh_repo,
             "gh_default_branch": tenant.gh_default_branch,
             "git_last_synced_at": tenant.git_last_synced_at,
@@ -569,6 +649,7 @@ class TenantManager:
             gh_user_id=gh_user_id,
             gh_token=gh_token,
             is_demo=is_demo,
+            visibility="public" if is_demo else "unlisted",
         )
         return self.upsert(tenant)
 

--- a/backend/app/url_scrape.py
+++ b/backend/app/url_scrape.py
@@ -36,7 +36,7 @@ import re
 import socket
 from dataclasses import dataclass, field
 from typing import Optional
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urlunparse
 
 import httpx
 from bs4 import BeautifulSoup
@@ -78,32 +78,72 @@ def _ip_is_blocked(ip_text: str) -> bool:
     )
 
 
+def _public_ips_for_host(host: str) -> tuple[list[str], str]:
+    """Resolve ``host`` and return public IPs, or ([], reason) if blocked."""
+    if not host:
+        return [], "missing host"
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except (socket.gaierror, UnicodeError) as exc:
+        return [], f"DNS resolution failed: {exc}"
+    if not infos:
+        return [], "host did not resolve"
+    ips: list[str] = []
+    for info in infos:
+        ip_text = info[4][0]
+        if _ip_is_blocked(ip_text):
+            return [], f"blocked address {ip_text} (private/loopback/link-local)"
+        if ip_text not in ips:
+            ips.append(ip_text)
+    return ips, ""
+
+
 def _host_resolves_safe(host: str) -> tuple[bool, str]:
     """Resolve ``host`` (A + AAAA) and confirm EVERY address is a public,
     routable IP. Returns (ok, reason). Blocks SSRF to cloud metadata,
     localhost, and internal networks. Re-run for every redirect hop.
-
-    Residual caveat (honest): this validates at resolve time, so a TOCTOU
-    DNS-rebind between this check and httpx's own resolution is still
-    theoretically possible. Closing that fully requires pinning the
-    connection to the validated IP; for this owner/signed-in-user-gated
-    onboarding flow the resolve-time check removes the practical hole.
     """
     if _allow_private_targets():
         return True, ""
-    if not host:
-        return False, "missing host"
+    ips, reason = _public_ips_for_host(host)
+    return (bool(ips), reason)
+
+
+def _pin_ip_for_host(host: str) -> tuple[Optional[str], str]:
+    """First already-validated IP to connect to (do not let httpx re-resolve)."""
+    if _allow_private_targets():
+        try:
+            infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+        except (socket.gaierror, UnicodeError) as exc:
+            return None, f"DNS resolution failed: {exc}"
+        if not infos:
+            return None, "host did not resolve"
+        return infos[0][4][0], ""
+    ips, reason = _public_ips_for_host(host)
+    if not ips:
+        return None, reason
+    return ips[0], ""
+
+
+def _url_on_pinned_ip(url: str, ip: str) -> str:
+    """Rewrite ``url`` so the connect target is ``ip``; caller sets Host/SNI."""
+    parsed = urlparse(url)
     try:
-        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
-    except (socket.gaierror, UnicodeError) as exc:
-        return False, f"DNS resolution failed: {exc}"
-    if not infos:
-        return False, "host did not resolve"
-    for info in infos:
-        ip_text = info[4][0]
-        if _ip_is_blocked(ip_text):
-            return False, f"blocked address {ip_text} (private/loopback/link-local)"
-    return True, ""
+        version = ipaddress.ip_address(ip).version
+    except ValueError:
+        version = 4
+    host = f"[{ip}]" if version == 6 else ip
+    port = parsed.port
+    netloc = f"{host}:{port}" if port is not None else host
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+def _host_header(parsed) -> str:
+    hostname = parsed.hostname or ""
+    port = parsed.port
+    if port is None:
+        return hostname
+    return f"{hostname}:{port}"
 
 
 @dataclass
@@ -184,15 +224,10 @@ async def scrape(url: str) -> ScrapedPage:
         page.errors.append("URL missing a hostname")
         return page
 
-    safe, reason = _host_resolves_safe(parsed.hostname)
-    if not safe:
-        page.errors.append(f"refusing to fetch {parsed.hostname!r}: {reason}")
-        return page
-
-    # Manual redirect following so we can re-validate the target host on
-    # every hop. httpx's built-in follow_redirects would chase a 3xx to an
-    # internal address without giving us a chance to re-check it — the
-    # classic SSRF redirect bypass.
+    # Manual redirect following so we can re-validate + pin the target
+    # IP on every hop. Connecting to the already-validated address
+    # (Host/SNI keep the original hostname) closes DNS rebinding
+    # between the check and httpx's own resolve.
     r: Optional[httpx.Response] = None
     try:
         async with httpx.AsyncClient(
@@ -206,23 +241,30 @@ async def scrape(url: str) -> ScrapedPage:
         ) as client:
             current = url
             for _ in range(MAX_REDIRECTS + 1):
-                r = await client.get(current)
+                hop = urlparse(current)
+                if hop.scheme not in ("http", "https") or not hop.hostname:
+                    page.errors.append(f"unsupported target {current!r}")
+                    return page
+                pinned_ip, why = _pin_ip_for_host(hop.hostname)
+                if pinned_ip is None:
+                    label = "refusing to fetch" if current == url else "refusing redirect to"
+                    page.errors.append(f"{label} {hop.hostname!r}: {why}")
+                    return page
+                pinned_url = _url_on_pinned_ip(current, pinned_ip)
+                req = client.build_request(
+                    "GET",
+                    pinned_url,
+                    headers={"Host": _host_header(hop)},
+                )
+                if hop.scheme == "https":
+                    req.extensions["sni_hostname"] = hop.hostname
+                r = await client.send(req)
                 if r.status_code not in (301, 302, 303, 307, 308):
                     break
                 location = r.headers.get("location")
                 if not location:
                     break
                 current = urljoin(current, location)
-                hop = urlparse(current)
-                if hop.scheme not in ("http", "https") or not hop.hostname:
-                    page.errors.append(f"redirect to unsupported target {current!r}")
-                    return page
-                ok, why = _host_resolves_safe(hop.hostname)
-                if not ok:
-                    page.errors.append(
-                        f"refusing redirect to {hop.hostname!r}: {why}"
-                    )
-                    return page
             else:
                 page.errors.append("too many redirects; aborting")
                 return page

--- a/backend/tests/test_hosted_multitenant.py
+++ b/backend/tests/test_hosted_multitenant.py
@@ -43,14 +43,21 @@ def multi_tenant_app(tmp_path, monkeypatch):
     # Seed two tenants on disk. Pages are explicitly public so the
     # anonymous viewer in the test client can see them, with explicit titles.
     tenants_root = tmp_path / "tenants"
-    for tid, body in (
+    for tid, body, is_demo in (
         (
             "alice",
             "---\ntitle: Alice Index\ntier: public\n---\n# Alice\n\nAlice loves portable wikis.\n",
+            False,
         ),
         (
             "bob",
             "---\ntitle: Bob Index\ntier: public\n---\n# Bob\n\nBob runs a homelab.\n",
+            False,
+        ),
+        (
+            "avery",
+            "---\ntitle: Avery Index\ntier: public\n---\n# Avery\n\nPublic demo wiki.\n",
+            True,
         ),
     ):
         wiki = tenants_root / tid / "wiki"
@@ -70,7 +77,7 @@ def multi_tenant_app(tmp_path, monkeypatch):
                     "gh_default_branch": "main",
                     "created_at": "2026-05-24T00:00:00Z",
                     "updated_at": "2026-05-24T00:00:00Z",
-                    "is_demo": tid == "alice",
+                    "is_demo": is_demo,
                     "visibility": "public",
                 }
             ),
@@ -107,6 +114,7 @@ def multi_tenant_app(tmp_path, monkeypatch):
     import app.tenants as _tenants
     import app.wiki as _wiki
     import app.auth as _auth
+    import app.hosted_routes as _hosted
     import app.main as _main
 
     importlib.reload(_config)
@@ -116,6 +124,7 @@ def multi_tenant_app(tmp_path, monkeypatch):
     # tenants ``current_tenant_var`` for session-cookie ownership. Reload
     # it AFTER config + tenants so it picks up the fresh references.
     importlib.reload(_auth)
+    importlib.reload(_hosted)
     importlib.reload(_main)
 
     from fastapi.testclient import TestClient
@@ -162,6 +171,7 @@ def multi_tenant_app(tmp_path, monkeypatch):
         importlib.reload(_tenants)
         importlib.reload(_wiki)
         importlib.reload(_auth)
+        importlib.reload(_hosted)
         importlib.reload(_main)
 
 
@@ -304,11 +314,19 @@ def test_healthz_reports_tenant_volume(multi_tenant_app):
     r = multi_tenant_app.get("/healthz")
     assert r.status_code == 200
     data = r.json()
-    assert data["tenant_count"] == 2
-    assert data["tenant_dir_count"] == 2
-    assert data["preexisting_dir_count"] == 0
+    assert data["status"] == "ok"
     assert data["disk_total_bytes"] > 0
     assert data["disk_free_bytes"] >= 0
+    assert data["disk_used_bytes"] >= 0
+    for leaked in (
+        "wiki_root",
+        "indexed_tenant_ids",
+        "indexed_tenants",
+        "tenant_count",
+        "tenant_dir_count",
+        "preexisting_dir_count",
+    ):
+        assert leaked not in data, leaked
 
 
 def test_tenant_metadata_endpoint(multi_tenant_app):
@@ -317,7 +335,7 @@ def test_tenant_metadata_endpoint(multi_tenant_app):
     payload = r.json()
     assert payload["id"] == "alice"
     assert payload["display_name"] == "Alice"
-    assert payload["is_demo"] is True
+    assert payload["is_demo"] is False
 
 
 def test_oauth_login_redirects_to_github(multi_tenant_app):
@@ -516,15 +534,12 @@ def test_owner_routes_still_require_some_auth(multi_tenant_app):
     assert r.status_code == 401, r.text
 
 
-def test_logout_get_clears_session_and_redirects(multi_tenant_app):
-    """GET /auth/logout must clear the session AND 302 to a safe target.
+def test_logout_get_does_not_clear_session(multi_tenant_app):
+    """GET /auth/logout must not clear the session (logout CSRF).
 
-    Reachable from the nav menu's "Sign out" link, so the redirect has
-    to land on the frontend origin and the session has to actually be
-    gone (i.e. a follow-up /auth/me reports unauthenticated).
+    Nav must POST. GET returns 405 and leaves the cookie intact.
     """
     _set_session_user(multi_tenant_app, "alice", login="alice")
-    # Sanity: we're authenticated before logout.
     r = multi_tenant_app.get("/auth/me")
     assert r.status_code == 200
     assert r.json().get("authenticated") is True
@@ -532,30 +547,31 @@ def test_logout_get_clears_session_and_redirects(multi_tenant_app):
     r = multi_tenant_app.get(
         "/auth/logout?return_to=/welcome", follow_redirects=False
     )
-    assert r.status_code == 302
-    # Returned target should reanchor onto the frontend origin if
-    # PUBLIC_BASE_URL is set, OR keep the relative path if not. We
-    # don't pin a literal here — the redirect just must not 500.
-    assert "Location" in r.headers
+    assert r.status_code == 405
+    assert "POST" in r.json().get("detail", "")
+
+    r = multi_tenant_app.get("/auth/me")
+    assert r.json().get("authenticated") is True
 
 
-def test_switch_account_clears_session_then_kicks_oauth(multi_tenant_app):
-    """GET /auth/switch-account is the "sign in as a different GitHub
-    account" affordance from the nav menu. It must clear the current
-    session AND 302 into /auth/github/login (which itself 302s out to
-    github.com). Pinning this end-to-end stops a regression where one
-    half (logout) silently happens but the next hop (OAuth kickoff)
-    breaks, leaving the user signed out with no path back in.
-    """
+def test_switch_account_get_does_not_clear_session(multi_tenant_app):
+    """GET /auth/switch-account must not clear the session. Nav must POST."""
     _set_session_user(multi_tenant_app, "alice", login="alice")
     r = multi_tenant_app.get("/auth/switch-account", follow_redirects=False)
+    assert r.status_code == 405
+    assert "POST" in r.json().get("detail", "")
+    r = multi_tenant_app.get("/auth/me")
+    assert r.json().get("authenticated") is True
+
+
+def test_switch_account_post_clears_session_then_kicks_oauth(multi_tenant_app):
+    """POST /auth/switch-account clears the session and 302s into OAuth."""
+    _set_session_user(multi_tenant_app, "alice", login="alice")
+    r = multi_tenant_app.post("/auth/switch-account", follow_redirects=False)
     assert r.status_code == 302
     location = r.headers.get("Location", "")
     assert "/auth/github/login" in location, location
 
-    # Following one more hop should land on github.com — but we don't
-    # want the test to actually hit github. Just confirm the next
-    # response is also a 302 (to github.com/login/oauth/authorize).
     r = multi_tenant_app.get(location, follow_redirects=False)
     assert r.status_code == 302
     assert "github.com/login/oauth/authorize" in r.headers.get("Location", "")
@@ -1321,77 +1337,24 @@ def test_safe_redirect_when_public_base_is_www_accepts_apex_too(monkeypatch):
     )
 
 
-def test_logout_with_www_return_to_lands_on_frontend_not_welcome(monkeypatch):
-    """The exact failure mode from the user-reported bug:
+def test_logout_get_with_www_return_to_does_not_clear_session(multi_tenant_app):
+    """GET /auth/logout is a no-op even with a frontend return_to.
 
-      1. User on www.portablellm.wiki clicks "Sign out".
-      2. NavBar sends ``return_to=https://www.portablellm.wiki``.
-      3. PUBLIC_BASE_URL is configured as the apex (``https://portablellm.wiki``).
-      4. Old _safe_redirect rejected the www variant.
-      5. Logout fell back to _default_return_to() = ``<base>/welcome``.
-      6. The welcome page sees authenticated=false and renders
-         "We can't finish signing you in" with the cookie-warning copy.
-
-    Post-fix the redirect must land on the public-frontend ROOT, not
-    /welcome, regardless of which apex/www variant the user is on.
+    Nav must POST. This used to 302-clear the session (logout CSRF).
     """
-    monkeypatch.setenv("PUBLIC_BASE_URL", "https://portablellm.wiki")
-    monkeypatch.setenv("SINGLE_TENANT_MODE", "0")
-    monkeypatch.setenv("SESSION_SECRET", "test-secret-must-be-long-enough")
-    import app.config
-    import app.hosted_routes
-    import app.main as app_main
-
-    importlib.reload(app.config)
-    importlib.reload(app.hosted_routes)
-    importlib.reload(app_main)
-
-    from fastapi.testclient import TestClient
-
-    client = TestClient(app_main.app)
-    r = client.get(
+    r = multi_tenant_app.get(
         "/auth/logout?return_to=https://www.portablellm.wiki",
         follow_redirects=False,
     )
-    assert r.status_code == 302
-    location = r.headers.get("Location", "")
-    # The whole point: NOT /welcome.
-    assert "/welcome" not in location, (
-        f"post-logout redirect must not land on /welcome (anon visit "
-        f"renders a 'sign-in problem' error); got: {location!r}"
-    )
-    # Should land on a frontend origin (either apex or www variant).
-    assert location.startswith("https://portablellm.wiki") or location.startswith(
-        "https://www.portablellm.wiki"
-    ), f"unexpected logout landing: {location!r}"
+    assert r.status_code == 405
+    assert "POST" in r.json().get("detail", "")
 
 
-def test_logout_with_no_return_to_lands_on_frontend_root(monkeypatch):
-    """Defensive: a sign-out link without return_to (legacy clients,
-    direct curl, etc.) must still land on the public root rather than
-    the /welcome onboarding page."""
-    monkeypatch.setenv("PUBLIC_BASE_URL", "https://portablellm.wiki")
-    monkeypatch.setenv("SINGLE_TENANT_MODE", "0")
-    monkeypatch.setenv("SESSION_SECRET", "test-secret-must-be-long-enough")
-    import app.config
-    import app.hosted_routes
-    import app.main as app_main
-
-    importlib.reload(app.config)
-    importlib.reload(app.hosted_routes)
-    importlib.reload(app_main)
-
-    from fastapi.testclient import TestClient
-
-    client = TestClient(app_main.app)
-    r = client.get("/auth/logout", follow_redirects=False)
-    assert r.status_code == 302
-    location = r.headers.get("Location", "")
-    assert "/welcome" not in location, location
-    assert location.rstrip("/") in (
-        "https://portablellm.wiki",
-        "https://www.portablellm.wiki",
-    ), f"unexpected logout landing: {location!r}"
+def test_logout_with_no_return_to_does_not_clear_session(multi_tenant_app):
+    """GET /auth/logout without return_to still does not clear the session."""
+    r = multi_tenant_app.get("/auth/logout", follow_redirects=False)
+    assert r.status_code == 405
+    assert "POST" in r.json().get("detail", "")
 
 
 # ---------------------------------------------------------------------------
@@ -2397,23 +2360,22 @@ def test_index_cache_lru_evicts_cold_tenants(multi_tenant_app, monkeypatch):
 
     monkeypatch.setenv("WIKI_INDEX_CACHE_MAX", "1")
     mgr = _tenants.manager()
-    alice = mgr.require("alice")  # fixture marks alice is_demo=True
+    avery = mgr.require("avery")  # fixture marks avery is_demo=True
     bob = mgr.require("bob")
 
-    # Cap=1 with alice (demo) already warm: loading bob reserves the
+    # Cap=1 with avery (demo) already warm: loading bob reserves the
     # only slot for the in-flight tenant after pinned demos → bob is
     # protected during load, but a subsequent third-party eviction with
-    # no protect (or loading bob when alice fills the pin budget) drops
-    # non-demo cold entries. Warm alice first, then bob: bob stays
-    # (protected as the touch), alice stays (demo). Force a tight
-    # eviction that does not protect bob to prove non-demos drop.
-    _ = alice.index
+    # no protect drops non-demo cold entries. Warm avery first, then bob:
+    # avery stays (demo). Force a tight eviction that does not protect
+    # bob to prove non-demos drop.
+    _ = avery.index
     _ = bob.index
-    assert alice._index is not None
-    # Explicit eviction with no protect: cap=1, alice pinned → bob gone.
+    assert avery._index is not None
+    # Explicit eviction with no protect: cap=1, avery pinned → bob gone.
     dropped = mgr.evict_cold_indexes()
     assert bob._index is None
-    assert alice._index is not None  # demo pinned
+    assert avery._index is not None  # demo pinned
     assert dropped >= 1
 
 
@@ -2506,8 +2468,8 @@ def test_webhook_bad_signature_rejected(multi_tenant_app, monkeypatch):
     assert pulled["n"] == 0
 
 
-def test_webhook_unknown_repo_404(multi_tenant_app):
-    """A push for a repo no tenant owns is unrouted (404), not a silent OK."""
+def test_webhook_unknown_repo_401(multi_tenant_app):
+    """Unknown repo and bad HMAC share 401 so existence is not an oracle."""
     body = json.dumps(
         {"ref": "refs/heads/main", "repository": {"full_name": "nobody/ghost-repo"}}
     ).encode()
@@ -2520,7 +2482,8 @@ def test_webhook_unknown_repo_404(multi_tenant_app):
             "Content-Type": "application/json",
         },
     )
-    assert r.status_code == 404
+    assert r.status_code == 401
+    assert r.json()["detail"] == "unauthorized"
 
 
 # ---------------------------------------------------------------------------
@@ -3682,3 +3645,176 @@ def test_convention_auto_bind_skips_product_fork_at_legacy_name(
     # Critical: must NOT have bound to the product fork.
     assert refreshed.gh_repo == ""
     assert bootstrap_called == []
+
+
+# ---------------------------------------------------------------------------
+# Red-team hardening: visibility, owner token, Avery bind, assemble caps
+# ---------------------------------------------------------------------------
+
+
+def test_provision_defaults_to_unlisted(multi_tenant_app):
+    from app import tenants as _tenants
+
+    tenant = _tenants.manager().provision_local("carol", display_name="Carol")
+    assert tenant.visibility == "unlisted"
+    assert tenant.is_demo is False
+
+
+def test_tenants_list_excludes_unlisted(multi_tenant_app):
+    from app import tenants as _tenants
+
+    carol = _tenants.manager().provision_local("carol", display_name="Carol")
+    assert carol.visibility == "unlisted"
+
+    r = multi_tenant_app.get("/tenants")
+    ids = {t["id"] for t in r.json()["tenants"]}
+    assert "alice" in ids
+    assert "carol" not in ids
+
+    r = multi_tenant_app.get("/tenants/carol")
+    assert r.status_code == 200
+    assert r.json()["visibility"] == "unlisted"
+
+    carol.visibility = "private"
+    _tenants.manager().upsert(carol)
+    assert _tenants.manager().get("carol").visibility == "private"
+    r = multi_tenant_app.get("/tenants/carol")
+    assert r.status_code == 404
+
+
+def test_owner_sets_tenant_visibility(multi_tenant_app):
+    _set_session_user(multi_tenant_app, "alice", login="alice")
+    r = multi_tenant_app.post(
+        "/t/alice/owner/tenant/visibility",
+        json={"visibility": "private"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["visibility"] == "private"
+
+    r = multi_tenant_app.get("/tenants/alice")
+    assert r.status_code == 404
+
+    r = multi_tenant_app.post(
+        "/t/alice/owner/tenant/visibility",
+        json={"visibility": "unlisted"},
+    )
+    assert r.status_code == 200
+    r = multi_tenant_app.get("/tenants/alice")
+    assert r.status_code == 200
+    assert r.json()["visibility"] == "unlisted"
+
+    listed = {t["id"] for t in multi_tenant_app.get("/tenants").json()["tenants"]}
+    assert "alice" not in listed
+
+
+def test_hosted_env_owner_token_is_not_master_key(multi_tenant_app, monkeypatch):
+    """Process-wide OWNER_TOKEN must not write another tenant in hosted mode."""
+    import app.auth as _auth
+    import app.config as _config
+
+    monkeypatch.setattr(_config.settings, "owner_token", "hosted-env-token")
+    monkeypatch.setattr(_auth.settings, "owner_token", "hosted-env-token")
+
+    r = multi_tenant_app.post(
+        "/t/bob/owner/reload",
+        headers={"Authorization": "Bearer hosted-env-token"},
+    )
+    assert r.status_code == 401, r.text
+
+    _set_session_user(multi_tenant_app, "bob", login="bob")
+    r = multi_tenant_app.post("/t/bob/owner/reload")
+    assert r.status_code == 200, r.text
+
+
+def test_demo_tenant_writes_rejected(multi_tenant_app):
+    _set_session_user(multi_tenant_app, "avery", login="avery")
+    r = multi_tenant_app.post("/t/avery/owner/reload")
+    assert r.status_code == 403
+    assert "demo" in r.json()["detail"].lower()
+
+
+def test_github_callback_refuses_reserved_and_demo(multi_tenant_app, monkeypatch):
+    from app import github_api
+    from app.github_api import GitHubUser
+
+    async def fake_exchange(**_kwargs):
+        return "tok"
+
+    def _user(login: str) -> GitHubUser:
+        return GitHubUser(
+            id=99,
+            login=login,
+            name=login,
+            avatar_url="",
+            bio="",
+            email="",
+            company="",
+            blog="",
+            location="",
+            twitter_username="",
+            html_url="",
+        )
+
+    monkeypatch.setattr(github_api, "exchange_oauth_code", fake_exchange)
+
+    async def fake_avery(_token):
+        return _user("avery")
+
+    monkeypatch.setattr(github_api, "get_user", fake_avery)
+
+    import json as _json
+    import base64
+    import itsdangerous
+
+    payload = {"oauth_state": "state-avery"}
+    data = base64.b64encode(_json.dumps(payload).encode("utf-8"))
+    signer = itsdangerous.TimestampSigner("test-secret-do-not-use-in-prod")
+    multi_tenant_app.cookies.set("plw_session", signer.sign(data).decode("utf-8"))
+
+    r = multi_tenant_app.get(
+        "/auth/github/callback?code=abc&state=state-avery",
+        follow_redirects=False,
+    )
+    assert r.status_code == 403, r.text
+
+
+def test_assemble_rejects_over_cap(multi_tenant_app):
+    _set_session_user(multi_tenant_app, "alice", login="alice")
+    r = multi_tenant_app.post(
+        "/onboarding/assemble",
+        json={
+            "urls": [{"url": f"https://example.com/{i}"} for i in range(6)],
+        },
+    )
+    assert r.status_code == 422
+
+    r = multi_tenant_app.post(
+        "/onboarding/assemble",
+        json={
+            "answers": [
+                {"question": f"Q{i}", "answer": f"A{i}"} for i in range(9)
+            ],
+        },
+    )
+    assert r.status_code == 422
+
+    r = multi_tenant_app.post(
+        "/onboarding/assemble",
+        json={
+            "text_sources": [
+                {"content": f"text {i}"} for i in range(9)
+            ],
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_logout_post_clears_session(multi_tenant_app):
+    _set_session_user(multi_tenant_app, "alice", login="alice")
+    r = multi_tenant_app.post("/auth/logout")
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    # Drop the planted cookie so the client only keeps what Set-Cookie wrote.
+    multi_tenant_app.cookies.delete("plw_session")
+    r = multi_tenant_app.get("/auth/me")
+    assert r.json().get("authenticated") is False

--- a/backend/tests/test_jobs_tenant_scope.py
+++ b/backend/tests/test_jobs_tenant_scope.py
@@ -1,0 +1,99 @@
+"""Process-global jobs/swarms must not leak across tenants."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app import lint_swarm, orchestrator, tenants
+
+
+def _job(
+    tracking_id: str,
+    cwd: str,
+    tenant_id: str | None,
+    started_at: str = "2026-08-15T00:00:00Z",
+) -> orchestrator.TrackedJob:
+    return orchestrator.TrackedJob(
+        tracking_id=tracking_id,
+        kind="ingest",
+        raw_path="raw/x.md",
+        note="",
+        started_at=started_at,
+        cwd=cwd,
+        log_path="unused.log",
+        tenant_id=tenant_id,
+    )
+
+
+def test_jobs_filtered_by_tenant_and_legacy_cwd(tmp_path, monkeypatch):
+    monkeypatch.setattr(orchestrator, "JOBS_FILE", tmp_path / "jobs.json")
+    alice_root = tmp_path / "alice"
+    bob_root = tmp_path / "bob"
+    alice_root.mkdir()
+    bob_root.mkdir()
+    alice = tenants.Tenant(id="alice", wiki_root=alice_root)
+    bob = tenants.Tenant(id="bob", wiki_root=bob_root)
+
+    orchestrator._save_jobs(
+        {
+            "alice-job": _job("alice-job", str(alice_root), "alice"),
+            "bob-job": _job("bob-job", str(bob_root), "bob"),
+            "legacy-alice": _job("legacy-alice", str(alice_root), None),
+            "legacy-bob": _job("legacy-bob", str(bob_root), None),
+        }
+    )
+
+    with tenants.set_current_tenant(alice):
+        ids = {j.tracking_id for j in orchestrator.list_jobs()}
+        assert ids == {"alice-job", "legacy-alice"}
+        assert orchestrator.get_job("alice-job") is not None
+        assert orchestrator.get_job("bob-job") is None
+        assert orchestrator.get_job("legacy-bob") is None
+        assert orchestrator.get_job("missing") is None
+
+    with tenants.set_current_tenant(bob):
+        ids = {j.tracking_id for j in orchestrator.list_jobs()}
+        assert ids == {"bob-job", "legacy-bob"}
+        assert orchestrator.get_job("alice-job") is None
+
+
+def test_swarms_filtered_by_tenant_and_legacy_artifacts(tmp_path, monkeypatch):
+    monkeypatch.setattr(lint_swarm, "SWARMS_FILE", tmp_path / "swarms.json")
+    alice_root = tmp_path / "alice"
+    bob_root = tmp_path / "bob"
+    (alice_root / ".lint" / "s1").mkdir(parents=True)
+    (bob_root / ".lint" / "s2").mkdir(parents=True)
+    alice = tenants.Tenant(id="alice", wiki_root=alice_root)
+    bob = tenants.Tenant(id="bob", wiki_root=bob_root)
+
+    recs = {
+        "alice-swarm": lint_swarm.LintSwarmRecord(
+            swarm_id="alice-swarm",
+            started_at="2026-08-15T00:00:00Z",
+            artifacts_dir=str(alice_root / ".lint" / "s1"),
+            tenant_id="alice",
+        ),
+        "bob-swarm": lint_swarm.LintSwarmRecord(
+            swarm_id="bob-swarm",
+            started_at="2026-08-15T00:00:01Z",
+            artifacts_dir=str(bob_root / ".lint" / "s2"),
+            tenant_id="bob",
+        ),
+        "legacy-alice": lint_swarm.LintSwarmRecord(
+            swarm_id="legacy-alice",
+            started_at="2026-08-15T00:00:02Z",
+            artifacts_dir=str(alice_root / ".lint" / "s1"),
+            tenant_id=None,
+        ),
+    }
+    lint_swarm._save_swarms(recs)
+
+    with tenants.set_current_tenant(alice):
+        ids = {r.swarm_id for r in lint_swarm.list_swarms()}
+        assert ids == {"alice-swarm", "legacy-alice"}
+        assert lint_swarm.get_swarm("bob-swarm") is None
+        assert lint_swarm.get_swarm("alice-swarm") is not None
+
+    with tenants.set_current_tenant(bob):
+        ids = {r.swarm_id for r in lint_swarm.list_swarms()}
+        assert ids == {"bob-swarm"}
+        assert lint_swarm.get_swarm("legacy-alice") is None

--- a/backend/tests/test_owner_import.py
+++ b/backend/tests/test_owner_import.py
@@ -186,3 +186,28 @@ def test_import_uses_starter_prompt_not_capture_prompt():
     # starter prompt — that asymmetry is what keeps the page-count
     # behavior different.
     assert "extending an existing wiki" not in _dd._SYSTEM_PROMPT
+
+
+def test_draft_starter_pages_forces_private(monkeypatch):
+    """Starter drafts clamp to private, same as capture-context pages."""
+    captured = {}
+
+    async def fake_draft(**kwargs):
+        captured.update(kwargs)
+        return _dd.DraftResult(backend="test", model="x")
+
+    monkeypatch.setattr(_dd, "_draft_with_prompt", fake_draft)
+
+    import asyncio
+
+    from app.tenants import Tenant
+
+    tenant = Tenant(id="t", wiki_root=__import__("pathlib").Path("/tmp/unused"))
+    asyncio.run(
+        _dd.draft_starter_pages(
+            source_label="bio",
+            source_content="hello world",
+            tenant=tenant,
+        )
+    )
+    assert captured.get("force_tier") == "private"

--- a/backend/tests/test_query_and_ingest.py
+++ b/backend/tests/test_query_and_ingest.py
@@ -149,3 +149,5 @@ def test_healthz_reports_page_count(client):
     assert data["disk_total_bytes"] > 0
     assert data["disk_used_bytes"] >= 0
     assert data["disk_free_bytes"] >= 0
+    for leaked in ("wiki_root", "indexed_tenant_ids", "indexed_tenants"):
+        assert leaked not in data, leaked

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -95,6 +95,22 @@ def _make_app() -> FastAPI:
     def wiki_chat_stream():
         return {"answer": "..."}
 
+    @app.post("/onboarding/import-url")
+    def onboarding_import_url():
+        return {"ok": True}
+
+    @app.post("/onboarding/import-text")
+    def onboarding_import_text():
+        return {"ok": True}
+
+    @app.post("/onboarding/assemble")
+    def onboarding_assemble():
+        return {"ok": True}
+
+    @app.post("/t/{tenant}/onboarding/assemble")
+    def tenant_onboarding_assemble(tenant: str):
+        return {"ok": True, "tenant": tenant}
+
     @app.get("/owner/share-tokens")
     def owner_share_tokens():
         # Owner-gated path — used by tests to verify NON-LLM paths
@@ -407,7 +423,18 @@ def test_share_token_in_header_bypasses_rate_limit(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("path", ["/wiki/query", "/wiki/chat", "/wiki/chat/stream"])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/wiki/query",
+        "/wiki/chat",
+        "/wiki/chat/stream",
+        "/onboarding/import-url",
+        "/onboarding/import-text",
+        "/onboarding/assemble",
+        "/t/alice/onboarding/assemble",
+    ],
+)
 def test_synthesis_endpoints_are_metered_not_bypassed(monkeypatch, path):
     """The crawler bypass exempts /wiki/ reads, but the budget-spending
     synthesis endpoints must still be throttled or a scripted loop runs the

--- a/backend/tests/test_tenant_secrets.py
+++ b/backend/tests/test_tenant_secrets.py
@@ -1,0 +1,74 @@
+"""gh_token and gh_webhook_secret are encrypted at rest in tenant.json."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+from app import tenants
+
+
+def test_secrets_encrypted_on_persist_and_omitted_from_to_dict(tmp_path):
+    root = tmp_path / "carol"
+    tenant = tenants.Tenant(
+        id="carol",
+        wiki_root=root,
+        display_name="Carol",
+        gh_token="gho_plaintext_token",
+        gh_webhook_secret="whsec_plain",
+        visibility="unlisted",
+    )
+    tenant._persist()
+
+    meta_path = root / "tenant.json"
+    raw = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert raw["gh_token"].startswith("enc:v1:")
+    assert raw["gh_webhook_secret"].startswith("enc:v1:")
+    dumped = json.dumps(raw)
+    assert "gho_plaintext_token" not in dumped
+    assert "whsec_plain" not in dumped
+
+    public = tenant.to_dict()
+    assert "gh_token" not in public
+    assert "gh_webhook_secret" not in public
+
+    mode = stat.S_IMODE(meta_path.stat().st_mode)
+    if os.name != "nt":
+        assert mode == 0o600
+
+    loaded = tenants.manager()._tenant_from_json("carol", root, raw)
+    assert loaded.gh_token == "gho_plaintext_token"
+    assert loaded.gh_webhook_secret == "whsec_plain"
+
+
+def test_plaintext_secrets_dual_read_then_reencrypt(tmp_path):
+    root = tmp_path / "dave"
+    root.mkdir()
+    meta_path = root / "tenant.json"
+    meta_path.write_text(
+        json.dumps(
+            {
+                "id": "dave",
+                "display_name": "Dave",
+                "gh_token": "legacy-plain-token",
+                "gh_webhook_secret": "legacy-whsec",
+                "visibility": "unlisted",
+            }
+        ),
+        encoding="utf-8",
+    )
+    data = json.loads(meta_path.read_text(encoding="utf-8"))
+    loaded = tenants.manager()._tenant_from_json("dave", root, data)
+    assert loaded.gh_token == "legacy-plain-token"
+    assert loaded.gh_webhook_secret == "legacy-whsec"
+
+    loaded._persist()
+    rewritten = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert rewritten["gh_token"].startswith("enc:v1:")
+    assert rewritten["gh_webhook_secret"].startswith("enc:v1:")
+    assert "legacy-plain-token" not in json.dumps(rewritten)
+
+    again = tenants.manager()._tenant_from_json("dave", root, rewritten)
+    assert again.gh_token == "legacy-plain-token"
+    assert again.gh_webhook_secret == "legacy-whsec"

--- a/backend/tests/test_url_scrape_ssrf.py
+++ b/backend/tests/test_url_scrape_ssrf.py
@@ -65,3 +65,45 @@ def test_scrape_refuses_loopback_url():
     page = asyncio.run(url_scrape.scrape("http://127.0.0.1:8000/owner/secrets"))
     assert page.content == ""
     assert any("refusing to fetch" in e for e in page.errors)
+
+
+def test_url_on_pinned_ip_rewrites_netloc():
+    assert url_scrape._url_on_pinned_ip("http://example.test/a", "203.0.113.10") == (
+        "http://203.0.113.10/a"
+    )
+    assert url_scrape._url_on_pinned_ip("https://example.test:8443/a", "203.0.113.10") == (
+        "https://203.0.113.10:8443/a"
+    )
+
+
+def test_scrape_pins_connect_to_validated_ip(monkeypatch):
+    """scrape() connects to the already-validated IP, not a re-resolved hostname."""
+    from urllib.parse import urlparse
+
+    import httpx
+
+    seen: dict = {}
+
+    def fake_pin(host: str):
+        return "8.8.8.8", ""
+
+    class FakeResp:
+        status_code = 200
+        reason_phrase = "OK"
+        headers = {"content-type": "text/html"}
+        text = "<html><title>ok</title><body><p>" + ("word " * 40) + "</p></body></html>"
+        url = "http://8.8.8.8/page"
+
+    async def fake_send(self, request):
+        seen["url"] = str(request.url)
+        seen["host"] = request.headers.get("host")
+        return FakeResp()
+
+    monkeypatch.setattr(url_scrape, "_pin_ip_for_host", fake_pin)
+    monkeypatch.setattr(httpx.AsyncClient, "send", fake_send)
+
+    page = asyncio.run(url_scrape.scrape("http://example.test/page"))
+    assert seen.get("url"), page.errors
+    assert urlparse(seen["url"]).hostname == "8.8.8.8"
+    assert seen["host"] == "example.test"
+    assert page.title == "ok"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       # wiki. Generate with: `openssl rand -hex 32`
       OWNER_TOKEN: ${OWNER_TOKEN:?set OWNER_TOKEN in your environment or .env file}
       WIKI_ROOT: /app/wiki
-      DEFAULT_TIER: public
+      DEFAULT_TIER: private
       PUBLIC_BASE_URL: ${PUBLIC_BASE_URL:-http://localhost:8000}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000}
       # Optional — uncomment + set for LLM-backed answers. Without these

--- a/frontend/app/[tenant]/page.tsx
+++ b/frontend/app/[tenant]/page.tsx
@@ -17,11 +17,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "next/navigation";
 import {
   apiBase,
+  askWiki,
   fetchManifest,
-  getOwnerToken,
   type Manifest,
-  type PageSummary,
 } from "@/lib/api";
+import { HandshakeCallout } from "@/components/HandshakeCallout";
 import { Markdown } from "@/components/Markdown";
 import { PageList } from "@/components/TenantPageList";
 
@@ -46,12 +46,6 @@ type TenantMeta = {
 type AuthMeResponse = {
   authenticated: boolean;
   user?: { tenant_id: string; login: string; name: string; avatar_url: string };
-};
-
-type QueryResponse = {
-  question: string;
-  answer: string;
-  citations: { slug: string; title: string }[];
 };
 
 // ---------- Page ----------------------------------------------------------
@@ -262,116 +256,6 @@ function TenantHeader({
   );
 }
 
-// ---------- LLM handshake callout -----------------------------------------
-
-function HandshakeCallout({
-  tenant,
-  isOwnerView,
-}: {
-  tenant: string;
-  /** True when /auth/me resolved a session belonging to this tenant.
-   *  When true we add a footnote explaining that this visible URL is
-   *  public-tier — and link the owner to /owner where they can mint
-   *  a personal URL that includes their private content. Without this
-   *  affordance owners would assume copying the URL they see here is
-   *  what gives them LLM portability, and they'd be missing their
-   *  private notes from every LLM conversation. */
-  isOwnerView: boolean;
-}) {
-  // Vanity URL — Next.js rewrites /<tenant>/llm to /t/<tenant>/llm on
-  // the backend (see frontend/next.config.mjs). Short + memorable for
-  // the "paste this URL into ChatGPT" pitch.
-  //
-  // If the visitor arrived via a tier-elevated share link
-  // (`?share=<token>`), ShareTokenCatcher has already stashed the
-  // token in localStorage by the time this component renders. We
-  // append it as `?t=<token>` here so the URL we hand out from the
-  // callout grants the SAME tier the visitor is currently browsing.
-  // Without this the QR-scan recipient would land at recruiter tier
-  // (correct) but the "Paste this URL into ChatGPT" widget would hand
-  // them a public-only URL (wrong) — silently downgrading them when
-  // they pivot from human-browsing to LLM-chatting.
-  const baseLlmUrl = `https://portablellm.wiki/${tenant}/llm`;
-  const [shareToken, setShareToken] = useState<string | null>(null);
-  useEffect(() => {
-    // Read once on mount AND whenever ShareTokenCatcher emits its
-    // post-capture event so we re-resolve in time for the visitor's
-    // first interaction with the callout.
-    const sync = () => setShareToken(getOwnerToken());
-    sync();
-    if (typeof window === "undefined") return;
-    window.addEventListener("wiki:preview-as-change", sync);
-    return () => window.removeEventListener("wiki:preview-as-change", sync);
-  }, []);
-  const llmUrl = shareToken
-    ? `${baseLlmUrl}?t=${encodeURIComponent(shareToken)}`
-    : baseLlmUrl;
-  const [copied, setCopied] = useState(false);
-  const copy = () => {
-    if (typeof navigator !== "undefined" && navigator.clipboard) {
-      navigator.clipboard.writeText(llmUrl);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    }
-  };
-  return (
-    <section className="border-2 border-ink rounded-2xl bg-white p-5 sm:p-6 shadow-[0_1px_0_rgba(0,0,0,0.02),0_20px_60px_-30px_rgba(14,14,16,0.18)]">
-      <div className="text-[11px] uppercase tracking-[0.22em] font-semibold text-accent">
-        Paste this URL into any LLM
-      </div>
-      <div className="mt-1.5 text-lg sm:text-xl font-semibold tracking-tight text-ink">
-        One URL. Any model. Full context.
-      </div>
-      <p className="mt-1.5 text-sm text-ink-muted leading-relaxed">
-        Any LLM that can fetch URLs can now read this wiki — try Claude,
-        ChatGPT, Cursor, Gemini.
-      </p>
-
-      <div className="mt-4 flex items-center gap-2 bg-paper-soft/70 rounded-lg p-2 pr-2.5">
-        <code className="flex-1 font-mono text-sm text-ink truncate px-2 py-1.5">
-          {llmUrl}
-        </code>
-        <button
-          onClick={copy}
-          className="shrink-0 px-3 py-1.5 rounded-md bg-ink text-paper text-xs font-medium hover:bg-ink-soft inline-flex items-center gap-1.5 whitespace-nowrap"
-        >
-          {copied ? "Copied ✓" : "Copy ↗"}
-        </button>
-      </div>
-
-      <div className="mt-3 text-xs flex items-center gap-3 flex-wrap">
-        <a
-          href={llmUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="text-accent hover:underline"
-        >
-          preview what an LLM sees →
-        </a>
-        {isOwnerView && !shareToken && (
-          // The URL above is the PUBLIC-tier link — the same artifact a
-          // stranger gets when they scan the QR. Pasting it into YOUR
-          // ChatGPT gives ChatGPT only your public pages, which silently
-          // strips out exactly the private context that would make its
-          // answers about you actually useful. The fix lives in /owner
-          // (PersonalLlmUrlPanel) — a one-time mint that produces a
-          // tokenized URL revealing your full wiki. This footnote is
-          // owner-only, and suppressed when a share token is active
-          // (because then the displayed URL already includes ?t=…
-          // elevating to that tier).
-          <Link
-            href={`/${tenant}/owner#personal-llm-url`}
-            className="text-red-700 hover:text-red-900 hover:underline"
-            title="Mint a private-tier URL for your own LLMs — they'll see your full wiki including private notes."
-          >
-            this URL is public-tier · get your personal LLM URL →
-          </Link>
-        )}
-      </div>
-    </section>
-  );
-}
-
 // ---------- Inline ask form -----------------------------------------------
 
 type ChatMessage =
@@ -404,25 +288,7 @@ function AskInline({ tenant }: { tenant: string }) {
     setDraft("");
     setPending(true);
     try {
-      const r = await fetch(
-        `${apiBase()}/t/${encodeURIComponent(tenant)}/wiki/query`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ question: q }),
-        },
-      );
-      if (!r.ok) {
-        let detail = `HTTP ${r.status}`;
-        try {
-          const j = (await r.json()) as { detail?: string };
-          if (j?.detail) detail = j.detail;
-        } catch {
-          /* ignore */
-        }
-        throw new Error(detail);
-      }
-      const data = (await r.json()) as QueryResponse;
+      const data = await askWiki(q, tenant);
       setMessages((m) => [
         ...m,
         {

--- a/frontend/app/connect/marionette/page.tsx
+++ b/frontend/app/connect/marionette/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { apiBase, authMe } from "@/lib/api";
+import { loginReturnTo } from "@/lib/safeReturnTo";
 import {
   buildOwnerConnectPath,
   rememberMarionetteClientFromLocation,
@@ -27,12 +28,10 @@ export default function ConnectMarionettePage() {
       /* ignore */
     }
 
-    const here =
-      typeof window !== "undefined"
-        ? window.location.href
-        : "/connect/marionette?client=marionette";
     setSignInHref(
-      `${apiBase()}/auth/github/login?return_to=${encodeURIComponent(here)}`,
+      `${apiBase()}/auth/github/login?return_to=${encodeURIComponent(
+        loginReturnTo("/connect/marionette"),
+      )}`,
     );
 
     let cancelled = false;
@@ -95,13 +94,8 @@ export default function ConnectMarionettePage() {
                 try {
                   const u = new URL("/welcome", "https://portablellm.wiki");
                   u.searchParams.set("client", "marionette");
-                  if (typeof window !== "undefined") {
-                    const cur = new URLSearchParams(window.location.search);
-                    const ret = cur.get("return");
-                    const nonce = cur.get("nonce");
-                    if (ret) u.searchParams.set("return", ret);
-                    if (nonce) u.searchParams.set("nonce", nonce);
-                  }
+                  // client=marionette is the only query we forward. share/t/return/nonce
+                  // stay out of login and onboarding URLs.
                   return `${u.pathname}?${u.searchParams.toString()}`;
                 } catch {
                   return "/welcome?client=marionette";

--- a/frontend/app/owner/page.tsx
+++ b/frontend/app/owner/page.tsx
@@ -10,6 +10,7 @@ import { ShareTokensPanel } from "@/components/ShareTokensPanel";
 import { SwitchRepoModal } from "@/components/SwitchRepoModal";
 import {
   apiBase,
+  authLogout,
   authMe,
   fetchManifest,
   fetchPublicConfig,
@@ -27,6 +28,7 @@ import {
   ownerGetLintSwarm,
   ownerDraftMissingPage,
   ownerDraftContradiction,
+  ownerSetTenantVisibility,
   ownerSyncNow,
   ownerSyncPull,
   ownerSyncStatus,
@@ -43,6 +45,7 @@ import {
   type PreviewAs,
   type SyncNowResponse,
   type SyncPullResponse,
+  type TenantVisibility,
   type TrackedJob,
 } from "@/lib/api";
 import { useTenant } from "@/lib/useTenant";
@@ -531,14 +534,20 @@ function OwnerPageInner({ tenant }: { tenant?: string }) {
               {manifest.page_count} page{manifest.page_count === 1 ? "" : "s"} indexed
             </span>
           )}
-          <a
-            href={`${apiBase()}/auth/logout?return_to=${encodeURIComponent(
-              typeof window !== "undefined" ? window.location.origin : "/",
-            )}`}
+          <button
+            type="button"
+            onClick={async () => {
+              try {
+                await authLogout();
+              } catch {
+                /* still leave */
+              }
+              window.location.assign("/");
+            }}
             className="text-xs text-ink-muted hover:text-ink underline ml-auto sm:ml-3"
           >
             Sign out
-          </a>
+          </button>
         </section>
       )}
 
@@ -573,6 +582,7 @@ function OwnerPageInner({ tenant }: { tenant?: string }) {
        * stored OAuth token. Same persistence machinery, keyed to the
        * user's repo instead of an ops-owned one. Tracked, not built. */}
       {authed && !hosted && <PersistencePanel tenant={tenant} />}
+      {authed && hosted && <WikiVisibilityPanel tenantId={tenant} />}
       {authed && hosted && <GitHubSyncPanel tenantId={tenant} />}
 
       {/* PersonalLlmUrlPanel sits ABOVE ShareTokensPanel because it
@@ -1443,6 +1453,97 @@ function PreviewAsPanel({
           </button>
         ))}
       </div>
+    </section>
+  );
+}
+
+const VISIBILITY_OPTIONS: {
+  value: TenantVisibility;
+  label: string;
+  hint: string;
+}[] = [
+  {
+    value: "unlisted",
+    label: "Unlisted",
+    hint: "Reachable at your URL. Not shown on the public directory.",
+  },
+  {
+    value: "public",
+    label: "Public",
+    hint: "Listed on portablellm.wiki for anyone to discover.",
+  },
+  {
+    value: "private",
+    label: "Private",
+    hint: "Hidden from the directory and from /tenants/{id}. Direct URL 404s for anonymous viewers.",
+  },
+];
+
+/** Hosted-mode directory listing. New signups default to unlisted. */
+export function WikiVisibilityPanel({ tenantId }: { tenantId?: string }) {
+  const [visibility, setVisibility] = useState<TenantVisibility>("unlisted");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    authMe()
+      .then((me) => {
+        const next = me.tenant?.visibility;
+        if (next === "public" || next === "unlisted" || next === "private") {
+          setVisibility(next);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  async function save(next: TenantVisibility) {
+    setSaving(true);
+    setError(null);
+    try {
+      const out = await ownerSetTenantVisibility(next, tenantId);
+      setVisibility(out.visibility);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="mt-6 bg-white border border-paper-soft rounded-xl p-4 sm:p-5">
+      <div className="text-sm font-medium text-ink">Wiki visibility</div>
+      <p className="text-xs text-ink-muted mt-1 mb-3">
+        New wikis start unlisted. Public puts your GitHub login on the
+        landing directory. Private hides the wiki from anonymous visitors.
+      </p>
+      <div className="flex flex-col gap-2">
+        {VISIBILITY_OPTIONS.map((opt) => (
+          <label
+            key={opt.value}
+            className="flex items-start gap-2 text-sm text-ink cursor-pointer"
+          >
+            <input
+              type="radio"
+              name="wiki-visibility"
+              value={opt.value}
+              checked={visibility === opt.value}
+              disabled={saving}
+              onChange={() => {
+                void save(opt.value);
+              }}
+            />
+            <span>
+              <span className="font-medium">{opt.label}</span>
+              <span className="block text-xs text-ink-muted">{opt.hint}</span>
+            </span>
+          </label>
+        ))}
+      </div>
+      {error && (
+        <p className="text-xs text-red-700 mt-2" role="alert">
+          {error}
+        </p>
+      )}
     </section>
   );
 }

--- a/frontend/components/HandshakeCallout.tsx
+++ b/frontend/components/HandshakeCallout.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { getShareToken, redactTokenizedUrl, SHARE_TOKEN_CHANGE_EVENT } from "@/lib/shareToken";
+
+export function HandshakeCallout({
+  tenant,
+  isOwnerView,
+}: {
+  tenant: string;
+  /** True when /auth/me resolved a session belonging to this tenant.
+   *  When true we add a footnote explaining that this visible URL is
+   *  public-tier — and link the owner to /owner where they can mint
+   *  a personal URL that includes their private content. Without this
+   *  affordance owners would assume copying the URL they see here is
+   *  what gives them LLM portability, and they'd be missing their
+   *  private notes from every LLM conversation. */
+  isOwnerView: boolean;
+}) {
+  // Vanity URL — Next.js rewrites /<tenant>/llm to /t/<tenant>/llm on
+  // the backend (see frontend/next.config.mjs). Short + memorable for
+  // the "paste this URL into ChatGPT" pitch.
+  //
+  // If the visitor arrived via a tier-elevated share link
+  // (`?share=<token>`), ShareTokenCatcher has already stashed the
+  // token in the share-token store. Copy includes `?t=<token>` so the
+  // URL we hand out grants the same tier the visitor is browsing —
+  // but the raw token is never painted into the DOM.
+  const publicLlmUrl = `https://portablellm.wiki/${tenant}/llm`;
+  const [shareToken, setShareTokenState] = useState<string | null>(null);
+  useEffect(() => {
+    const sync = () => setShareTokenState(getShareToken(tenant));
+    sync();
+    if (typeof window === "undefined") return;
+    window.addEventListener("wiki:preview-as-change", sync);
+    window.addEventListener(SHARE_TOKEN_CHANGE_EVENT, sync);
+    return () => {
+      window.removeEventListener("wiki:preview-as-change", sync);
+      window.removeEventListener(SHARE_TOKEN_CHANGE_EVENT, sync);
+    };
+  }, [tenant]);
+  const copyUrl = shareToken
+    ? `${publicLlmUrl}?t=${encodeURIComponent(shareToken)}`
+    : publicLlmUrl;
+  const visibleUrl = shareToken ? redactTokenizedUrl(copyUrl) : publicLlmUrl;
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      navigator.clipboard.writeText(copyUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  };
+  return (
+    <section className="border-2 border-ink rounded-2xl bg-white p-5 sm:p-6 shadow-[0_1px_0_rgba(0,0,0,0.02),0_20px_60px_-30px_rgba(14,14,16,0.18)]">
+      <div className="text-[11px] uppercase tracking-[0.22em] font-semibold text-accent">
+        Paste this URL into any LLM
+      </div>
+      <div className="mt-1.5 text-lg sm:text-xl font-semibold tracking-tight text-ink">
+        One URL. Any model. Full context.
+      </div>
+      <p className="mt-1.5 text-sm text-ink-muted leading-relaxed">
+        Any LLM that can fetch URLs can now read this wiki — try Claude,
+        ChatGPT, Cursor, Gemini.
+      </p>
+
+      <div className="mt-4 flex items-center gap-2 bg-paper-soft/70 rounded-lg p-2 pr-2.5">
+        <code className="flex-1 font-mono text-sm text-ink truncate px-2 py-1.5">
+          {visibleUrl}
+        </code>
+        <button
+          onClick={copy}
+          className="shrink-0 px-3 py-1.5 rounded-md bg-ink text-paper text-xs font-medium hover:bg-ink-soft inline-flex items-center gap-1.5 whitespace-nowrap"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+
+      <div className="mt-3 text-xs flex items-center gap-3 flex-wrap">
+        <a
+          href={publicLlmUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="text-accent hover:underline"
+        >
+          preview what an LLM sees →
+        </a>
+        {isOwnerView && !shareToken && (
+          // The URL above is the PUBLIC-tier link — the same artifact a
+          // stranger gets when they scan the QR. Pasting it into YOUR
+          // ChatGPT gives ChatGPT only your public pages, which silently
+          // strips out exactly the private context that would make its
+          // answers about you actually useful. The fix lives in /owner
+          // (PersonalLlmUrlPanel) — a one-time mint that produces a
+          // tokenized URL revealing your full wiki. This footnote is
+          // owner-only, and suppressed when a share token is active
+          // (because then copy already includes ?t=… elevating to that
+          // tier).
+          <Link
+            href={`/${tenant}/owner#personal-llm-url`}
+            className="text-red-700 hover:text-red-900 hover:underline"
+            title="Mint a private-tier URL for your own LLMs — they'll see your full wiki including private notes."
+          >
+            this URL is public-tier · get your personal LLM URL →
+          </Link>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -4,7 +4,8 @@ import Link from "next/link";
 import { usePathname, useParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { apiBase, authMe, isHostedMode, type AuthUser } from "@/lib/api";
+import { apiBase, authLogout, authMe, isHostedMode, type AuthUser } from "@/lib/api";
+import { loginReturnTo } from "@/lib/safeReturnTo";
 
 import { ViewerBadge } from "./ViewerBadge";
 
@@ -272,10 +273,8 @@ function HostedIdentityBadge({
     return <span className="text-xs text-ink-muted">…</span>;
   }
   if (!viewer) {
-    const returnTo =
-      typeof window !== "undefined" ? window.location.href : "/";
     const signInUrl = `${apiBase()}/auth/github/login?return_to=${encodeURIComponent(
-      returnTo,
+      loginReturnTo(),
     )}`;
     return (
       <a
@@ -287,15 +286,28 @@ function HostedIdentityBadge({
     );
   }
 
-  const homeUrl =
-    typeof window !== "undefined" ? window.location.origin : "/";
-  const signOutUrl = `${apiBase()}/auth/logout?return_to=${encodeURIComponent(homeUrl)}`;
-  // "Switch account" = clear our session AND kick off GitHub OAuth in
-  // one server-side hop. Backend endpoint /auth/switch-account does
-  // both — needed because /auth/logout's return_to is restricted to
-  // the frontend origin (correctly), so a client-side chain wouldn't
-  // make it to /auth/github/login.
-  const switchAccountUrl = `${apiBase()}/auth/switch-account?return_to=${encodeURIComponent(homeUrl)}`;
+  const signOut = async () => {
+    try {
+      await authLogout();
+    } catch {
+      /* still leave the page */
+    }
+    window.location.assign("/");
+  };
+
+  // GET /auth/switch-account no longer clears the session (CSRF).
+  // POST logout, then send the user through GitHub login ourselves.
+  const switchAccount = async () => {
+    try {
+      await authLogout();
+    } catch {
+      /* still offer a fresh login */
+    }
+    const returnTo = loginReturnTo();
+    window.location.assign(
+      `${apiBase()}/auth/github/login?return_to=${encodeURIComponent(returnTo)}`,
+    );
+  };
 
   return (
     <div ref={wrapRef} className="relative">
@@ -359,15 +371,13 @@ function HostedIdentityBadge({
           {/* Account management */}
           <div className="border-t border-paper-soft py-1">
             <MenuLink
-              href={switchAccountUrl}
               label="Switch GitHub account"
-              external
+              onAction={switchAccount}
               hint="Uses whichever account you're currently signed into on github.com. Open incognito to use a different one."
             />
             <MenuLink
-              href={signOutUrl}
               label="Sign out"
-              external
+              onAction={signOut}
               danger
             />
           </div>
@@ -380,37 +390,42 @@ function HostedIdentityBadge({
 function MenuLink({
   href,
   label,
-  external,
   danger,
   hint,
   onClick,
+  onAction,
 }: {
-  href: string;
+  href?: string;
   label: string;
-  external?: boolean;
   danger?: boolean;
   hint?: string;
   onClick?: () => void;
+  onAction?: () => void | Promise<void>;
 }) {
   const className = `block w-full text-left px-4 py-2 text-sm hover:bg-paper-soft/60 ${
     danger ? "text-red-700 hover:text-red-800" : "text-ink"
   }`;
-  // External (= /auth/logout etc.) needs a full navigation, not Next
-  // client-side routing — the cookie clear happens server-side.
-  if (external) {
+  if (onAction) {
     return (
-      <a href={href} className={className} onClick={onClick}>
+      <button
+        type="button"
+        className={className}
+        onClick={() => {
+          onClick?.();
+          void onAction();
+        }}
+      >
         <div>{label}</div>
         {hint && (
           <div className="mt-0.5 text-[11px] text-ink-muted font-normal leading-snug">
             {hint}
           </div>
         )}
-      </a>
+      </button>
     );
   }
   return (
-    <Link href={href} className={className} onClick={onClick}>
+    <Link href={href || "/"} className={className} onClick={onClick}>
       <div>{label}</div>
       {hint && (
         <div className="mt-0.5 text-[11px] text-ink-muted font-normal leading-snug">

--- a/frontend/components/OwnerGate.tsx
+++ b/frontend/components/OwnerGate.tsx
@@ -22,6 +22,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { apiBase, authMe, isHostedMode, type AuthMeResponse } from "@/lib/api";
+import { loginReturnTo } from "@/lib/safeReturnTo";
 
 type GateState =
   | { kind: "loading" }
@@ -103,10 +104,9 @@ export function OwnerGate({
     );
   }
   if (state.kind === "anonymous") {
-    const signInUrl =
-      typeof window !== "undefined"
-        ? `${apiBase()}/auth/github/login?return_to=${encodeURIComponent(window.location.href)}`
-        : `${apiBase()}/auth/github/login`;
+    const signInUrl = `${apiBase()}/auth/github/login?return_to=${encodeURIComponent(
+      loginReturnTo(),
+    )}`;
     return (
       <PanelMessage
         eyebrow="owner only"
@@ -132,10 +132,9 @@ export function OwnerGate({
     );
   }
   if (state.kind === "tenant-missing") {
-    const signInUrl =
-      typeof window !== "undefined"
-        ? `${apiBase()}/auth/github/login?return_to=${encodeURIComponent(window.location.href)}`
-        : `${apiBase()}/auth/github/login`;
+    const signInUrl = `${apiBase()}/auth/github/login?return_to=${encodeURIComponent(
+      loginReturnTo(),
+    )}`;
     return (
       <PanelMessage
         eyebrow="wiki not on server"

--- a/frontend/components/PersonalLlmUrlPanel.tsx
+++ b/frontend/components/PersonalLlmUrlPanel.tsx
@@ -51,6 +51,7 @@ import {
   type MintedShareToken,
   type ShareTokenInfo,
 } from "@/lib/api";
+import { redactTokenizedUrl } from "@/lib/shareToken";
 import { buildOfflineBriefing, isBriefingComplete } from "@/lib/briefing";
 import { ConnectMarionetteButton } from "@/components/ConnectMarionetteButton";
 import {
@@ -284,10 +285,9 @@ export function PersonalLlmUrlPanel({
             <div className="flex gap-2">
               <input
                 readOnly
-                value={personalLlmUrl(newlyMinted.token)}
+                value={redactTokenizedUrl(personalLlmUrl(newlyMinted.token))}
                 aria-label="Newly minted personal LLM URL"
                 className="flex-1 border border-red-300 rounded px-2 py-1.5 text-xs font-mono bg-white"
-                onFocus={(e) => e.currentTarget.select()}
               />
               <button
                 onClick={() => copyMinted(newlyMinted.token)}

--- a/frontend/components/ShareTokenCatcher.tsx
+++ b/frontend/components/ShareTokenCatcher.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 // Recognizes `?share=...` on any page load. If the URL has a share token,
-// stores it in localStorage (under the same key the rest of the app uses)
+// stores it in a tenant-scoped share-token key (never llmwiki:ownerToken)
 // and strips the query param from the URL so it doesn't leak via reload /
 // back button / clipboard paste.
 //
 // This is the receiver side of the tokenized share flow. The owner mints a
-// URL like `https://wiki.example.com?share=ABC123` and hands it to someone.
-// When that someone opens the URL, this component captures the token and
-// the rest of the app sees a tier-elevated viewer.
+// URL like `https://wiki.example.com/<tenant>?share=ABC123` and hands it
+// to someone. When that someone opens the URL, this component captures
+// the token; browse/API reads send it as X-Share-Token.
 
 import { useEffect } from "react";
-import { setOwnerToken } from "@/lib/api";
+import { setShareToken, tenantFromPathname } from "@/lib/shareToken";
 
 export function ShareTokenCatcher() {
   useEffect(() => {
@@ -19,7 +19,7 @@ export function ShareTokenCatcher() {
     const params = new URLSearchParams(window.location.search);
     const share = params.get("share");
     if (!share) return;
-    setOwnerToken(share);
+    setShareToken(share, tenantFromPathname(window.location.pathname));
     params.delete("share");
     const newSearch = params.toString();
     const cleanUrl =

--- a/frontend/components/ShareTokensPanel.tsx
+++ b/frontend/components/ShareTokensPanel.tsx
@@ -8,6 +8,7 @@ import {
   type MintedShareToken,
   type ShareTokenInfo,
 } from "@/lib/api";
+import { redactTokenizedUrl } from "@/lib/shareToken";
 
 type Tier = "public" | "recruiter" | "friend";
 
@@ -217,9 +218,8 @@ export function ShareTokensPanel({
               <div className="flex gap-2">
                 <input
                   readOnly
-                  value={llmShareUrl(newlyMinted.token)}
+                  value={redactTokenizedUrl(llmShareUrl(newlyMinted.token))}
                   className="flex-1 border border-amber-300 rounded px-2 py-1.5 text-xs font-mono bg-white"
-                  onFocus={(e) => e.currentTarget.select()}
                 />
                 <button
                   onClick={() => copyShare(newlyMinted.token, "llm")}
@@ -240,9 +240,8 @@ export function ShareTokensPanel({
               <div className="flex gap-2">
                 <input
                   readOnly
-                  value={humanShareUrl(newlyMinted.token)}
+                  value={redactTokenizedUrl(humanShareUrl(newlyMinted.token))}
                   className="flex-1 border border-amber-300 rounded px-2 py-1.5 text-xs font-mono bg-white"
-                  onFocus={(e) => e.currentTarget.select()}
                 />
                 <button
                   onClick={() => copyShare(newlyMinted.token, "human")}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,6 +1,8 @@
 // Browser-side API client. All requests proxy through Next.js /api/backend/*
 // (configured in next.config.mjs) so we don't fight CORS during local dev.
 
+import { getShareToken } from "./shareToken";
+
 /**
  * Durability verdict the backend stamps on every content-create response so
  * the UI can warn when a write won't actually reach a git remote / hosted
@@ -208,13 +210,16 @@ function ownerHeaders(extra?: HeadersInit): HeadersInit {
 /**
  * Browse/ask/graph headers — may include ``X-Preview-As`` from
  * ``wiki.preview_as`` so owners can audit the wiki as public /
- * recruiter / friend. Do not use for owner-console verify or
- * ``/owner/*`` endpoints.
+ * recruiter / friend, and ``X-Share-Token`` from the tenant-scoped
+ * share-token store (never the owner-token key). Do not use for
+ * owner-console verify or ``/owner/*`` endpoints.
  */
-function browseHeaders(extra?: HeadersInit): HeadersInit {
+function browseHeaders(extra?: HeadersInit, tenant?: string): HeadersInit {
   const h = { ...(ownerHeaders(extra) as Record<string, string>) };
   const preview = getPreviewAs();
   if (preview !== "owner") h["X-Preview-As"] = preview;
+  const share = getShareToken(tenant);
+  if (share) h["X-Share-Token"] = share;
   return h;
 }
 
@@ -270,7 +275,7 @@ export async function fetchManifest(
 ): Promise<Manifest> {
   return asJson<Manifest>(
     await apiFetch(`${wikiBase(tenant)}/wiki/manifest.json`, {
-      headers: opts?.asOwner ? ownerHeaders() : browseHeaders(),
+      headers: opts?.asOwner ? ownerHeaders() : browseHeaders(undefined, tenant),
       cache: "no-store",
     })
   );
@@ -280,7 +285,7 @@ export async function fetchPage(slug: string, tenant?: string): Promise<PageFull
   return asJson<PageFull>(
     await apiFetch(
       `${wikiBase(tenant)}/wiki/page/${encodeURIComponent(slug)}`,
-      { headers: browseHeaders(), cache: "no-store" }
+      { headers: browseHeaders(undefined, tenant), cache: "no-store" }
     )
   );
 }
@@ -289,7 +294,7 @@ export async function searchWiki(q: string, tenant?: string): Promise<SearchResp
   return asJson<SearchResponse>(
     await apiFetch(
       `${wikiBase(tenant)}/wiki/search?q=${encodeURIComponent(q)}`,
-      { headers: browseHeaders(), cache: "no-store" }
+      { headers: browseHeaders(undefined, tenant), cache: "no-store" }
     )
   );
 }
@@ -298,7 +303,7 @@ export async function askWiki(question: string, tenant?: string): Promise<QueryR
   return asJson<QueryResponse>(
     await apiFetch(`${wikiBase(tenant)}/wiki/query`, {
       method: "POST",
-      headers: browseHeaders(),
+      headers: browseHeaders(undefined, tenant),
       body: JSON.stringify({ question }),
     })
   );
@@ -850,7 +855,7 @@ export async function chatWithWiki(
   return asJson<ChatResponse>(
     await apiFetch(`${wikiBase(tenant)}/wiki/chat`, {
       method: "POST",
-      headers: { ...browseHeaders(), "Content-Type": "application/json" },
+      headers: { ...browseHeaders(undefined, tenant), "Content-Type": "application/json" },
       body: JSON.stringify({ message, history }),
     }),
   );
@@ -894,7 +899,7 @@ export async function streamChatWithWiki(
   const r = await apiFetch(`${wikiBase(tenant)}/wiki/chat/stream`, {
     method: "POST",
     headers: {
-      ...browseHeaders(),
+      ...browseHeaders(undefined, tenant),
       "Content-Type": "application/json",
       Accept: "text/event-stream",
     },
@@ -1087,7 +1092,7 @@ export type GraphResponse = {
 
 export async function fetchGraph(tenant?: string): Promise<GraphResponse> {
   return asJson<GraphResponse>(
-    await apiFetch(`${wikiBase(tenant)}/wiki/graph`, { headers: browseHeaders(), cache: "no-store" })
+    await apiFetch(`${wikiBase(tenant)}/wiki/graph`, { headers: browseHeaders(undefined, tenant), cache: "no-store" })
   );
 }
 
@@ -1095,7 +1100,7 @@ export async function fetchSubgraph(slug: string, hops = 1, tenant?: string): Pr
   return asJson<GraphResponse>(
     await apiFetch(
       `${wikiBase(tenant)}/wiki/graph/${encodeURIComponent(slug)}?hops=${hops}`,
-      { headers: browseHeaders(), cache: "no-store" }
+      { headers: browseHeaders(undefined, tenant), cache: "no-store" }
     )
   );
 }
@@ -1333,6 +1338,8 @@ export async function ownerReplacePage(slug: string, markdown: string, tenant?: 
 // All requests use `credentials: "include"` so the session cookie set
 // by the GitHub OAuth callback is sent back to the backend.
 
+export type TenantVisibility = "public" | "unlisted" | "private";
+
 export type AuthTenant = {
   id: string;
   github_login: string;
@@ -1340,6 +1347,7 @@ export type AuthTenant = {
   avatar_url: string | null;
   created_at: string;
   is_public: boolean;
+  visibility?: TenantVisibility;
 };
 
 export type AuthUser = {
@@ -1668,6 +1676,20 @@ export async function ownerDeleteAccount(): Promise<DeleteAccountResponse> {
   return backendFetch<DeleteAccountResponse>("/owner/account", {
     method: "DELETE",
   });
+}
+
+/** Hosted-only: list this wiki on the public directory, keep it URL-only, or hide it. */
+export async function ownerSetTenantVisibility(
+  visibility: TenantVisibility,
+  tenant?: string,
+): Promise<{ ok: boolean; id: string; visibility: TenantVisibility }> {
+  return asJson(
+    await apiFetch(`${wikiBase(tenant)}/owner/tenant/visibility`, {
+      method: "POST",
+      headers: ownerHeaders(),
+      body: JSON.stringify({ visibility }),
+    }),
+  );
 }
 
 /**

--- a/frontend/lib/llmPrompts.ts
+++ b/frontend/lib/llmPrompts.ts
@@ -126,10 +126,11 @@ export function buildLlmUrlForTier(opts: {
  *
  *  Recruiter / friend → /<tenant>?share=<token>. ShareTokenCatcher
  *  (mounted globally in app/layout.tsx) pulls the token out of the URL
- *  on first paint, stores it in localStorage, and strips ?share= from
- *  the address bar so the user doesn't accidentally leak the token via
- *  reload / clipboard. Subsequent page navigation respects the
- *  elevated tier.
+ *  on first paint, stores it in a tenant-scoped share-token key (never
+ *  llmwiki:ownerToken), and strips ?share= from the address bar so the
+ *  user doesn't accidentally leak the token via reload / clipboard.
+ *  Browse reads send X-Share-Token. Subsequent page navigation respects
+ *  the elevated tier.
  *
  *  Why a SEPARATE helper from buildLlmUrlForTier: the two URLs have
  *  different audiences (humans vs LLMs), different query-param shapes

--- a/frontend/lib/safeReturnTo.ts
+++ b/frontend/lib/safeReturnTo.ts
@@ -1,0 +1,27 @@
+/**
+ * Safe return_to for GitHub login / post-auth redirects.
+ *
+ * Login URLs must never forward ?share=, ?t=, ?return=, or ?nonce= —
+ * those leak share tokens and marionette loopback secrets through
+ * OAuth. Pathname only is enough: marionette client state is already
+ * remembered in sessionStorage before we bounce to GitHub.
+ */
+export function loginReturnTo(href?: string): string {
+  try {
+    const raw =
+      href ??
+      (typeof window !== "undefined" ? window.location.href : "/");
+    const origin =
+      typeof window !== "undefined"
+        ? window.location.origin
+        : "https://portablellm.wiki";
+    const url = new URL(raw, origin);
+    return url.pathname || "/";
+  } catch {
+    return "/";
+  }
+}
+
+export function safeReturnTo(href?: string): string {
+  return loginReturnTo(href);
+}

--- a/frontend/lib/shareToken.ts
+++ b/frontend/lib/shareToken.ts
@@ -1,0 +1,72 @@
+// Tenant-scoped share-token store for human share links (?share=).
+//
+// Share tokens are NOT owner tokens. Storing a recruiter/friend token
+// under llmwiki:ownerToken would overwrite a real OSS OWNER_TOKEN and
+// send it as Authorization on owner routes. Browse/API reads send the
+// value here as X-Share-Token instead.
+
+const SHARE_TOKEN_PREFIX = "llmwiki:shareToken:";
+const DEFAULT_SCOPE = "default";
+
+const RESERVED_FIRST_SEGMENTS = new Set([
+  "welcome",
+  "signup",
+  "signin",
+  "me",
+  "owner",
+  "browse",
+  "capture",
+  "share",
+  "connect",
+  "ask",
+  "graph",
+  "page",
+  "og",
+  "api",
+  "auth",
+  "healthz",
+  "_next",
+  "favicon.ico",
+]);
+
+export const SHARE_TOKEN_CHANGE_EVENT = "wiki:share-token-change";
+
+/** First path segment when it looks like a hosted tenant id. */
+export function tenantFromPathname(pathname?: string): string | undefined {
+  const path =
+    pathname ??
+    (typeof window !== "undefined" ? window.location.pathname : "");
+  const first = path.split("/").filter(Boolean)[0];
+  if (!first || RESERVED_FIRST_SEGMENTS.has(first)) return undefined;
+  return first;
+}
+
+export function shareTokenStorageKey(tenant?: string | null): string {
+  const scope = tenant || tenantFromPathname() || DEFAULT_SCOPE;
+  return `${SHARE_TOKEN_PREFIX}${scope}`;
+}
+
+export function getShareToken(tenant?: string | null): string | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem(shareTokenStorageKey(tenant));
+}
+
+export function setShareToken(
+  token: string | null,
+  tenant?: string | null,
+): void {
+  if (typeof window === "undefined") return;
+  const key = shareTokenStorageKey(tenant);
+  if (token) window.localStorage.setItem(key, token);
+  else window.localStorage.removeItem(key);
+  window.dispatchEvent(new Event(SHARE_TOKEN_CHANGE_EVENT));
+  // HandshakeCallout and ViewerBadge already listen for this.
+  window.dispatchEvent(new Event("wiki:preview-as-change"));
+}
+
+/** Replace plaintext ?t= / ?share= values so tokens never render as text. */
+export function redactTokenizedUrl(url: string): string {
+  return url
+    .replace(/([?&]t=)[^&#]*/gi, "$1••••••••")
+    .replace(/([?&]share=)[^&#]*/gi, "$1••••••••");
+}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -42,6 +42,14 @@ const nextConfig = {
 
     return [...baseRewrites, ...(hosted ? hostedRewrites : singleTenantRewrites)];
   },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [{ key: "Referrer-Policy", value: "no-referrer" }],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/tests/ConnectMarionettePage.test.tsx
+++ b/frontend/tests/ConnectMarionettePage.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * ConnectMarionettePage login return_to is pathname only — no share/t/return/nonce.
+ */
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    authMe: vi.fn(),
+    apiBase: () => "https://api.portablellm.wiki",
+  };
+});
+
+import { authMe } from "@/lib/api";
+import ConnectMarionettePage from "@/app/connect/marionette/page";
+
+describe("ConnectMarionettePage return_to", () => {
+  beforeEach(() => {
+    vi.mocked(authMe).mockReset();
+    vi.mocked(authMe).mockResolvedValue({
+      authenticated: false,
+      user: null,
+      tenant: null,
+      fresh_signup: false,
+    });
+    window.history.pushState(
+      {},
+      "",
+      "/connect/marionette?client=marionette&share=abc&t=secret&return=http://127.0.0.1:9/api/wiki/connect&nonce=n1",
+    );
+  });
+
+  it("sign-in href is pathname-only return_to", async () => {
+    render(<ConnectMarionettePage />);
+    const link = await screen.findByRole("link", { name: /sign in with github/i });
+    await waitFor(() => {
+      expect(link.getAttribute("href")).toContain("return_to=");
+    });
+    const href = link.getAttribute("href") || "";
+    const returnTo = decodeURIComponent(href.split("return_to=")[1] || "");
+    expect(returnTo).toBe("/connect/marionette");
+    expect(href).not.toContain("share=");
+    expect(href).not.toContain("secret");
+    expect(href).not.toContain("nonce=");
+    expect(href).not.toContain("127.0.0.1");
+  });
+});

--- a/frontend/tests/HandshakeCallout.test.tsx
+++ b/frontend/tests/HandshakeCallout.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * HandshakeCallout must never paint a plaintext share/owner token into
+ * the DOM (code block or preview href). Copy may still put ?t= on the
+ * clipboard when a share-token store value exists.
+ */
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import { HandshakeCallout } from "@/components/HandshakeCallout";
+import { setOwnerToken } from "@/lib/api";
+import { setShareToken } from "@/lib/shareToken";
+
+describe("HandshakeCallout", () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    writeText.mockClear();
+    Object.assign(navigator, { clipboard: { writeText } });
+  });
+
+  it("shows the public /<tenant>/llm URL when no share token is stored", () => {
+    render(<HandshakeCallout tenant="cary" isOwnerView={false} />);
+    expect(screen.getByText("https://portablellm.wiki/cary/llm")).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain("?t=");
+    const preview = screen.getByRole("link", { name: /preview what an LLM sees/i });
+    expect(preview.getAttribute("href")).toBe("https://portablellm.wiki/cary/llm");
+  });
+
+  it("does not render a stored share token; copy still includes ?t=", async () => {
+    setShareToken("SECRET_SHARE_TOKEN", "cary");
+    render(<HandshakeCallout tenant="cary" isOwnerView={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/t=••••••••/)).toBeInTheDocument();
+    });
+    expect(document.body.textContent).not.toContain("SECRET_SHARE_TOKEN");
+    const preview = screen.getByRole("link", { name: /preview what an LLM sees/i });
+    expect(preview.getAttribute("href")).toBe("https://portablellm.wiki/cary/llm");
+    expect(preview.getAttribute("href")).not.toContain("SECRET_SHARE_TOKEN");
+
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }));
+    expect(writeText).toHaveBeenCalledWith(
+      "https://portablellm.wiki/cary/llm?t=SECRET_SHARE_TOKEN",
+    );
+  });
+
+  it("does not treat llmwiki:ownerToken as a share token", () => {
+    setOwnerToken("OWNER_PLAINTEXT");
+    render(<HandshakeCallout tenant="cary" isOwnerView={true} />);
+    expect(screen.getByText("https://portablellm.wiki/cary/llm")).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain("OWNER_PLAINTEXT");
+    expect(document.body.textContent).not.toContain("?t=");
+  });
+});

--- a/frontend/tests/NavBar.hosted.test.tsx
+++ b/frontend/tests/NavBar.hosted.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Hosted NavBar: Sign out is POST /auth/logout (not a CSRF-able GET).
+ * Switch-account is not a GET that clears the session. Sign-in return_to
+ * is pathname only.
+ */
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    isHostedMode: vi.fn(() => true),
+    authMe: vi.fn(),
+    authLogout: vi.fn(),
+    apiBase: () => "https://api.portablellm.wiki",
+  };
+});
+
+import { authLogout, authMe } from "@/lib/api";
+import { NavBar } from "@/components/NavBar";
+
+describe("NavBar hosted logout / return_to", () => {
+  beforeEach(() => {
+    vi.mocked(authMe).mockReset();
+    vi.mocked(authLogout).mockReset();
+    vi.mocked(authLogout).mockResolvedValue({ ok: true });
+    window.history.pushState({}, "", "/cary?share=abc&t=secret");
+  });
+
+  it("anonymous sign-in uses pathname-only return_to", async () => {
+    vi.mocked(authMe).mockResolvedValue({
+      authenticated: false,
+      user: null,
+      tenant: null,
+      fresh_signup: false,
+    });
+    render(<NavBar />);
+    const link = await screen.findByRole("link", { name: /sign in/i });
+    const href = link.getAttribute("href") || "";
+    const returnTo = decodeURIComponent(href.split("return_to=")[1] || "");
+    expect(returnTo).toBe("/cary");
+    expect(returnTo).not.toContain("share=");
+    expect(returnTo).not.toContain("t=");
+  });
+
+  it("Sign out POSTs /auth/logout and is not an <a href> GET", async () => {
+    vi.mocked(authMe).mockResolvedValue({
+      authenticated: true,
+      user: {
+        tenant_id: "cary",
+        login: "cary",
+        name: "Cary",
+        avatar_url: "",
+      },
+      tenant: { id: "cary" } as never,
+      fresh_signup: false,
+    });
+    const assign = vi.fn();
+    vi.stubGlobal("location", { ...window.location, assign });
+
+    render(<NavBar />);
+    const chip = await screen.findByRole("button", { name: /@cary/i });
+    fireEvent.click(chip);
+
+    const signOut = screen.getByRole("button", { name: /sign out/i });
+    expect(signOut.tagName).toBe("BUTTON");
+    expect(screen.queryByRole("link", { name: /sign out/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /switch github account/i })).toBeNull();
+
+    fireEvent.click(signOut);
+    await waitFor(() => {
+      expect(authLogout).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("Switch account POSTs logout then goes to GitHub login, not GET switch-account", async () => {
+    vi.mocked(authMe).mockResolvedValue({
+      authenticated: true,
+      user: {
+        tenant_id: "cary",
+        login: "cary",
+        name: "Cary",
+        avatar_url: "",
+      },
+      tenant: { id: "cary" } as never,
+      fresh_signup: false,
+    });
+    const assign = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        assign,
+        href: "https://portablellm.wiki/cary?share=abc&t=secret",
+        pathname: "/cary",
+        origin: "https://portablellm.wiki",
+        search: "?share=abc&t=secret",
+      },
+    });
+
+    render(<NavBar />);
+    fireEvent.click(await screen.findByRole("button", { name: /@cary/i }));
+    fireEvent.click(screen.getByRole("button", { name: /switch github account/i }));
+
+    await waitFor(() => {
+      expect(authLogout).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(assign).toHaveBeenCalled();
+    });
+    const dest = String(assign.mock.calls[0][0]);
+    expect(dest).toContain("/auth/github/login?return_to=");
+    expect(dest).not.toContain("/auth/switch-account");
+    expect(dest).not.toContain("share=");
+    expect(dest).not.toContain("t=secret");
+  });
+});

--- a/frontend/tests/OwnerGate.test.tsx
+++ b/frontend/tests/OwnerGate.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * OwnerGate login links must pass pathname-only return_to — never
+ * ?share= or ?t= from the current page.
+ */
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    isHostedMode: vi.fn(() => true),
+    authMe: vi.fn(),
+    apiBase: () => "https://api.portablellm.wiki",
+  };
+});
+
+import { authMe } from "@/lib/api";
+import { OwnerGate } from "@/components/OwnerGate";
+
+describe("OwnerGate return_to", () => {
+  beforeEach(() => {
+    vi.mocked(authMe).mockReset();
+    window.history.pushState(
+      {},
+      "",
+      "/cary/owner?share=leaked&t=also-leaked&nonce=n1",
+    );
+  });
+
+  it("anonymous sign-in link uses pathname only", async () => {
+    vi.mocked(authMe).mockResolvedValue({
+      authenticated: false,
+      user: null,
+      tenant: null,
+      fresh_signup: false,
+    });
+    render(
+      <OwnerGate tenant="cary">
+        <div>secret owner ui</div>
+      </OwnerGate>,
+    );
+    const link = await screen.findByRole("link", { name: /sign in with github/i });
+    const href = link.getAttribute("href") || "";
+    expect(href).toContain("/auth/github/login?return_to=");
+    const returnTo = decodeURIComponent(href.split("return_to=")[1] || "");
+    expect(returnTo).toBe("/cary/owner");
+    expect(returnTo).not.toContain("share=");
+    expect(returnTo).not.toContain("t=");
+    expect(returnTo).not.toContain("nonce=");
+  });
+
+  it("tenant-missing re-sign-in link also strips secrets", async () => {
+    vi.mocked(authMe).mockResolvedValue({
+      authenticated: true,
+      user: {
+        tenant_id: "cary",
+        login: "cary",
+        name: "Cary",
+        avatar_url: "",
+      },
+      tenant: null,
+      fresh_signup: false,
+    });
+    render(
+      <OwnerGate tenant="cary">
+        <div>secret owner ui</div>
+      </OwnerGate>,
+    );
+    const link = await screen.findByRole("link", {
+      name: /re-sign in with github/i,
+    });
+    const href = link.getAttribute("href") || "";
+    const returnTo = decodeURIComponent(href.split("return_to=")[1] || "");
+    expect(returnTo).toBe("/cary/owner");
+    expect(href).not.toContain("share=");
+    expect(href).not.toContain("also-leaked");
+  });
+});

--- a/frontend/tests/PersonalLlmUrlPanel.test.tsx
+++ b/frontend/tests/PersonalLlmUrlPanel.test.tsx
@@ -148,14 +148,23 @@ describe("PersonalLlmUrlPanel", () => {
       );
     });
 
-    // The minted URL surfaces in a readonly <input>; check it points
-    // at the LLM handshake endpoint with the token in the ?t= query.
+    // The minted URL is redacted in the DOM; the real token stays off-screen.
     const minted = (await screen.findByLabelText(
       /newly minted personal llm url/i,
     )) as HTMLInputElement;
     expect(minted.value).toBe(
-      "https://portablellm.wiki/cary/llm?t=PLAINTEXT_TOKEN_VALUE",
+      "https://portablellm.wiki/cary/llm?t=••••••••",
     );
+    expect(document.body.textContent).not.toContain("PLAINTEXT_TOKEN_VALUE");
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    fireEvent.click(screen.getByRole("button", { name: /copy url/i }));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        "https://portablellm.wiki/cary/llm?t=PLAINTEXT_TOKEN_VALUE",
+      );
+    });
   });
 
   it("URL-encodes special characters in tokens", async () => {
@@ -189,8 +198,10 @@ describe("PersonalLlmUrlPanel", () => {
       /newly minted personal llm url/i,
     )) as HTMLInputElement;
     expect(minted.value).toBe(
-      "https://portablellm.wiki/cary/llm?t=a%2Bb%2Fc%3Dd",
+      "https://portablellm.wiki/cary/llm?t=••••••••",
     );
+    expect(minted.value).not.toContain("a+b/c=d");
+    expect(document.body.textContent).not.toContain("a+b/c=d");
   });
 
   it("lists ONLY private-tier tokens (recruiter tokens stay in the other panel)", async () => {

--- a/frontend/tests/ShareTokenCatcher.test.tsx
+++ b/frontend/tests/ShareTokenCatcher.test.tsx
@@ -1,24 +1,28 @@
 /**
  * ShareTokenCatcher: when the URL contains ?share=<token>, we store the
- * token as the owner token and scrub the query string so it doesn't
- * accidentally end up in logs or screenshots.
+ * token in a tenant-scoped share-token key (never llmwiki:ownerToken)
+ * and scrub the query string so it doesn't end up in logs or screenshots.
  *
  * This is the single most security-sensitive client-side component, so
  * we test:
- *  - happy path: ?share=X writes localStorage and cleans URL
+ *  - happy path: ?share=X writes the share-token key and cleans URL
+ *  - does not overwrite a real OSS OWNER_TOKEN
  *  - empty share param doesn't break or write garbage
  *  - non-share URLs don't touch localStorage
  */
 import React from "react";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { render, waitFor } from "@testing-library/react";
 
 import { ShareTokenCatcher } from "@/components/ShareTokenCatcher";
+import { setOwnerToken } from "@/lib/api";
+import { getShareToken, shareTokenStorageKey } from "@/lib/shareToken";
 
-function setUrl(search: string) {
+function setUrl(pathAndSearch: string) {
   // jsdom doesn't let us assign window.location directly, but it does support
   // history.pushState to rewrite the URL within the same origin.
-  window.history.pushState({}, "", `/${search ? "?" + search : ""}`);
+  const path = pathAndSearch.startsWith("/") ? pathAndSearch : `/${pathAndSearch ? "?" + pathAndSearch : ""}`;
+  window.history.pushState({}, "", path);
 }
 
 describe("ShareTokenCatcher", () => {
@@ -27,28 +31,51 @@ describe("ShareTokenCatcher", () => {
     setUrl("");
   });
 
-  it("stores the token from ?share=… and scrubs the URL", async () => {
+  it("stores the token from ?share=… in the share-token key and scrubs the URL", async () => {
     setUrl("share=abc123tok");
     expect(window.location.search).toContain("share=abc123tok");
 
     render(<ShareTokenCatcher />);
 
     await waitFor(() => {
-      // Token persisted under the api.ts owner-token key
-      expect(window.localStorage.getItem("llmwiki:ownerToken")).toBe(
-        "abc123tok",
+      expect(getShareToken()).toBe("abc123tok");
+    });
+    expect(window.localStorage.getItem("llmwiki:ownerToken")).toBeNull();
+    expect(window.location.search).not.toContain("share=");
+  });
+
+  it("scopes the share token to the hosted tenant path", async () => {
+    setUrl("/cary?share=recruiter-tok");
+    render(<ShareTokenCatcher />);
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(shareTokenStorageKey("cary"))).toBe(
+        "recruiter-tok",
       );
     });
-    // URL was rewritten to drop the share param
-    expect(window.location.search).not.toContain("share=");
+    expect(window.localStorage.getItem("llmwiki:ownerToken")).toBeNull();
+    expect(window.localStorage.getItem(shareTokenStorageKey("other"))).toBeNull();
+  });
+
+  it("does not overwrite a real OSS owner token", async () => {
+    setOwnerToken("real-owner-secret");
+    setUrl("/cary?share=friend-share");
+    render(<ShareTokenCatcher />);
+
+    await waitFor(() => {
+      expect(getShareToken("cary")).toBe("friend-share");
+    });
+    expect(window.localStorage.getItem("llmwiki:ownerToken")).toBe(
+      "real-owner-secret",
+    );
   });
 
   it("does nothing when there is no share param", async () => {
     setUrl("foo=bar");
     render(<ShareTokenCatcher />);
-    // Give the effect a tick
     await new Promise((r) => setTimeout(r, 5));
     expect(window.localStorage.getItem("llmwiki:ownerToken")).toBeNull();
+    expect(getShareToken()).toBeNull();
     expect(window.location.search).toContain("foo=bar");
   });
 
@@ -57,5 +84,6 @@ describe("ShareTokenCatcher", () => {
     render(<ShareTokenCatcher />);
     await new Promise((r) => setTimeout(r, 5));
     expect(window.localStorage.getItem("llmwiki:ownerToken")).toBeNull();
+    expect(getShareToken()).toBeNull();
   });
 });

--- a/frontend/tests/WikiVisibilityPanel.test.tsx
+++ b/frontend/tests/WikiVisibilityPanel.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    authMe: vi.fn(),
+    ownerSetTenantVisibility: vi.fn(),
+  };
+});
+
+import { authMe, ownerSetTenantVisibility } from "@/lib/api";
+import { WikiVisibilityPanel } from "@/app/owner/page";
+
+describe("WikiVisibilityPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authMe).mockResolvedValue({
+      authenticated: true,
+      user: {
+        tenant_id: "alice",
+        login: "alice",
+        name: "Alice",
+        avatar_url: null,
+      },
+      tenant: {
+        id: "alice",
+        github_login: "alice",
+        display_name: "Alice",
+        avatar_url: null,
+        created_at: "",
+        is_public: false,
+        visibility: "unlisted",
+      },
+      fresh_signup: false,
+    });
+    vi.mocked(ownerSetTenantVisibility).mockResolvedValue({
+      ok: true,
+      id: "alice",
+      visibility: "public",
+    });
+  });
+
+  it("loads current visibility and posts a change", async () => {
+    render(<WikiVisibilityPanel tenantId="alice" />);
+    const unlisted = await screen.findByDisplayValue("unlisted");
+    expect(unlisted).toBeChecked();
+
+    fireEvent.click(screen.getByDisplayValue("public"));
+    await waitFor(() => {
+      expect(ownerSetTenantVisibility).toHaveBeenCalledWith("public", "alice");
+    });
+  });
+});

--- a/frontend/tests/api.test.ts
+++ b/frontend/tests/api.test.ts
@@ -12,6 +12,7 @@ import {
   fetchManifest,
   ownerLint,
 } from "@/lib/api";
+import { setShareToken } from "@/lib/shareToken";
 
 describe("owner token roundtrip", () => {
   beforeEach(() => {
@@ -153,5 +154,51 @@ describe("preview-as vs owner bootstrap headers", () => {
     const hdrs = init.headers as Record<string, string>;
     expect(hdrs["Authorization"]).toBe("Bearer owner-secret");
     expect(hdrs["X-Preview-As"]).toBeUndefined();
+  });
+
+  it("browse sends X-Share-Token and does not put the share token in Authorization", async () => {
+    setShareToken("recruiter-share", "cary");
+    setOwnerToken("real-owner-secret");
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ...ownerManifest,
+        viewer_tier: "recruiter",
+        viewer_is_owner: false,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchManifest("cary");
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const hdrs = init.headers as Record<string, string>;
+    expect(hdrs["X-Share-Token"]).toBe("recruiter-share");
+    expect(hdrs["Authorization"]).toBe("Bearer real-owner-secret");
+  });
+
+  it("owner endpoints never send X-Share-Token as Authorization substitute", async () => {
+    setShareToken("recruiter-share");
+    setOwnerToken("owner-secret");
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        totals: { pages: 0, by_section: {}, by_tier: {} },
+        orphans: [],
+        stale: [],
+        missing_pages: [],
+        broken_provenance: [],
+        missing_index_entries: [],
+        generated_at: "2026-01-01T00:00:00Z",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await ownerLint();
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const hdrs = init.headers as Record<string, string>;
+    expect(hdrs["Authorization"]).toBe("Bearer owner-secret");
+    expect(hdrs["X-Share-Token"]).toBeUndefined();
   });
 });

--- a/frontend/tests/safeReturnTo.test.ts
+++ b/frontend/tests/safeReturnTo.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+
+import { loginReturnTo } from "@/lib/safeReturnTo";
+
+describe("loginReturnTo", () => {
+  it("returns pathname only and strips share, t, return, nonce", () => {
+    expect(
+      loginReturnTo(
+        "https://portablellm.wiki/cary/owner?share=abc&t=secret&return=http://127.0.0.1:9/api/wiki/connect&nonce=n1",
+      ),
+    ).toBe("/cary/owner");
+  });
+
+  it("keeps a bare path", () => {
+    expect(loginReturnTo("/connect/marionette")).toBe("/connect/marionette");
+  });
+
+  it("falls back to / on an unparseable href", () => {
+    expect(loginReturnTo("http://")).toBe("/");
+  });
+});

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -10,6 +10,15 @@
   },
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Referrer-Policy",
+          "value": "no-referrer"
+        }
+      ]
+    },
+    {
       "source": "/og",
       "headers": [
         {

--- a/render.yaml
+++ b/render.yaml
@@ -89,7 +89,7 @@ services:
       - key: WIKI_ROOT
         value: /app/wiki
       - key: DEFAULT_TIER
-        value: public
+        value: private
       - key: OWNER_TOKEN
         generateValue: true  # Render auto-generates a strong value
 


### PR DESCRIPTION
## Summary
- Merge `dev` into `main` so the red-team hardening (PR #3) can auto-deploy.
- Public `/healthz` no longer names tenants; existing tenants stay public; new signups default unlisted with an owner visibility control.
- Owner jobs are tenant-scoped; hosted `OWNER_TOKEN` is not a cross-tenant master key; share tokens stay out of the owner-token key.

## Test plan
- [x] Local: 435 pytest, 196 vitest + tsc
- [ ] GitHub Actions CI green on this PR (backend / frontend / mcp)
- [ ] After merge + Render deploy: `GET /healthz` has no `indexed_tenant_ids`
- [ ] After deploy: `GET /tenants` still lists the existing public wikis
- [ ] After deploy: `https://portablellm.wiki/professorpalmer` and `/avery` stay 200