### PR TITLE
fix: allow hosted OWNER_TOKEN only on listed operator tenants

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,14 +19,17 @@ WIKI_ROOT=/Users/me/my-wiki
 # Single-tenant boot refuses OWNER_TOKEN=change-me-to-a-long-random-string.
 OWNER_TOKEN=
 
+# Hosted only. Comma-separated tenant ids for which OWNER_TOKEN is a
+# headless owner key (Cursor / MCP). Empty = not a master key.
+# HOSTED_OWNER_TENANT_IDS=your-github-login
+
 # ---------------------------------------------------------------------------
 # Tier model
 # ---------------------------------------------------------------------------
 
 # Default tier for pages that don't declare one in frontmatter.
 # Safer default is "private" so nothing leaks by accident. The Render
-# blueprint ships "public" so the hosted demo works out of the box —
-# flip to "private" on your own deploy if you'd rather opt-in per page.
+# blueprint also ships private.
 DEFAULT_TIER=private
 
 # Optional share tokens (format: tokenA:recruiter,tokenB:friend).

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -140,14 +140,26 @@ def viewer_from_header(authorization: str | None) -> Viewer:
     if len(parts) != 2 or parts[0].lower() != "bearer":
         return PUBLIC_VIEWER
     token = parts[1].strip()
-    # Hosted OWNER_TOKEN is not a master key across tenants. OSS
-    # single-tenant still treats the env token as the owner credential.
+    # OSS: process OWNER_TOKEN is the owner credential.
+    # Hosted: the same env token is owner only for tenants listed in
+    # HOSTED_OWNER_TENANT_IDS — never a cross-tenant master key.
     if (
-        settings.single_tenant_mode
-        and settings.owner_token
+        settings.owner_token
+        and len(token) == len(settings.owner_token)
         and hmac.compare_digest(token, settings.owner_token)
     ):
-        return Viewer(tier="private", is_owner=True, label="owner")
+        if settings.single_tenant_mode:
+            return Viewer(tier="private", is_owner=True, label="owner")
+        allowed = getattr(settings, "hosted_owner_tenant_ids", frozenset())
+        if allowed:
+            try:
+                from . import tenants as _tenants
+
+                current = _tenants.current_tenant_or_none()
+            except Exception:  # noqa: BLE001
+                current = None
+            if current is not None and current.id.lower() in allowed:
+                return Viewer(tier="private", is_owner=True, label="owner")
     # Static SHARE_TOKENS env var (legacy v0 mechanism)
     tiers = _share_tokens()
     if token in tiers:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -68,6 +68,9 @@ class _BaseSettings:
     # Brave, Safari ITP) block the cross-host AJAX cookie even on shared
     # eTLD+1. Empty = host-only (legacy behavior).
     session_cookie_domain: str
+    # Hosted-only: tenant ids for which process OWNER_TOKEN is a headless
+    # owner key. Empty means the env token is never a master key.
+    hosted_owner_tenant_ids: frozenset[str]
 
 
 class Settings:
@@ -119,6 +122,13 @@ def _load_owner_token(single_tenant_mode: bool) -> str:
             "token with: openssl rand -hex 32"
         )
     return token
+
+
+def _load_hosted_owner_tenant_ids() -> frozenset[str]:
+    raw = os.environ.get("HOSTED_OWNER_TENANT_IDS", "").strip()
+    if not raw:
+        return frozenset()
+    return frozenset(part.strip().lower() for part in raw.split(",") if part.strip())
 
 
 def _load_settings() -> Settings:
@@ -199,6 +209,7 @@ def _load_settings() -> Settings:
         or "plw_session",
         session_secret=os.environ.get("SESSION_SECRET", "").strip(),
         session_cookie_domain=os.environ.get("SESSION_COOKIE_DOMAIN", "").strip(),
+        hosted_owner_tenant_ids=_load_hosted_owner_tenant_ids(),
     )
 
     return Settings(base)

--- a/backend/tests/test_hosted_multitenant.py
+++ b/backend/tests/test_hosted_multitenant.py
@@ -3714,6 +3714,8 @@ def test_hosted_env_owner_token_is_not_master_key(multi_tenant_app, monkeypatch)
 
     monkeypatch.setattr(_config.settings, "owner_token", "hosted-env-token")
     monkeypatch.setattr(_auth.settings, "owner_token", "hosted-env-token")
+    monkeypatch.setattr(_config.settings, "hosted_owner_tenant_ids", frozenset())
+    monkeypatch.setattr(_auth.settings, "hosted_owner_tenant_ids", frozenset())
 
     r = multi_tenant_app.post(
         "/t/bob/owner/reload",
@@ -3724,6 +3726,30 @@ def test_hosted_env_owner_token_is_not_master_key(multi_tenant_app, monkeypatch)
     _set_session_user(multi_tenant_app, "bob", login="bob")
     r = multi_tenant_app.post("/t/bob/owner/reload")
     assert r.status_code == 200, r.text
+
+
+def test_hosted_owner_token_allowlist_is_tenant_scoped(multi_tenant_app, monkeypatch):
+    """HOSTED_OWNER_TENANT_IDS elevates OWNER_TOKEN for listed tenants only."""
+    import app.auth as _auth
+    import app.config as _config
+
+    monkeypatch.setattr(_config.settings, "owner_token", "hosted-env-token")
+    monkeypatch.setattr(_auth.settings, "owner_token", "hosted-env-token")
+    allowed = frozenset({"alice"})
+    monkeypatch.setattr(_config.settings, "hosted_owner_tenant_ids", allowed)
+    monkeypatch.setattr(_auth.settings, "hosted_owner_tenant_ids", allowed)
+
+    r = multi_tenant_app.post(
+        "/t/alice/owner/reload",
+        headers={"Authorization": "Bearer hosted-env-token"},
+    )
+    assert r.status_code == 200, r.text
+
+    r = multi_tenant_app.post(
+        "/t/bob/owner/reload",
+        headers={"Authorization": "Bearer hosted-env-token"},
+    )
+    assert r.status_code == 401, r.text
 
 
 def test_demo_tenant_writes_rejected(multi_tenant_app):

--- a/render.yaml
+++ b/render.yaml
@@ -92,6 +92,12 @@ services:
         value: private
       - key: OWNER_TOKEN
         generateValue: true  # Render auto-generates a strong value
+      # Hosted operator allowlist. Process OWNER_TOKEN is a headless
+      # owner key only for these tenant ids (comma-separated). Leave
+      # unset/blank so the token cannot open every tenant. Production
+      # sets this in the dashboard (sync: false) to the operator wiki.
+      - key: HOSTED_OWNER_TENANT_IDS
+        sync: false
 
       # --- Single-tenant (OSS) vs multi-tenant (hosted) toggle ---
       # PROMPTED at first deploy because the right value depends on


### PR DESCRIPTION
## Summary
- Process `OWNER_TOKEN` is owner in hosted mode only for tenant ids in `HOSTED_OWNER_TENANT_IDS`.
- Restores Cursor/MCP private access for the operator wiki without reopening the cross-tenant master key.

## Test plan
- [x] `test_hosted_env_owner_token_is_not_master_key`
- [x] `test_hosted_owner_token_allowlist_is_tenant_scoped`
- [ ] After deploy: wiki MCP `list_pages` sees private-tier pages again
- [ ] `GET /t/other/owner/reload` with process token still 401