### PR TITLE
feat: first wiki, directory honesty, GitHub trust

### DIFF
--- a/HOSTED_DEPLOYMENT.md
+++ b/HOSTED_DEPLOYMENT.md
@@ -44,8 +44,42 @@ Register the OAuth App at <https://github.com/settings/applications/new>:
 Click "Generate a new client secret" — copy both the **Client ID** and
 **Client Secret** for the env vars below.
 
-The OAuth app only needs `read:user, public_repo` scopes (the backend
-requests these implicitly; users see them on the consent screen).
+The OAuth app requests `read:user, repo`. We need `repo` (not
+`public_repo`) so we can create and push **one** wiki repository on the
+user's account and import a private wiki they already have. An OAuth
+App cannot be limited to a single repo — that is honest, and it is why
+GitHub's consent screen looks broad. Do not switch live OAuth to
+`public_repo`; that breaks private-wiki import and push.
+
+The narrower path is a GitHub App the user installs on just that one
+repo. Leave the App unset until you create it; OAuth keeps working.
+
+### 1b. GitHub App (optional, later)
+
+When you are ready to narrow trust, create a GitHub App at
+<https://github.com/settings/apps/new>:
+
+* **Name**: Portable LLM Wiki
+* **Homepage URL**: `https://portablellm.wiki`
+* **Webhook**: inactive until you need one
+* **Repository permissions**: Contents (read/write), Metadata (read).
+  No org or account-wide administration.
+* **Where can this GitHub App be installed?**: Only on this account,
+  then install it on the one wiki repo (or let each user install it on
+  theirs).
+
+Generate a private key. Set on the backend (empty = unused):
+
+```bash
+GITHUB_APP_ID=<numeric app id>
+GITHUB_APP_PRIVATE_KEY=<PEM; literal \n newlines are fine>
+GITHUB_APP_INSTALL_URL=https://github.com/apps/<slug>/installations/new
+# Optional, single-install deploys only:
+# GITHUB_APP_INSTALLATION_ID=<numeric installation id>
+```
+
+You do not need to create the App for the current OAuth path or for
+CI. Tests mock the installation-token mint.
 
 ### 2. DNS
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -168,11 +168,21 @@ PUBLIC_BASE_URL=http://localhost:3000
 
 # GitHub OAuth App credentials (https://github.com/settings/applications/new).
 # Authorization callback URL must match GITHUB_OAUTH_REDIRECT_URL exactly.
-# The OAuth App needs `read:user, public_repo` scopes (we request them
-# automatically; user sees the consent screen).
+# We request `read:user,repo` so we can create/push ONE wiki repo and
+# import a private wiki the user already has. `public_repo` cannot see
+# private wikis — do not switch live OAuth to it. The narrower path is
+# a GitHub App installed on just that one repo (optional vars below).
 # GITHUB_OAUTH_CLIENT_ID=
 # GITHUB_OAUTH_CLIENT_SECRET=
 # GITHUB_OAUTH_REDIRECT_URL=https://api.portablellm.wiki/auth/github/callback
+#
+# Optional GitHub App (leave unset — OAuth continues unchanged).
+# Create later at https://github.com/settings/apps/new ; install on the
+# one wiki repo. PEM may use literal \n for newlines.
+# GITHUB_APP_ID=
+# GITHUB_APP_PRIVATE_KEY=
+# GITHUB_APP_INSTALL_URL=
+# GITHUB_APP_INSTALLATION_ID=
 #
 # Public origin of the API host, used to build the GitHub push-webhook
 # callback (POST <PUBLIC_API_BASE_URL>/hooks/github). Registered per

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -52,6 +52,12 @@ class _BaseSettings:
     github_oauth_client_id: str
     github_oauth_client_secret: str
     github_oauth_redirect_url: str
+    # Optional GitHub App (narrower than OAuth ``repo``). Empty = unused;
+    # the current OAuth path continues unchanged. See github_app.py.
+    github_app_id: str
+    github_app_private_key: str
+    github_app_install_url: str
+    github_app_installation_id: str
     # Public origin of the API host (e.g. https://api.portablellm.wiki).
     # Used to build the GitHub push-webhook callback URL. Defaults to the
     # origin of github_oauth_redirect_url (which already lives on the API
@@ -200,6 +206,12 @@ def _load_settings() -> Settings:
         github_oauth_client_secret=os.environ.get("GITHUB_OAUTH_CLIENT_SECRET", "").strip(),
         github_oauth_redirect_url=os.environ.get(
             "GITHUB_OAUTH_REDIRECT_URL", ""
+        ).strip(),
+        github_app_id=os.environ.get("GITHUB_APP_ID", "").strip(),
+        github_app_private_key=os.environ.get("GITHUB_APP_PRIVATE_KEY", "").strip(),
+        github_app_install_url=os.environ.get("GITHUB_APP_INSTALL_URL", "").strip(),
+        github_app_installation_id=os.environ.get(
+            "GITHUB_APP_INSTALLATION_ID", ""
         ).strip(),
         public_api_base_url=(
             os.environ.get("PUBLIC_API_BASE_URL", "").strip()

--- a/backend/app/github_api.py
+++ b/backend/app/github_api.py
@@ -5,8 +5,9 @@ Used by the hosted onboarding flow:
 * :func:`exchange_oauth_code` — swap an OAuth ``code`` for an access token.
 * :func:`get_user` — fetch the authenticated user's profile + bio.
 * :func:`create_repo` — create ``<owner>/my-portable-llm-wiki`` on the user's
-  account (uses ``public_repo`` scope; falls back to private if the user
-  requests it).
+  account (private by default; pass ``private=False`` for a public wiki).
+* :func:`resolve_access_token` — prefer a GitHub App installation token
+  when App env is set; otherwise keep the OAuth user token.
 * :func:`commit_files` — Contents-API style batch write of multiple
   files to a repo (used to seed the repo on signup and to push wiki edits).
 
@@ -32,22 +33,33 @@ GITHUB_OAUTH = "https://github.com/login/oauth"
 
 # Scopes we request:
 #   * ``read:user`` — show the user their name/avatar after sign-in.
-#   * ``repo``      — read + write any of the user's repos, public OR
-#                     private. We need private-repo read so the
-#                     onboarding "Import existing wiki" picker can list
-#                     and clone the user's own private wikis (most users
-#                     keep their personal-context wikis private), and
-#                     read+write because the existing OSS path creates +
-#                     pushes to a portable-llm-wiki repo on their account.
+#   * ``repo``      — create + push ONE wiki repo on the user's account,
+#                     and list/clone a private wiki they already have so
+#                     onboarding can import it. Most personal-context
+#                     wikis are private; ``public_repo`` cannot see them.
 #
-# This is broader than the more conservative ``public_repo`` scope we
-# used in earlier OAuth-app versions. The trade-off: we get the
-# private-repo import flow that users actually want (no PAT to paste),
-# at the cost of asking for the full repo scope at consent. Existing
-# users signed in with the old scope will need to re-authorize once —
-# the onboarding UI detects insufficient scope from the
-# ``X-OAuth-Scopes`` header and prompts them to re-sign-in.
+# Honest consent: ``repo`` is broader than the one wiki we touch. We
+# ask for it because a GitHub OAuth App cannot be limited to a single
+# repository. The narrower path is a GitHub App the user installs on
+# just that one repo (see github_app.py). Until that App is configured
+# (GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY), this OAuth scope stays
+# ``repo`` — switching live OAuth to ``public_repo`` would break
+# private-wiki import and push.
+#
+# Existing users signed in with the old ``public_repo`` scope need to
+# re-authorize once. The onboarding UI detects insufficient scope from
+# the ``X-OAuth-Scopes`` header and prompts them to re-sign-in.
 DEFAULT_SCOPES = "read:user,repo"
+
+# Shown in operator docs and tests so the consent story cannot drift
+# from the scope we actually request.
+REPO_SCOPE_CONSENT = (
+    "We ask for the repo scope so we can create and push one wiki "
+    "repository on your GitHub account and import a private wiki you "
+    "already have. We do not need access to your other repositories. "
+    "A GitHub App you install on just that one repo is the narrower "
+    "path; OAuth repo remains until that App is live."
+)
 
 
 class GitHubAPIError(RuntimeError):
@@ -152,6 +164,28 @@ async def exchange_oauth_code(
         # GitHub returns 200 with an error field if the code is bad.
         raise GitHubAPIError(400, payload.get("error_description") or str(payload))
     return str(payload["access_token"])
+
+
+async def resolve_access_token(
+    oauth_token: str,
+    *,
+    installation_id: str | int | None = None,
+    settings: object | None = None,
+) -> str:
+    """Return the token subsequent GitHub calls should use.
+
+    When GitHub App env is unset (the default), this is a no-op and the
+    OAuth user token is returned unchanged. When App env is set and an
+    installation id is known, mint a short-lived installation token
+    instead. See :mod:`app.github_app`.
+    """
+    from . import github_app
+
+    return await github_app.resolve_access_token(
+        oauth_token,
+        installation_id=installation_id,
+        settings=settings,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -466,15 +500,17 @@ async def create_repo(
     *,
     name: str = "my-portable-llm-wiki",
     description: str = "My portable LLM wiki. Vendor-neutral personal context, in markdown.",
-    private: bool = False,
+    private: bool = True,
     auto_init: bool = True,
 ) -> dict:
     """POST /user/repos.
 
+    New wiki repos are private unless the caller passes ``private=False``.
     Returns the GitHub repo object (full_name, default_branch, html_url, …).
     If a repo with the same name already exists, we GET that one instead and
     return it — onboarding is idempotent.
     """
+    token = await resolve_access_token(token)
     async with httpx.AsyncClient(timeout=30.0) as client:
         r = await client.post(
             f"{GITHUB_API}/user/repos",

--- a/backend/app/github_app.py
+++ b/backend/app/github_app.py
@@ -1,0 +1,219 @@
+"""Optional GitHub App installation-token path.
+
+A GitHub OAuth App cannot be limited to a single repository, so hosted
+sign-in currently asks for the ``repo`` scope — enough to create/push
+ONE wiki repo and import a private wiki the user already has. The
+narrower trust path is a GitHub App the user installs on just that
+repo. This module mints installation tokens when the operator has
+created that App and set env; it does nothing when env is unset.
+
+Env (all optional — empty keeps today's OAuth path):
+
+* ``GITHUB_APP_ID``
+* ``GITHUB_APP_PRIVATE_KEY`` (PEM; ``\\n`` escaped newlines are ok)
+* ``GITHUB_APP_INSTALL_URL`` (user-facing install link)
+* ``GITHUB_APP_INSTALLATION_ID`` (single-install deploys only)
+
+Tests mock :func:`mint_installation_token` / the HTTP + JWT signer so
+the App does not have to exist for CI to pass.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from typing import Any, Callable
+
+import httpx
+
+GITHUB_API = "https://api.github.com"
+
+
+class GitHubAppError(RuntimeError):
+    """GitHub App JWT or installation-token failure."""
+
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(f"GitHub App error {status_code}: {message}")
+        self.status_code = status_code
+        self.message = message
+
+
+def _settings_value(settings: object | None, name: str) -> str:
+    if settings is not None:
+        return str(getattr(settings, name, "") or "").strip()
+    try:
+        from .config import settings as _loaded
+
+        return str(getattr(_loaded, name, "") or "").strip()
+    except Exception:  # noqa: BLE001
+        env_name = {
+            "github_app_id": "GITHUB_APP_ID",
+            "github_app_private_key": "GITHUB_APP_PRIVATE_KEY",
+            "github_app_install_url": "GITHUB_APP_INSTALL_URL",
+            "github_app_installation_id": "GITHUB_APP_INSTALLATION_ID",
+        }.get(name, name.upper())
+        return os.environ.get(env_name, "").strip()
+
+
+def is_configured(settings: object | None = None) -> bool:
+    """True when both App id and private key are present."""
+    return bool(
+        _settings_value(settings, "github_app_id")
+        and _settings_value(settings, "github_app_private_key")
+    )
+
+
+def install_url(settings: object | None = None) -> str:
+    """Operator-supplied install URL, or empty when the App is not live."""
+    return _settings_value(settings, "github_app_install_url")
+
+
+def _normalize_pem(raw: str) -> str:
+    key = raw.strip()
+    if "\\n" in key and "\n" not in key:
+        key = key.replace("\\n", "\n")
+    return key
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _sign_rs256(message: bytes, pem: str) -> bytes:
+    """RS256-sign ``message`` with a PEM private key.
+
+    Tries PyJWT's cryptography backend, then ``cryptography`` directly,
+    then ``openssl``. Tests inject their own signer and never hit this.
+    """
+    try:
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import padding
+
+        key = serialization.load_pem_private_key(pem.encode("utf-8"), password=None)
+        return key.sign(message, padding.PKCS1v15(), hashes.SHA256())
+    except ImportError:
+        pass
+
+    import subprocess
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".pem")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(pem)
+            if not pem.endswith("\n"):
+                handle.write("\n")
+        os.chmod(path, 0o600)
+        result = subprocess.run(
+            ["openssl", "dgst", "-sha256", "-sign", path],
+            input=message,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            err = (result.stderr or b"").decode("utf-8", errors="replace")[:200]
+            raise GitHubAppError(500, f"openssl RS256 sign failed: {err}")
+        return result.stdout
+    except FileNotFoundError as exc:
+        raise GitHubAppError(
+            500,
+            "GitHub App JWT signing needs the cryptography package or openssl.",
+        ) from exc
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def build_app_jwt(
+    *,
+    app_id: str,
+    private_key_pem: str,
+    now: int | None = None,
+    sign: Callable[[bytes, str], bytes] | None = None,
+) -> str:
+    """Mint a short-lived GitHub App JWT (RS256, iss=app id)."""
+    issued = int(now if now is not None else time.time())
+    header = {"alg": "RS256", "typ": "JWT"}
+    payload = {"iat": issued - 60, "exp": issued + 9 * 60, "iss": str(app_id)}
+    signing_input = (
+        f"{_b64url(json.dumps(header, separators=(',', ':')).encode('utf-8'))}."
+        f"{_b64url(json.dumps(payload, separators=(',', ':')).encode('utf-8'))}"
+    )
+    signer = sign or _sign_rs256
+    signature = signer(signing_input.encode("ascii"), _normalize_pem(private_key_pem))
+    return f"{signing_input}.{_b64url(signature)}"
+
+
+async def mint_installation_token(
+    *,
+    installation_id: str | int,
+    settings: object | None = None,
+    jwt_token: str | None = None,
+    sign: Callable[[bytes, str], bytes] | None = None,
+) -> str:
+    """POST /app/installations/{id}/access_tokens — short-lived token."""
+    if not is_configured(settings):
+        raise GitHubAppError(
+            500,
+            "GitHub App is not configured. Set GITHUB_APP_ID and "
+            "GITHUB_APP_PRIVATE_KEY, or keep using OAuth.",
+        )
+    install_id = str(installation_id).strip()
+    if not install_id:
+        raise GitHubAppError(400, "installation_id is required to mint an App token")
+
+    token = jwt_token
+    if not token:
+        token = build_app_jwt(
+            app_id=_settings_value(settings, "github_app_id"),
+            private_key_pem=_settings_value(settings, "github_app_private_key"),
+            sign=sign,
+        )
+
+    url = f"{GITHUB_API}/app/installations/{install_id}/access_tokens"
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.post(
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+    if response.status_code not in (200, 201):
+        raise GitHubAppError(response.status_code, response.text[:200])
+    payload: Any = response.json()
+    minted = str((payload or {}).get("token") or "").strip()
+    if not minted:
+        raise GitHubAppError(502, "GitHub App token response missing token")
+    return minted
+
+
+async def resolve_access_token(
+    oauth_token: str,
+    *,
+    installation_id: str | int | None = None,
+    settings: object | None = None,
+) -> str:
+    """Prefer an installation token when the App is configured.
+
+    If App env is unset, or no installation id is available, return
+    ``oauth_token`` unchanged so today's OAuth path keeps working.
+    """
+    if not is_configured(settings):
+        return oauth_token
+    resolved_id = (
+        str(installation_id).strip()
+        if installation_id is not None
+        else _settings_value(settings, "github_app_installation_id")
+    )
+    if not resolved_id:
+        return oauth_token
+    return await mint_installation_token(
+        installation_id=resolved_id,
+        settings=settings,
+    )

--- a/backend/app/hosted_routes.py
+++ b/backend/app/hosted_routes.py
@@ -51,7 +51,7 @@ from fastapi import APIRouter, Body, Cookie, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 from pydantic import BaseModel, Field
 
-from . import github_api, persistence, tenants, url_scrape
+from . import github_api, onboarding_seed, persistence, tenants, url_scrape
 from .config import settings
 
 
@@ -1629,6 +1629,14 @@ async def onboarding_connect_repo(
     # Never blocks connect — a failure just means we rely on polling.
     await _register_push_webhook_best_effort(tenant, token, full_name, default_branch)
 
+    # A 0-page tenant after a successful connect is a failed signup.
+    # Seed a deterministic private starter (purpose + how-to-ingest) so
+    # the wiki is real immediately. Skip when bootstrap already imported
+    # pages. Never clones the Avery demo.
+    starter_seed = onboarding_seed.seed_starter_wiki(tenant)
+    if starter_seed.get("action") == "seeded":
+        persistence.flush_tenant_async(tenant, "wiki: seed starter pages")
+
     # If there was preexisting local content, the bootstrap already pushed
     # it as the seed commit. Just confirm and return status.
     return {
@@ -1639,6 +1647,7 @@ async def onboarding_connect_repo(
         "html_url": f"https://github.com/{full_name}",
         "bootstrap": boot,
         "status": persistence.get_tenant_status(tenant),
+        "starter_seed": starter_seed,
     }
 
 
@@ -2467,16 +2476,20 @@ def onboarding_cleanup_imports(request: Request) -> dict:
 
 @router.get("/tenants")
 def list_tenants() -> dict:
-    """Public list of tenants whose ``visibility`` is ``public``.
+    """Public directory of tenants with real content.
 
-    Unlisted wikis are reachable by direct URL (GET /tenants/{id}) but
-    must not appear in the directory. Private tenants 404 on GET by id.
+    Lists ``visibility==public`` tenants that have at least one wiki
+    page, plus demo tenants (Avery) regardless of page count. Unlisted
+    wikis stay reachable by GET /tenants/{id} but do not appear here.
+    Empty public shells are omitted so the directory does not advertise
+    wikis with no pages. Private tenants 404 on GET by id. This filter
+    does not rewrite ``tenant.json`` visibility fields.
     """
     if settings.single_tenant_mode:
         return {"tenants": []}
     out = []
     for t in tenants.manager().all_tenants():
-        if t.visibility != "public":
+        if not tenants.listed_in_public_directory(t):
             continue
         out.append(
             {

--- a/backend/app/onboarding_seed.py
+++ b/backend/app/onboarding_seed.py
@@ -1,0 +1,189 @@
+"""Deterministic private starter wiki for empty post-connect tenants.
+
+A 0-page tenant after a successful ``/onboarding/connect-repo`` is a
+failed signup: the user has a login, not a wiki. This module writes a
+tiny, LLM-free starter — a purpose page plus a how-to-ingest page —
+so ``GET /t/{id}/wiki/manifest.json`` reports ``page_count >= 1``.
+
+Rules:
+
+* Never overwrite existing pages. If bootstrap cloned or imported a
+  wiki that already has markdown, do nothing.
+* Never clone the Avery Chen 29-page demo. These two pages are generic
+  onboarding copy, not a persona snapshot.
+* Pages are ``tier: private`` with valid frontmatter the wiki index
+  can load.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tenants import Tenant
+
+log = logging.getLogger(__name__)
+
+# Fixed stamp so every empty tenant gets byte-identical starter files.
+STARTER_DATE = "2026-08-16"
+
+STARTER_PAGES: tuple[tuple[str, str, str], ...] = (
+    (
+        "purpose.md",
+        "Purpose",
+        """# Purpose
+
+This is your Portable LLM Wiki — a git-backed markdown corpus that any
+LLM client can query. Pages live in your GitHub repo as plain files.
+You own them.
+
+The wiki is private until you promote a page. Start by adding a first
+source on the welcome assemble step (a short bio, a resume, a URL, or
+an existing markdown wiki). The drafter turns that into linked pages.
+
+## What belongs here
+
+- **Entities**: people, companies, products
+- **Concepts**: operating principles and ways of thinking
+- **Decisions**: choices with rationale
+- **Projects**: what you are shipping
+- **Sources**: the raw material those pages were derived from
+
+See [[How to ingest]] for the concrete next step.
+""",
+    ),
+    (
+        "how-to-ingest.md",
+        "How to ingest",
+        """# How to ingest
+
+A wiki with no sources stays a shell. Add material, then let the
+drafter (or your own edits) turn it into pages.
+
+## First source
+
+On `/welcome`, use **Assemble starter wiki**:
+
+1. Answer one or two interview questions, or
+2. Paste a resume / LinkedIn About / README, or
+3. Add a URL to scrape
+
+Submit the bundle. Pages land in this repo automatically.
+
+## Other paths
+
+- **Import existing wiki** — paste a GitHub URL to a markdown wiki
+- **Owner console** — capture a file or conversation later
+- **Edit in git** — clone the repo and write markdown yourself
+
+Every ingest should cite where the claim came from. Prefer verbatim
+source files under `raw/` over reconstructed memory.
+
+This wiki's [[Purpose]] page is the other half of the starter set.
+""",
+    ),
+)
+
+
+def count_wiki_pages(tenant: Tenant) -> int:
+    """Count ``*.md`` files under ``tenant.wiki_dir``.
+
+    Matches :func:`app.hosted_routes._count_tenant_pages` so the seeder
+    and ``/auth/me`` agree on "empty".
+    """
+    wiki_dir = tenant.wiki_dir
+    try:
+        if not wiki_dir.exists():
+            return 0
+        return sum(1 for _ in wiki_dir.rglob("*.md"))
+    except OSError:
+        return 0
+
+
+def _render_page(title: str, body: str) -> str:
+    return (
+        "---\n"
+        "type: overview\n"
+        f"title: {title}\n"
+        f"created: {STARTER_DATE}\n"
+        f"updated: {STARTER_DATE}\n"
+        "tier: private\n"
+        "sources: []\n"
+        "tags: [meta, onboarding]\n"
+        "---\n\n"
+        + body.strip()
+        + "\n"
+    )
+
+
+def _write_starter_page(wiki_dir: Path, filename: str, title: str, body: str) -> Path | None:
+    """Write one starter page. Returns the path, or None if it already exists."""
+    target = wiki_dir / filename
+    if target.exists():
+        return None
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(_render_page(title, body), encoding="utf-8")
+    return target
+
+
+def seed_starter_wiki(tenant: Tenant) -> dict:
+    """Write the private starter wiki if ``tenant`` currently has 0 pages.
+
+    Returns a JSON-safe dict for the connect-repo response::
+
+        {"action": "seeded"|"skipped"|"error", "pages": [...], "page_count": int, ...}
+
+    Never raises — connect-repo already succeeded; a seed failure must
+    not turn that into a 500. Local files still count even if the
+    in-memory index reload fails.
+    """
+    existing = count_wiki_pages(tenant)
+    if existing > 0:
+        return {
+            "action": "skipped",
+            "reason": "existing_pages",
+            "pages": [],
+            "page_count": existing,
+        }
+
+    written: list[str] = []
+    try:
+        wiki_dir = tenant.wiki_dir
+        wiki_dir.mkdir(parents=True, exist_ok=True)
+        for filename, title, body in STARTER_PAGES:
+            path = _write_starter_page(wiki_dir, filename, title, body)
+            if path is not None:
+                written.append(path.name)
+    except Exception as exc:  # noqa: BLE001 — seed must not fail connect
+        log.exception("starter seed failed for tenant %s", getattr(tenant, "id", "?"))
+        return {
+            "action": "error",
+            "error": str(exc)[:200],
+            "pages": written,
+            "page_count": count_wiki_pages(tenant),
+        }
+
+    if not written:
+        return {
+            "action": "skipped",
+            "reason": "starter_files_already_present",
+            "pages": [],
+            "page_count": count_wiki_pages(tenant),
+        }
+
+    try:
+        tenant.reload_index()
+    except Exception as exc:  # noqa: BLE001 — disk is source of truth
+        log.warning(
+            "starter seed wrote pages for %s but index reload failed: %s",
+            getattr(tenant, "id", "?"),
+            exc,
+        )
+
+    return {
+        "action": "seeded",
+        "pages": written,
+        "page_count": count_wiki_pages(tenant),
+    }

--- a/backend/app/tenants.py
+++ b/backend/app/tenants.py
@@ -247,6 +247,40 @@ class Tenant:
         _manager._persist(self)
 
 
+def count_wiki_markdown_pages(tenant: Tenant) -> int:
+    """Count ``*.md`` files under ``tenant.wiki_dir`` without warming an index.
+
+    Listing the public directory must not construct a :class:`WikiIndex`
+    for every tenant — each index holds page bodies in RAM. A recursive
+    markdown count is enough to know whether the wiki has content.
+    """
+    wiki_dir = tenant.wiki_dir
+    try:
+        if not wiki_dir.is_dir():
+            return 0
+        return sum(1 for _ in wiki_dir.rglob("*.md"))
+    except OSError:
+        return 0
+
+
+def listed_in_public_directory(tenant: Tenant) -> bool:
+    """Whether GET /tenants should include this tenant.
+
+    Demo tenants (Avery) are always listed. Everyone else appears only
+    when ``visibility`` is ``public`` and the wiki dir has at least one
+    markdown page. Does not rewrite ``tenant.json``.
+    """
+    if tenant.is_demo:
+        return True
+    if tenant.visibility != "public":
+        return False
+    wiki_dir = tenant.wiki_dir
+    try:
+        return wiki_dir.is_dir() and any(wiki_dir.rglob("*.md"))
+    except OSError:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Request-scoped tenant context (one entry per HTTP request)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_directory_honesty.py
+++ b/backend/tests/test_directory_honesty.py
@@ -1,0 +1,100 @@
+"""Directory honesty: GET /tenants lists real public wikis, plus Avery.
+
+Empty public shells stay off the directory. GET /tenants/{id} is unchanged
+(public/unlisted 200, private 404) even when page_count is 0. Listing
+counts markdown on disk and must not rewrite tenant.json visibility or
+warm every WikiIndex into RAM.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.tenants import (
+    Tenant,
+    count_wiki_markdown_pages,
+    listed_in_public_directory,
+)
+from tests.test_hosted_multitenant import multi_tenant_app  # noqa: F401
+
+
+def _tenant(tmp_path, tenant_id: str, **kwargs) -> Tenant:
+    root = tmp_path / tenant_id
+    root.mkdir()
+    return Tenant(id=tenant_id, wiki_root=root, display_name=tenant_id, **kwargs)
+
+
+def test_count_missing_wiki_dir_is_zero(tmp_path) -> None:
+    tenant = _tenant(tmp_path, "ghost", visibility="public")
+    assert count_wiki_markdown_pages(tenant) == 0
+    assert listed_in_public_directory(tenant) is False
+
+
+def test_empty_public_tenant_is_not_listed(tmp_path) -> None:
+    tenant = _tenant(tmp_path, "empty", visibility="public")
+    tenant.wiki_dir.mkdir(parents=True)
+    assert count_wiki_markdown_pages(tenant) == 0
+    assert listed_in_public_directory(tenant) is False
+
+
+def test_public_tenant_with_nested_markdown_is_listed(tmp_path) -> None:
+    tenant = _tenant(tmp_path, "alice", visibility="public")
+    (tenant.wiki_dir / "concepts").mkdir(parents=True)
+    (tenant.wiki_dir / "index.md").write_text("# Alice\n", encoding="utf-8")
+    (tenant.wiki_dir / "concepts" / "idea.md").write_text("# Idea\n", encoding="utf-8")
+    assert count_wiki_markdown_pages(tenant) == 2
+    assert listed_in_public_directory(tenant) is True
+
+
+def test_unlisted_and_private_with_pages_are_not_listed(tmp_path) -> None:
+    for vis in ("unlisted", "private"):
+        tenant = _tenant(tmp_path, vis, visibility=vis)
+        tenant.wiki_dir.mkdir(parents=True)
+        (tenant.wiki_dir / "index.md").write_text("# Hi\n", encoding="utf-8")
+        assert count_wiki_markdown_pages(tenant) == 1
+        assert listed_in_public_directory(tenant) is False
+
+
+def test_demo_tenant_is_listed_without_pages(tmp_path) -> None:
+    tenant = _tenant(tmp_path, "avery", visibility="public", is_demo=True)
+    tenant.wiki_dir.mkdir(parents=True)
+    assert count_wiki_markdown_pages(tenant) == 0
+    assert listed_in_public_directory(tenant) is True
+
+
+def test_demo_tenant_is_listed_even_if_unlisted(tmp_path) -> None:
+    tenant = _tenant(tmp_path, "avery", visibility="unlisted", is_demo=True)
+    assert listed_in_public_directory(tenant) is True
+
+
+def test_count_does_not_warm_wiki_index(tmp_path) -> None:
+    tenant = _tenant(tmp_path, "alice", visibility="public")
+    tenant.wiki_dir.mkdir(parents=True)
+    (tenant.wiki_dir / "index.md").write_text("# Alice\n", encoding="utf-8")
+    assert listed_in_public_directory(tenant) is True
+    assert tenant._index is None
+    assert count_wiki_markdown_pages(tenant) == 1
+    assert tenant._index is None
+
+
+def test_list_tenants_http_hides_empty_public_keeps_get_by_id(multi_tenant_app) -> None:
+    from app import tenants as _tenants
+
+    empty = _tenants.manager().provision_local("shell", display_name="Shell")
+    empty.visibility = "public"
+    _tenants.manager().upsert(empty)
+    alice = _tenants.manager().require("alice")
+    before = (alice.wiki_root / "tenant.json").read_text(encoding="utf-8")
+
+    listed = {row["id"] for row in multi_tenant_app.get("/tenants").json()["tenants"]}
+    assert "alice" in listed
+    assert "avery" in listed
+    assert "shell" not in listed
+
+    r = multi_tenant_app.get("/tenants/shell")
+    assert r.status_code == 200
+    assert r.json()["visibility"] == "public"
+
+    after = (alice.wiki_root / "tenant.json").read_text(encoding="utf-8")
+    assert after == before
+    assert json.loads(after)["visibility"] == "public"

--- a/backend/tests/test_github_trust.py
+++ b/backend/tests/test_github_trust.py
@@ -1,0 +1,221 @@
+"""GitHub-trust slice: honest ``repo`` consent, App-token scaffold, private default.
+
+Locks in:
+
+1. OAuth fallback — when GitHub App env is unset, ``resolve_access_token``
+   returns the user OAuth token unchanged (no HTTP).
+2. App token path — when App env is set, minting is mocked and the
+   installation token is preferred. The App does not have to exist.
+3. ``create_new`` wiki repos default ``private=True`` on both
+   ``create_repo`` and ``ConnectRepoRequest``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from app import github_api, github_app
+from app.github_api import DEFAULT_SCOPES, REPO_SCOPE_CONSENT
+from app.hosted_routes import ConnectRepoRequest
+
+
+@dataclass
+class _AppSettings:
+    github_app_id: str = ""
+    github_app_private_key: str = ""
+    github_app_install_url: str = ""
+    github_app_installation_id: str = ""
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, body: Any, text: str | None = None) -> None:
+        self.status_code = status_code
+        self._body = body
+        self.text = text if text is not None else json.dumps(body)
+
+    def json(self) -> Any:
+        return self._body
+
+
+class _FakeAsyncClient:
+    """Records the POST that mints an installation token."""
+
+    last: dict[str, Any] | None = None
+    reply: _FakeResponse = _FakeResponse(201, {"token": "ghs_install_mock"})
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+    async def post(self, url: str, headers: dict | None = None, json: Any = None) -> _FakeResponse:
+        type(self).last = {"url": url, "headers": headers or {}, "json": json}
+        return self.reply
+
+
+def test_oauth_scope_stays_repo_not_public_repo():
+    """Live OAuth must keep ``repo``. ``public_repo`` cannot import/push a private wiki."""
+    assert DEFAULT_SCOPES == "read:user,repo"
+    assert "public_repo" not in DEFAULT_SCOPES
+    assert "repo" in DEFAULT_SCOPES.split(",")
+    assert "GitHub App" in REPO_SCOPE_CONSENT
+    assert "one wiki" in REPO_SCOPE_CONSENT
+
+
+def test_oauth_fallback_when_app_env_unset(monkeypatch):
+    """Unset App env is a no-op: the OAuth user token is returned as-is."""
+    unset = _AppSettings()
+    assert github_app.is_configured(unset) is False
+
+    minted_calls: list[Any] = []
+
+    async def _should_not_mint(**kwargs: Any) -> str:
+        minted_calls.append(kwargs)
+        raise AssertionError("mint_installation_token must not run when App env is unset")
+
+    monkeypatch.setattr(github_app, "mint_installation_token", _should_not_mint)
+    token = asyncio.run(
+        github_api.resolve_access_token("oauth-user-token", settings=unset)
+    )
+    assert token == "oauth-user-token"
+    assert minted_calls == []
+
+
+def test_oauth_fallback_when_app_set_but_no_installation():
+    """App credentials without an installation still use OAuth (user has not installed)."""
+    configured = _AppSettings(
+        github_app_id="12345",
+        github_app_private_key="-----BEGIN FAKE-----\nxx\n-----END FAKE-----",
+    )
+    assert github_app.is_configured(configured) is True
+    token = asyncio.run(
+        github_api.resolve_access_token("oauth-user-token", settings=configured)
+    )
+    assert token == "oauth-user-token"
+
+
+def test_app_token_path_when_env_set_mocked(monkeypatch):
+    """Configured App + installation id prefers a mocked installation token."""
+    configured = _AppSettings(
+        github_app_id="12345",
+        github_app_private_key="-----BEGIN FAKE-----\nxx\n-----END FAKE-----",
+        github_app_install_url="https://github.com/apps/portable-llm-wiki/installations/new",
+        github_app_installation_id="99",
+    )
+
+    async def fake_mint(*, installation_id: str | int, settings: object | None = None, **_: Any) -> str:
+        assert str(installation_id) == "99"
+        assert settings is configured
+        return "ghs_installation_token"
+
+    monkeypatch.setattr(github_app, "mint_installation_token", fake_mint)
+    token = asyncio.run(
+        github_api.resolve_access_token("oauth-user-token", settings=configured)
+    )
+    assert token == "ghs_installation_token"
+
+
+def test_mint_installation_token_posts_to_app_api(monkeypatch):
+    """Mint hits GitHub's installation-token endpoint with the App JWT (mocked signer)."""
+    configured = _AppSettings(
+        github_app_id="12345",
+        github_app_private_key="-----BEGIN FAKE-----\nxx\n-----END FAKE-----",
+    )
+    _FakeAsyncClient.last = None
+    _FakeAsyncClient.reply = _FakeResponse(201, {"token": "ghs_from_github"})
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+
+    token = asyncio.run(
+        github_app.mint_installation_token(
+            installation_id=42,
+            settings=configured,
+            jwt_token="header.payload.sig",
+        )
+    )
+    assert token == "ghs_from_github"
+    assert _FakeAsyncClient.last is not None
+    assert _FakeAsyncClient.last["url"].endswith("/app/installations/42/access_tokens")
+    assert _FakeAsyncClient.last["headers"]["Authorization"] == "Bearer header.payload.sig"
+
+
+def test_create_new_defaults_private():
+    """create_new wikis are private unless the user explicitly asks public."""
+    sig = inspect.signature(github_api.create_repo)
+    assert sig.parameters["private"].default is True
+
+    fields = ConnectRepoRequest.model_fields
+    assert fields["private"].default is True
+
+    implied = ConnectRepoRequest(create_new=True)
+    assert implied.private is True
+
+    explicit_public = ConnectRepoRequest(create_new=True, private=False)
+    assert explicit_public.private is False
+
+
+def test_create_repo_posts_private_true_by_default(monkeypatch):
+    """The GitHub POST body is private unless the caller overrides."""
+    captured: dict[str, Any] = {}
+
+    class _CreateClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_CreateClient":
+            return self
+
+        async def __aexit__(self, *exc: Any) -> bool:
+            return False
+
+        async def post(self, url: str, json: Any = None, headers: Any = None) -> _FakeResponse:
+            captured["url"] = url
+            captured["json"] = json
+            return _FakeResponse(
+                201,
+                {
+                    "full_name": "alice/my-portable-llm-wiki",
+                    "default_branch": "main",
+                    "private": True,
+                },
+            )
+
+    monkeypatch.setattr(httpx, "AsyncClient", _CreateClient)
+    monkeypatch.setattr(github_app, "is_configured", lambda settings=None: False)
+    repo = asyncio.run(github_api.create_repo("oauth-user-token", name="my-portable-llm-wiki"))
+    assert captured["json"]["private"] is True
+    assert captured["json"]["name"] == "my-portable-llm-wiki"
+    assert repo["full_name"] == "alice/my-portable-llm-wiki"
+
+
+def test_create_repo_uses_oauth_token_when_app_unset(monkeypatch):
+    """create_repo keeps the OAuth token when App env is unset."""
+    seen_auth: list[str] = []
+
+    class _CreateClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_CreateClient":
+            return self
+
+        async def __aexit__(self, *exc: Any) -> bool:
+            return False
+
+        async def post(self, url: str, json: Any = None, headers: Any = None) -> _FakeResponse:
+            seen_auth.append((headers or {}).get("Authorization", ""))
+            return _FakeResponse(201, {"full_name": "alice/wiki", "default_branch": "main"})
+
+    monkeypatch.setattr(httpx, "AsyncClient", _CreateClient)
+    monkeypatch.setattr(github_app, "is_configured", lambda settings=None: False)
+    asyncio.run(github_api.create_repo("oauth-user-token"))
+    assert seen_auth == ["Bearer oauth-user-token"]

--- a/backend/tests/test_hosted_multitenant.py
+++ b/backend/tests/test_hosted_multitenant.py
@@ -3682,6 +3682,62 @@ def test_tenants_list_excludes_unlisted(multi_tenant_app):
     assert r.status_code == 404
 
 
+def test_tenants_list_excludes_empty_public(multi_tenant_app):
+    """Public tenants with zero markdown pages stay off the directory.
+
+    GET /tenants/{id} still 200 — the URL works; the directory just
+    refuses to advertise an empty shell.
+    """
+    from app import tenants as _tenants
+
+    empty = _tenants.manager().provision_local("empty-pub", display_name="Empty")
+    empty.visibility = "public"
+    _tenants.manager().upsert(empty)
+    assert _tenants.count_wiki_markdown_pages(empty) == 0
+
+    r = multi_tenant_app.get("/tenants")
+    ids = {t["id"] for t in r.json()["tenants"]}
+    assert "alice" in ids
+    assert "avery" in ids
+    assert "empty-pub" not in ids
+
+    r = multi_tenant_app.get("/tenants/empty-pub")
+    assert r.status_code == 200
+    assert r.json()["visibility"] == "public"
+
+
+def test_tenants_list_always_includes_empty_demo(multi_tenant_app):
+    """Avery stays in the directory even with no pages on disk."""
+    from app import tenants as _tenants
+
+    avery = _tenants.manager().require("avery")
+    for path in avery.wiki_dir.rglob("*.md"):
+        path.unlink()
+    assert _tenants.count_wiki_markdown_pages(avery) == 0
+    assert avery.is_demo is True
+
+    r = multi_tenant_app.get("/tenants")
+    ids = {t["id"] for t in r.json()["tenants"]}
+    assert "avery" in ids
+
+
+def test_tenants_list_does_not_rewrite_visibility_or_warm_indexes(multi_tenant_app):
+    from app import tenants as _tenants
+
+    mgr = _tenants.manager()
+    alice = mgr.require("alice")
+    meta_path = alice.wiki_root / "tenant.json"
+    before = meta_path.read_text(encoding="utf-8")
+    for tenant in mgr.all_tenants():
+        tenant.invalidate_index()
+
+    r = multi_tenant_app.get("/tenants")
+    assert r.status_code == 200
+    assert meta_path.read_text(encoding="utf-8") == before
+    assert json.loads(before)["visibility"] == "public"
+    assert mgr.indexed_tenant_ids() == []
+
+
 def test_owner_sets_tenant_visibility(multi_tenant_app):
     _set_session_user(multi_tenant_app, "alice", login="alice")
     r = multi_tenant_app.post(

--- a/backend/tests/test_onboarding_first_wiki.py
+++ b/backend/tests/test_onboarding_first_wiki.py
@@ -1,0 +1,204 @@
+"""FIRST WIKI, NOT FIRST LOGIN.
+
+A 0-page tenant after a successful connect-repo is a failed signup.
+These tests lock the deterministic private starter seeder and the
+connect-repo success-path hook that calls it.
+
+Invariants:
+  * Empty wiki after connect → purpose + how-to-ingest, tier=private,
+    valid frontmatter, manifest page_count >= 1.
+  * Existing pages (bootstrap imported a real wiki) → do nothing.
+  * Never clone Avery's 29-page demo.
+  * Never overwrite a page that already exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import frontmatter
+import pytest
+
+from app.onboarding_seed import (
+    STARTER_PAGES,
+    count_wiki_pages,
+    seed_starter_wiki,
+)
+from app.tenants import Tenant
+from tests.test_hosted_multitenant import (  # noqa: F401 — fixture + helpers
+    _set_session_user,
+    _stub_github_create_repo,
+    _stub_persistence_git,
+    multi_tenant_app,
+)
+
+
+AVERY_DEMO_SLUGS = {
+    "avery-chen",
+    "strand-bio",
+    "linh-park",
+    "mia-patel",
+    "hannah-wu",
+    "theo-nakamura",
+    "benchling",
+    "boring-stack-first",
+    "working-memory",
+}
+
+
+def _empty_tenant(tmp_path: Path, tenant_id: str = "carol") -> Tenant:
+    root = tmp_path / tenant_id
+    (root / "wiki").mkdir(parents=True)
+    (root / "raw").mkdir(parents=True)
+    return Tenant(id=tenant_id, wiki_root=root, display_name=tenant_id.title())
+
+
+def test_seed_writes_purpose_and_how_to_ingest(tmp_path: Path) -> None:
+    tenant = _empty_tenant(tmp_path)
+    result = seed_starter_wiki(tenant)
+
+    assert result["action"] == "seeded"
+    assert result["page_count"] >= 1
+    assert sorted(result["pages"]) == ["how-to-ingest.md", "purpose.md"]
+    assert count_wiki_pages(tenant) == 2
+
+    slugs = {p.stem for p in tenant.wiki_dir.rglob("*.md")}
+    assert slugs == {"purpose", "how-to-ingest"}
+    assert slugs.isdisjoint(AVERY_DEMO_SLUGS)
+    assert len(list(tenant.wiki_dir.rglob("*.md"))) != 29
+
+
+def test_seed_pages_are_private_with_valid_frontmatter(tmp_path: Path) -> None:
+    tenant = _empty_tenant(tmp_path)
+    seed_starter_wiki(tenant)
+
+    for filename, title, _body in STARTER_PAGES:
+        path = tenant.wiki_dir / filename
+        post = frontmatter.load(path)
+        assert post.metadata["title"] == title
+        assert post.metadata["tier"] == "private"
+        assert post.metadata["type"] == "overview"
+        assert post.content.strip()
+
+
+def test_seed_skips_when_wiki_already_has_pages(tmp_path: Path) -> None:
+    tenant = _empty_tenant(tmp_path)
+    existing = tenant.wiki_dir / "index.md"
+    existing.write_text(
+        "---\ntitle: Existing\ntier: public\n---\n# Existing\n",
+        encoding="utf-8",
+    )
+
+    result = seed_starter_wiki(tenant)
+
+    assert result["action"] == "skipped"
+    assert result["reason"] == "existing_pages"
+    assert result["page_count"] == 1
+    assert not (tenant.wiki_dir / "purpose.md").exists()
+    assert existing.read_text(encoding="utf-8").startswith("---\ntitle: Existing")
+
+
+def test_seed_does_not_overwrite_existing_starter_filenames(tmp_path: Path) -> None:
+    tenant = _empty_tenant(tmp_path)
+    first = seed_starter_wiki(tenant)
+    assert first["action"] == "seeded"
+    purpose = tenant.wiki_dir / "purpose.md"
+    original = purpose.read_text(encoding="utf-8")
+    purpose.write_text(original + "\n<!-- user edit -->\n", encoding="utf-8")
+
+    second = seed_starter_wiki(tenant)
+    assert second["action"] == "skipped"
+    assert "<!-- user edit -->" in purpose.read_text(encoding="utf-8")
+
+
+def test_seed_is_idempotent_on_seeded_wiki(tmp_path: Path) -> None:
+    tenant = _empty_tenant(tmp_path)
+    seed_starter_wiki(tenant)
+    again = seed_starter_wiki(tenant)
+    assert again["action"] == "skipped"
+    assert again["page_count"] == 2
+
+
+def _clear_alice_pages() -> None:
+    from app import tenants
+
+    alice = tenants.manager().require("alice")
+    if alice.wiki_dir.exists():
+        for path in alice.wiki_dir.rglob("*.md"):
+            path.unlink()
+    alice.invalidate_index()
+
+
+def test_connect_repo_seeds_empty_tenant(
+    multi_tenant_app, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: connect a new empty repo → starter pages land and
+    the owner-visible manifest reports page_count >= 1."""
+    from app import tenants
+
+    _clear_alice_pages()
+    alice = tenants.manager().require("alice")
+    alice.gh_token = "ghp_fake_for_test"
+    alice.gh_login = "alice"
+    tenants.manager().upsert(alice)
+
+    _set_session_user(multi_tenant_app, "alice", login="alice")
+    _stub_github_create_repo(monkeypatch)
+    _stub_persistence_git(monkeypatch, [])
+
+    r = multi_tenant_app.post(
+        "/onboarding/connect-repo",
+        json={"create_new": True, "name": "my-portable-llm-wiki", "private": True},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["connected"] is True
+    assert body["starter_seed"]["action"] == "seeded"
+    assert body["starter_seed"]["page_count"] >= 1
+
+    refreshed = tenants.manager().require("alice")
+    slugs = {p.stem for p in refreshed.wiki_dir.rglob("*.md")}
+    assert "purpose" in slugs
+    assert "how-to-ingest" in slugs
+    assert slugs.isdisjoint(AVERY_DEMO_SLUGS)
+
+    manifest = multi_tenant_app.get("/t/alice/wiki/manifest.json")
+    assert manifest.status_code == 200, manifest.text
+    assert manifest.json()["page_count"] >= 1
+    tiers = {p["tier"] for p in manifest.json()["pages"]}
+    assert tiers == {"private"}
+
+
+def test_connect_repo_skips_seed_when_bootstrap_imported_pages(
+    multi_tenant_app, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Alice's fixture wiki already has index.md. Connect must not
+    overwrite it or drop Avery-sized content on top."""
+    from app import tenants
+
+    alice = tenants.manager().require("alice")
+    original = (alice.wiki_dir / "index.md").read_text(encoding="utf-8")
+    alice.gh_token = "ghp_fake_for_test"
+    alice.gh_login = "alice"
+    tenants.manager().upsert(alice)
+
+    _set_session_user(multi_tenant_app, "alice", login="alice")
+    _stub_github_create_repo(monkeypatch)
+    _stub_persistence_git(monkeypatch, [])
+
+    r = multi_tenant_app.post(
+        "/onboarding/connect-repo",
+        json={"create_new": True, "name": "my-portable-llm-wiki", "private": True},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["starter_seed"]["action"] == "skipped"
+    assert body["starter_seed"]["reason"] == "existing_pages"
+
+    refreshed = tenants.manager().require("alice")
+    assert (refreshed.wiki_dir / "index.md").read_text(encoding="utf-8") == original
+    assert not (refreshed.wiki_dir / "purpose.md").exists()
+    assert not (refreshed.wiki_dir / "entities" / "avery-chen.md").exists()
+    assert count_wiki_pages(refreshed) == 1

--- a/frontend/app/welcome/page.tsx
+++ b/frontend/app/welcome/page.tsx
@@ -318,6 +318,11 @@ export default function WelcomePage() {
   // bouncer by default. If they click "Import anyway" we flip this to
   // true and render the import wizard with force_overwrite enabled.
   const [forceImport, setForceImport] = useState(false);
+  // After connect-repo seeds a private starter wiki, page_count > 0
+  // but the user has not added a first source yet. Keep them on the
+  // assemble step instead of the AlreadyOnboarded bouncer (which would
+  // send them to a wiki they have not authored).
+  const [needsFirstSource, setNeedsFirstSource] = useState(false);
 
   const [tab, setTab] = useState<Tab>("assemble");
   // Interview answers, keyed by INTERVIEW_PROMPTS[].id.
@@ -770,7 +775,12 @@ export default function WelcomePage() {
     stepBadge = isFreshSignup
       ? "Step 1 of 2 — Connect GitHub"
       : "One-time upgrade";
-  } else if (pageCount !== null && pageCount > 0 && !forceImport) {
+  } else if (
+    pageCount !== null &&
+    pageCount > 0 &&
+    !forceImport &&
+    !needsFirstSource
+  ) {
     stepBadge = null;
   } else {
     stepBadge = "Step 2 of 2 — Seed your wiki";
@@ -795,17 +805,25 @@ export default function WelcomePage() {
           // a populated repo (e.g. switching to an existing cary-wiki)
           // would leave pageCount stale at 0 and bounce the user into
           // the import wizard instead of the AlreadyOnboarded panel.
-          onConnected={async (status) => {
+          onConnected={async (status, meta) => {
             // Optimistic update first so the connect step disappears
             // immediately — re-fetch lands a moment later with the
             // authoritative counts.
             setSyncStatus(status);
+            if (meta?.keepOnFirstSource) {
+              setNeedsFirstSource(true);
+            }
             try {
-              await fetchAuthMe();
+              const me = await fetchAuthMe();
+              // Seed failed or not yet visible: still empty → stay on
+              // the assemble step instead of an empty tenant home.
+              if ((me?.page_count ?? 0) === 0) {
+                setNeedsFirstSource(true);
+              }
             } catch {
-              // Best-effort. If the re-fetch fails, the user just sees
-              // the form-section default (which is at worst harmless)
-              // and a 30s page refresh recovers the bouncer view.
+              // Best-effort. If the re-fetch fails, keep the user on
+              // the first-source form rather than dumping them home.
+              setNeedsFirstSource(true);
             }
           }}
         />
@@ -828,7 +846,8 @@ export default function WelcomePage() {
     phase.kind === "idle" &&
     pageCount !== null &&
     pageCount > 0 &&
-    !forceImport
+    !forceImport &&
+    !needsFirstSource
   ) {
     return (
       <div className="max-w-3xl mx-auto px-5 py-10 sm:py-14">
@@ -867,6 +886,7 @@ export default function WelcomePage() {
           submitting={phase.kind === "submitting"}
           submitError={submitError}
           forceImport={forceImport}
+          needsFirstSource={needsFirstSource}
         />
       ) : (
         <ProgressSection phase={phase} user={user} />
@@ -924,7 +944,10 @@ function ConnectRepoStep({
 }: {
   user: AuthUser;
   pageCount: number;
-  onConnected: (status: GitHubSyncStatus) => void;
+  onConnected: (
+    status: GitHubSyncStatus,
+    meta?: { keepOnFirstSource?: boolean },
+  ) => void;
 }) {
   type Mode = "create" | "existing";
   const [mode, setMode] = useState<Mode>("create");
@@ -1002,6 +1025,9 @@ function ConnectRepoStep({
       if (!res.connected) {
         throw new Error(res.message || "Connect failed for an unknown reason.");
       }
+      const starter = (
+        res as { starter_seed?: { action?: string } }
+      ).starter_seed;
       onConnected(
         res.status ?? {
           connected: true,
@@ -1012,6 +1038,7 @@ function ConnectRepoStep({
           last_error: res.bootstrap?.error ?? "",
           pushes_made: 0,
         },
+        { keepOnFirstSource: starter?.action === "seeded" },
       );
     } catch (e) {
       setError(e instanceof Error ? e.message : "unknown error");
@@ -1118,8 +1145,11 @@ function ConnectRepoStep({
             )}
             {needsReauth && (
               <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
-                Your GitHub token can&apos;t see private repos. Re-authorize
-                with the <code>repo</code> scope to see them in this list.
+                Your GitHub token can&apos;t see a private wiki. We ask
+                for the <code>repo</code> scope so we can create/push one
+                wiki repo and import yours. Re-authorize to continue. A
+                GitHub App on just that one repo is the narrower path
+                once it is live.
               </div>
             )}
             {reposError && (
@@ -1225,8 +1255,13 @@ function ConnectRepoStep({
               ? "Create repo + connect"
               : "Connect this repo"}
         </button>
-        <span className="text-xs text-ink-muted">
-          Uses the GitHub OAuth token you granted at sign-in. No PAT to paste.
+        <span className="text-xs text-ink-muted leading-relaxed">
+          We ask GitHub for the <code>repo</code> scope so we can create
+          and push one wiki repo on your account, and import a private
+          wiki you already have. We do not need your other repositories.
+          A GitHub App you install on just that one repo is the narrower
+          path; we will switch to it once the App is live. No PAT to
+          paste.
         </span>
       </div>
     </div>
@@ -1680,6 +1715,10 @@ function FormSection(props: {
   // banner so they don't lose the context that they're about to merge
   // into an existing wiki, not start fresh.
   forceImport?: boolean;
+  // Connect just seeded (or left empty) a private starter wiki. Keep
+  // the assemble form as the first-source step instead of bouncing
+  // home.
+  needsFirstSource?: boolean;
 }) {
   const {
     tab,
@@ -1699,6 +1738,7 @@ function FormSection(props: {
     submitting,
     submitError,
     forceImport,
+    needsFirstSource,
   } = props;
 
   return (
@@ -1708,6 +1748,15 @@ function FormSection(props: {
           Merging into your existing wiki. Conflicting slugs will get a{" "}
           <code className="font-mono">-imported</code> suffix.
         </div>
+      )}
+      {needsFirstSource && !forceImport && (
+        <p
+          className="mb-5 text-sm text-ink-muted leading-relaxed"
+          data-testid="first-source-step"
+        >
+          A private starter wiki is already in your repo. Add a first
+          source below so the pages are about you — not an empty shell.
+        </p>
       )}
       <Segmented tab={tab} setTab={setTab} />
 
@@ -2205,12 +2254,13 @@ function WikiImportForm({
       {needsReauth && (
         <div className="mb-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2.5 text-xs text-amber-900 leading-relaxed">
           You signed in with public-repo access only, so we can&apos;t see
-          your private repos.{" "}
+          a private wiki to import. We ask for the <code>repo</code>{" "}
+          scope so we can create/push one wiki repo and import yours.{" "}
           <a href={reauthHref} className="underline font-medium hover:text-amber-950">
             Re-authorize with private-repo access
           </a>{" "}
-          (one click, GitHub will ask for consent) and your private repos
-          will show up here.
+          (GitHub will ask for consent). A GitHub App installed on just
+          that one repo is the narrower path, once it is live.
         </div>
       )}
 

--- a/frontend/tests/welcome.test.tsx
+++ b/frontend/tests/welcome.test.tsx
@@ -289,6 +289,93 @@ describe("WelcomePage step badge + post-connect refetch", () => {
       expect(screen.queryByTestId("welcome-step-badge")).not.toBeInTheDocument();
     });
   });
+
+  it("post-connect of an empty repo stays on the first-source assemble step", async () => {
+    // FIRST WIKI, NOT FIRST LOGIN: connect-repo seeds a private starter
+    // so page_count becomes 2. That must NOT dump the user onto the
+    // AlreadyOnboarded bouncer (or an empty home). They still need to
+    // add a first source.
+    stubAuthMeQueue([
+      authMeBody({ pageCount: 0, connected: false }),
+      authMeBody({
+        pageCount: 2,
+        connected: true,
+        repo: "alice/my-portable-llm-wiki",
+      }),
+    ]);
+
+    mockConnect.mockResolvedValueOnce({
+      ok: true,
+      connected: true,
+      repo: "alice/my-portable-llm-wiki",
+      branch: "main",
+      html_url: "https://github.com/alice/my-portable-llm-wiki",
+      bootstrap: { ok: true, action: "seeded_empty" },
+      starter_seed: {
+        action: "seeded",
+        pages: ["purpose.md", "how-to-ingest.md"],
+        page_count: 2,
+      },
+      status: {
+        connected: true,
+        repo: "alice/my-portable-llm-wiki",
+        branch: "main",
+        html_url: "https://github.com/alice/my-portable-llm-wiki",
+        last_synced_at: 0,
+        last_error: "",
+        pushes_made: 0,
+      },
+    });
+
+    render(<WelcomePage />);
+    await screen.findByTestId("connect-repo-step");
+    fireEvent.click(screen.getByText(/Create repo \+ connect/i));
+
+    await waitFor(() => {
+      expect(mockConnect).toHaveBeenCalled();
+    });
+
+    expect(await screen.findByTestId("assemble-form")).toBeInTheDocument();
+    expect(screen.getByTestId("first-source-step")).toBeInTheDocument();
+    const badge = screen.getByTestId("welcome-step-badge");
+    expect(badge.textContent).toMatch(/Step 2 of 2 — Seed your wiki/);
+    expect(screen.queryByTestId("connect-repo-step")).not.toBeInTheDocument();
+  });
+
+  it("post-connect that is still empty keeps the assemble step (no empty home)", async () => {
+    stubAuthMeQueue([
+      authMeBody({ pageCount: 0, connected: false }),
+      authMeBody({ pageCount: 0, connected: true, repo: "alice/empty-wiki" }),
+    ]);
+
+    mockConnect.mockResolvedValueOnce({
+      ok: true,
+      connected: true,
+      repo: "alice/empty-wiki",
+      branch: "main",
+      html_url: "https://github.com/alice/empty-wiki",
+      bootstrap: { ok: true, action: "seeded_empty" },
+      starter_seed: { action: "error", pages: [], page_count: 0 },
+      status: {
+        connected: true,
+        repo: "alice/empty-wiki",
+        branch: "main",
+        html_url: "https://github.com/alice/empty-wiki",
+        last_synced_at: 0,
+        last_error: "",
+        pushes_made: 0,
+      },
+    });
+
+    render(<WelcomePage />);
+    await screen.findByTestId("connect-repo-step");
+    fireEvent.click(screen.getByText(/Create repo \+ connect/i));
+
+    expect(await screen.findByTestId("assemble-form")).toBeInTheDocument();
+    expect(screen.getByTestId("first-source-step")).toBeInTheDocument();
+    expect(screen.queryByText(/already onboarded/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("connect-repo-step")).not.toBeInTheDocument();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/render.yaml
+++ b/render.yaml
@@ -99,6 +99,18 @@ services:
       - key: HOSTED_OWNER_TENANT_IDS
         sync: false
 
+      # Optional GitHub App (narrower than OAuth ``repo``). Empty keeps
+      # today's OAuth path. Dashboard-only so Blueprint never stomps a
+      # live PEM. See HOSTED_DEPLOYMENT.md section 1b.
+      - key: GITHUB_APP_ID
+        sync: false
+      - key: GITHUB_APP_PRIVATE_KEY
+        sync: false
+      - key: GITHUB_APP_INSTALL_URL
+        sync: false
+      - key: GITHUB_APP_INSTALLATION_ID
+        sync: false
+
       # --- Single-tenant (OSS) vs multi-tenant (hosted) toggle ---
       # PROMPTED at first deploy because the right value depends on
       # what you're building:


### PR DESCRIPTION
## Summary
- Seed a deterministic private starter wiki (purpose + how-to-ingest) after a successful connect-repo when the tenant still has 0 pages. Welcome keeps those users on the assemble / first-source step instead of an empty home.
- Hide 0-page public shells from `GET /tenants`. Avery (`is_demo`) stays listed. `GET /tenants/{id}` is unchanged. No `tenant.json` visibility rewrite.
- Keep live OAuth on `read:user,repo` (do not switch to `public_repo`). New wiki repos stay private by default. Scaffold a GitHub App installation-token path behind env; OAuth is unchanged until the App exists.

## Test plan
- [x] `backend/.venv/bin/python -m pytest tests/test_onboarding_first_wiki.py tests/test_directory_honesty.py tests/test_github_trust.py` plus the new hosted list tests (28 passed)
- [x] Remaining backend suite excluding `test_hosted_multitenant.py` (324 passed)
- [x] Hosted multitenant: 156 passed; 5 pre-existing `asyncio.get_event_loop()` failures on 3.12, not from this change
- [x] `npx vitest run` (199) and `npx tsc --noEmit`
- [ ] After merge to `main`: live `GET /tenants` should drop empty public shells; Avery still listed; existing sessions stay valid