### PR TITLE
fix: keep the knowledge graph responsive on large wikis

### DIFF
--- a/frontend/app/graph/page.tsx
+++ b/frontend/app/graph/page.tsx
@@ -10,6 +10,17 @@ import {
   type GraphNode,
 } from "@/lib/api";
 import { useTenant } from "@/lib/useTenant";
+import {
+  graphLayoutProfile,
+  neighborSlugSet,
+  nodeRadius,
+  paintFocusEdges,
+  pickLabelAnchor,
+  requestGraphRedraw,
+  sparsifyEdges,
+  tryZoomToFit,
+  type LabelRect,
+} from "@/lib/graphView";
 
 // react-force-graph-2d is canvas-based, so it must be loaded client-side
 // only. ``next/dynamic`` returns a ``LoadableComponent`` HOC that does
@@ -71,10 +82,10 @@ export default function GraphPage() {
   const [viewerTier, setViewerTier] = useState<string>("public");
   const [isOwner, setIsOwner] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [hoveredSlug, setHoveredSlug] = useState<string | null>(null);
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const [sectionFilter, setSectionFilter] = useState<string>("");
   const [labelMode, setLabelMode] = useState<LabelMode>("off");
+  const [layoutPhase, setLayoutPhase] = useState<"running" | "settled">("running");
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   // The ForceGraph2D instance exposes d3Force(...) and zoomToFit() — keep a ref.
   // The library's exported type is loose; using `any` here is intentional.
@@ -83,8 +94,16 @@ export default function GraphPage() {
   // Per-frame accumulator for painted label rectangles so collision avoidance
   // can skip labels that would overlap already-painted ones. Reset every frame
   // in onRenderFramePre.
-  const labelRectsRef = useRef<Array<{ x: number; y: number; w: number; h: number }>>([]);
-  const [size, setSize] = useState({ w: 800, h: 600 });
+  const labelRectsRef = useRef<LabelRect[]>([]);
+  // Hover stays off the React render path so moving across 1k+ nodes does not
+  // rebuild canvas callbacks every frame. ForceGraph.refresh() redraws.
+  const hoveredSlugRef = useRef<string | null>(null);
+  const nodesRef = useRef<Array<{ slug?: string; x?: number; y?: number }>>(
+    [],
+  );
+  // null until ResizeObserver reports the real pane — mounting at 800x600 and
+  // then growing the canvas is what parks the cluster in the top-left corner.
+  const [size, setSize] = useState<{ w: number; h: number } | null>(null);
 
   useEffect(() => {
     fetchGraph(tenant)
@@ -104,7 +123,7 @@ export default function GraphPage() {
     if (!wrapperRef.current) return;
     const ro = new ResizeObserver((entries) => {
       const r = entries[0]?.contentRect;
-      if (!r) return;
+      if (!r || r.width < 8 || r.height < 8) return;
       setSize({ w: r.width, h: Math.max(500, r.height) });
     });
     ro.observe(wrapperRef.current);
@@ -124,28 +143,58 @@ export default function GraphPage() {
     };
   }, [graph, sectionFilter]);
 
+  const profile = useMemo(
+    () =>
+      graphLayoutProfile(
+        filtered?.nodes.length ?? 0,
+        filtered?.edges.length ?? 0,
+      ),
+    [filtered?.nodes.length, filtered?.edges.length],
+  );
+
+  const layoutEdges = useMemo(() => {
+    if (!filtered) return [];
+    return sparsifyEdges(filtered.nodes, filtered.edges, profile.maxLayoutEdges);
+  }, [filtered, profile.maxLayoutEdges]);
+
   const data = useMemo(() => {
     if (!filtered) return { nodes: [], links: [] };
     return {
-      nodes: filtered.nodes.map((n) => ({ ...n, id: n.slug })),
-      links: filtered.edges.map((e) => ({ source: e.source, target: e.target })),
+      nodes: filtered.nodes.map((n) => ({ ...n, id: n.slug })) as Array<
+        GraphNode & { id: string; x?: number; y?: number }
+      >,
+      links: layoutEdges,
     };
-  }, [filtered]);
+  }, [filtered, layoutEdges]);
+  nodesRef.current = data.nodes;
+
+  const graphKey = `${sectionFilter}:${data.nodes.length}:${data.links.length}`;
+  const nodesBySlug = useMemo(() => {
+    const map = new Map<string, { x?: number; y?: number }>();
+    for (const node of data.nodes) map.set(node.slug, node);
+    return map;
+  }, [data.nodes]);
+  const fullEdgesRef = useRef(filtered?.edges ?? []);
+  fullEdgesRef.current = filtered?.edges ?? [];
+
+  useEffect(() => {
+    setLayoutPhase("running");
+  }, [graphKey]);
 
   const selectedNode = useMemo(
     () => filtered?.nodes.find((n) => n.slug === selectedSlug) ?? null,
     [filtered, selectedSlug]
   );
 
-  const selectedNeighbors = useMemo(() => {
-    if (!filtered || !selectedSlug) return [];
-    const set = new Set<string>();
-    for (const e of filtered.edges) {
-      if (e.source === selectedSlug) set.add(e.target);
-      if (e.target === selectedSlug) set.add(e.source);
-    }
-    return filtered.nodes.filter((n) => set.has(n.slug));
+  const selectedNeighborSlugs = useMemo(() => {
+    if (!filtered || !selectedSlug) return new Set<string>();
+    return neighborSlugSet(filtered.edges, selectedSlug);
   }, [filtered, selectedSlug]);
+
+  const selectedNeighbors = useMemo(() => {
+    if (!filtered || selectedNeighborSlugs.size === 0) return [];
+    return filtered.nodes.filter((n) => selectedNeighborSlugs.has(n.slug));
+  }, [filtered, selectedNeighborSlugs]);
 
   const sectionCounts = useMemo(() => {
     if (!graph) return {} as Record<string, number>;
@@ -174,31 +223,44 @@ export default function GraphPage() {
     return set;
   }, [filtered, selectedSlug, selectedNeighbors, labelMode]);
 
-  // Tune the d3-force layout when graph data changes. Defaults are tuned for
-  // sparse graphs; our wiki graph has avg degree ~9, which collapses without
-  // stronger repulsion + a collision force.
+  // Tune the d3-force layout when graph data changes. Small wikis still get
+  // collision; dense graphs skip it (O(n^2)) and do not reheat — reheating
+  // plus a timed zoomToFit was both the jank and the random corner-zoom.
   useEffect(() => {
     if (!fgRef.current || !filtered || filtered.nodes.length === 0) return;
     const fg = fgRef.current;
     const linkF = fg.d3Force("link");
-    if (linkF) linkF.distance(90).strength(0.4);
+    if (linkF) linkF.distance(profile.linkDistance).strength(profile.linkStrength);
     const chargeF = fg.d3Force("charge");
-    if (chargeF) chargeF.strength(-420).distanceMax(600);
-    // Inject a collision force keyed to node radius so nodes don't overlap.
+    if (chargeF) {
+      chargeF.strength(profile.chargeStrength).distanceMax(profile.chargeDistanceMax);
+      if (typeof chargeF.theta === "function") chargeF.theta(profile.chargeTheta);
+    }
+    if (!profile.useCollision) {
+      fg.d3Force("collision", null);
+      return;
+    }
+    let cancelled = false;
     import("d3-force").then(({ forceCollide }) => {
+      if (cancelled || fgRef.current !== fg) return;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       fg.d3Force("collision", forceCollide((d: any) => {
-        const r = 4 + Math.sqrt(d.degree || 1) * 1.6;
-        return r + 14; // generous radius so labels also have room
-      }).strength(0.9));
+        return nodeRadius(d.degree || 1) + 14;
+      }).strength(0.7));
       fg.d3ReheatSimulation();
     });
+    return () => {
+      cancelled = true;
+    };
+  }, [filtered, profile, size]);
 
-    // onEngineStop sometimes doesn't fire when the simulation is rewarmed by
-    // dependencies. Belt-and-suspenders: explicit zoom-to-fit after a delay.
-    const t = setTimeout(() => fgRef.current?.zoomToFit?.(500, 60), 1500);
-    return () => clearTimeout(t);
-  }, [filtered]);
+  useEffect(() => {
+    if (!size || data.nodes.length === 0) return;
+    const t = window.setTimeout(() => {
+      tryZoomToFit(fgRef.current, nodesRef.current, 60);
+    }, 80);
+    return () => window.clearTimeout(t);
+  }, [size?.w, size?.h, data.nodes.length, data.links.length]);
 
   return (
     <div className="max-w-7xl mx-auto px-5 py-6">
@@ -228,6 +290,11 @@ export default function GraphPage() {
                   : "0"}
               </span>
             </span>
+            {layoutEdges.length < graph.edges.length && (
+              <span title="The force layout uses a hub backbone so the animation stays responsive. Select a node to see its real neighborhood.">
+                layout {layoutEdges.length} edges
+              </span>
+            )}
           </div>
         )}
       </div>
@@ -310,18 +377,21 @@ export default function GraphPage() {
             {LABEL_MODE_TEXT[labelMode]}
           </button>
           <button
-            onClick={() => fgRef.current?.zoomToFit?.(500, 80)}
+            onClick={() => tryZoomToFit(fgRef.current, nodesRef.current, 80, 500)}
             className="text-xs px-2 py-1 rounded border border-paper-soft text-ink-muted hover:border-ink hover:text-ink"
             title="Fit graph to view"
           >
-            ⤢ recenter
+            recenter
           </button>
           <button
-            onClick={() => fgRef.current?.d3ReheatSimulation?.()}
+            onClick={() => {
+              setLayoutPhase("running");
+              fgRef.current?.d3ReheatSimulation?.();
+            }}
             className="text-xs px-2 py-1 rounded border border-paper-soft text-ink-muted hover:border-ink hover:text-ink"
             title="Re-run layout simulation"
           >
-            ↻ relax
+            relax
           </button>
         </span>
       </div>
@@ -332,9 +402,11 @@ export default function GraphPage() {
           className="bg-white border border-paper-soft rounded-xl overflow-hidden"
           style={{ height: "78vh", minHeight: 600 }}
         >
-          {data.nodes.length === 0 ? (
+          {!size || data.nodes.length === 0 ? (
             <div className="h-full flex items-center justify-center text-sm text-ink-muted">
-              {graph ? "no pages match the current filter" : "loading…"}
+              {graph && data.nodes.length === 0
+                ? "no pages match the current filter"
+                : "loading…"}
             </div>
           ) : (
             <ForceGraphCanvas
@@ -344,57 +416,50 @@ export default function GraphPage() {
               graphData={data}
               backgroundColor="#fafaf7"
               nodeRelSize={6}
-              cooldownTicks={300}
-              d3AlphaDecay={0.018}
-              d3VelocityDecay={0.35}
-              warmupTicks={80}
+              cooldownTicks={profile.cooldownTicks}
+              cooldownTime={profile.cooldownTime}
+              warmupTicks={profile.warmupTicks}
+              d3AlphaDecay={profile.alphaDecay}
+              d3AlphaMin={profile.alphaMin}
+              d3VelocityDecay={profile.velocityDecay}
+              autoPauseRedraw
+              enablePointerInteraction={layoutPhase === "settled"}
               onEngineStop={() => {
-                fgRef.current?.zoomToFit?.(500, 60);
-                // Reset the per-frame label-rect accumulator so the new
-                // post-settle frame starts clean.
+                setLayoutPhase("settled");
+                tryZoomToFit(fgRef.current, nodesRef.current, 60, 500);
                 labelRectsRef.current = [];
               }}
               onRenderFramePre={() => {
-                // Clear the painted-label rect list at the start of every
-                // render frame so collision detection only considers labels
-                // drawn this frame.
                 labelRectsRef.current = [];
               }}
-              linkColor={(link: unknown) => {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const l = link as any;
-                const sSlug = typeof l.source === "object" ? l.source.slug : l.source;
-                const tSlug = typeof l.target === "object" ? l.target.slug : l.target;
-                if (
-                  selectedSlug &&
-                  (sSlug === selectedSlug || tSlug === selectedSlug)
-                ) {
-                  return "rgba(255,106,0,0.55)";
-                }
-                if (selectedSlug) return "rgba(14,14,16,0.06)";
-                return "rgba(14,14,16,0.12)";
+              onRenderFramePost={(ctx: CanvasRenderingContext2D) => {
+                if (layoutPhase !== "settled") return;
+                const focus = selectedSlug ?? hoveredSlugRef.current;
+                if (!focus) return;
+                paintFocusEdges(ctx, nodesBySlug, fullEdgesRef.current, focus, {
+                  color: selectedSlug
+                    ? "rgba(255,106,0,0.55)"
+                    : "rgba(14,14,16,0.28)",
+                  width: selectedSlug ? 1.6 : 1,
+                });
               }}
-              linkWidth={(link: unknown) => {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const l = link as any;
-                const sSlug = typeof l.source === "object" ? l.source.slug : l.source;
-                const tSlug = typeof l.target === "object" ? l.target.slug : l.target;
-                if (
-                  selectedSlug &&
-                  (sSlug === selectedSlug || tSlug === selectedSlug)
-                ) {
-                  return 1.6;
-                }
-                return 0.6;
-              }}
-              linkDirectionalArrowLength={3}
-              linkDirectionalArrowRelPos={0.92}
+              linkVisibility={() =>
+                layoutPhase === "settled" &&
+                !selectedSlug &&
+                !hoveredSlugRef.current
+              }
+              linkColor={() => "rgba(14,14,16,0.12)"}
+              linkWidth={0.6}
+              linkDirectionalArrowLength={0}
               onNodeHover={(node: unknown) => {
                 const n = node as { slug?: string } | null;
-                setHoveredSlug(n?.slug ?? null);
+                const slug = n?.slug ?? null;
+                if (hoveredSlugRef.current === slug) return;
+                hoveredSlugRef.current = slug;
                 if (wrapperRef.current) {
-                  wrapperRef.current.style.cursor = n ? "pointer" : "default";
+                  wrapperRef.current.style.cursor = slug ? "pointer" : "default";
                 }
+                requestGraphRedraw(fgRef.current);
               }}
               onNodeClick={(node: unknown) => {
                 const n = node as { slug?: string } | null;
@@ -403,13 +468,19 @@ export default function GraphPage() {
               onBackgroundClick={() => setSelectedSlug(null)}
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               nodeCanvasObject={(node: any, ctx: CanvasRenderingContext2D, scale: number) => {
-                const radius = Math.max(4, Math.min(14, 4 + Math.sqrt(node.degree || 1) * 1.6));
-                const isSelected = node.slug === selectedSlug;
-                const isHovered = node.slug === hoveredSlug;
-                const isNeighbor =
-                  !!selectedSlug &&
-                  selectedNeighbors.some((nb) => nb.slug === node.slug);
+                const radius = nodeRadius(node.degree || 1);
                 const fill = SECTION_COLORS[node.section] || SECTION_COLORS.other;
+                if (layoutPhase !== "settled") {
+                  ctx.beginPath();
+                  ctx.arc(node.x, node.y, radius, 0, 2 * Math.PI, false);
+                  ctx.fillStyle = fill;
+                  ctx.fill();
+                  return;
+                }
+
+                const isSelected = node.slug === selectedSlug;
+                const isHovered = node.slug === hoveredSlugRef.current;
+                const isNeighbor = selectedNeighborSlugs.has(node.slug);
                 const ring = TIER_RING[node.tier] || "#999";
 
                 ctx.beginPath();
@@ -428,92 +499,52 @@ export default function GraphPage() {
                   isHovered ||
                   labelSet.has(node.slug) ||
                   (labelMode !== "off" && scale > 1.6);
-                if (shouldLabel) {
-                  const fullTitle = node.title as string;
-                  const label =
-                    isSelected || isHovered || scale > 2 || fullTitle.length <= 26
-                      ? fullTitle
-                      : fullTitle.slice(0, 24) + "…";
-                  const fontSize = Math.max(9, 11 / Math.max(0.6, scale));
-                  ctx.font = `${isSelected || isHovered ? "600 " : ""}${fontSize}px ui-sans-serif`;
-                  const padX = 4 / scale;
-                  const padY = 2 / scale;
-                  const textW = ctx.measureText(label).width;
-                  const textH = fontSize;
-                  const gap = 4 / scale;
+                if (!shouldLabel) return;
 
-                  // Try several anchor positions around the node, in priority
-                  // order: below, above, right, left. Pick the first that
-                  // doesn't overlap an already-painted label this frame.
-                  // Selected/hovered always paints (and dominates everything).
-                  const candidates = [
-                    { x: node.x, y: node.y + radius + gap, ax: "center" as const, ay: "top" as const },
-                    { x: node.x, y: node.y - radius - gap, ax: "center" as const, ay: "bottom" as const },
-                    { x: node.x + radius + gap, y: node.y, ax: "left" as const, ay: "middle" as const },
-                    { x: node.x - radius - gap, y: node.y, ax: "right" as const, ay: "middle" as const },
-                  ];
+                const fullTitle = node.title as string;
+                const label =
+                  isSelected || isHovered || scale > 2 || fullTitle.length <= 26
+                    ? fullTitle
+                    : fullTitle.slice(0, 24) + "…";
+                const fontSize = Math.max(9, 11 / Math.max(0.6, scale));
+                ctx.font = `${isSelected || isHovered ? "600 " : ""}${fontSize}px ui-sans-serif`;
+                const padX = 4 / scale;
+                const padY = 2 / scale;
+                const textW = ctx.measureText(label).width;
+                const gap = 4 / scale;
+                const chosen = pickLabelAnchor(
+                  [
+                    { x: node.x, y: node.y + radius + gap, ax: "center", ay: "top" },
+                    { x: node.x, y: node.y - radius - gap, ax: "center", ay: "bottom" },
+                    { x: node.x + radius + gap, y: node.y, ax: "left", ay: "middle" },
+                    { x: node.x - radius - gap, y: node.y, ax: "right", ay: "middle" },
+                  ],
+                  textW,
+                  fontSize,
+                  padX,
+                  padY,
+                  labelRectsRef.current,
+                  isSelected || isHovered,
+                );
+                if (!chosen) return;
 
-                  function rectFor(c: (typeof candidates)[number]) {
-                    let rx = c.x;
-                    let ry = c.y;
-                    if (c.ax === "center") rx -= textW / 2;
-                    else if (c.ax === "right") rx -= textW;
-                    if (c.ay === "middle") ry -= textH / 2;
-                    else if (c.ay === "bottom") ry -= textH;
-                    return {
-                      x: rx - padX,
-                      y: ry - padY,
-                      w: textW + padX * 2,
-                      h: textH + padY * 2,
-                    };
-                  }
-
-                  function overlaps(
-                    a: { x: number; y: number; w: number; h: number },
-                    b: { x: number; y: number; w: number; h: number }
-                  ) {
-                    return !(
-                      a.x + a.w < b.x ||
-                      b.x + b.w < a.x ||
-                      a.y + a.h < b.y ||
-                      b.y + b.h < a.y
-                    );
-                  }
-
-                  const forced = isSelected || isHovered;
-                  let chosen: { rect: { x: number; y: number; w: number; h: number }; c: (typeof candidates)[number] } | null = null;
-                  for (const c of candidates) {
-                    const r = rectFor(c);
-                    const collision = labelRectsRef.current.some((other) => overlaps(r, other));
-                    if (!collision) {
-                      chosen = { rect: r, c };
-                      break;
-                    }
-                  }
-                  // If everything collides and the label isn't forced (selected/
-                  // hovered), skip drawing it — keeps dense clusters readable.
-                  if (!chosen && forced) {
-                    chosen = { rect: rectFor(candidates[0]), c: candidates[0] };
-                  }
-
-                  if (chosen) {
-                    const { rect, c } = chosen;
-                    ctx.fillStyle = forced
-                      ? "rgba(250,250,247,0.95)"
-                      : "rgba(250,250,247,0.85)";
-                    ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
-                    ctx.fillStyle = forced ? "#0e0e10" : "#525258";
-                    ctx.textAlign = c.ax;
-                    ctx.textBaseline = c.ay;
-                    ctx.fillText(label, c.x, c.y);
-                    labelRectsRef.current.push(rect);
-                  }
-                }
+                const { rect, anchor } = chosen;
+                ctx.fillStyle =
+                  isSelected || isHovered
+                    ? "rgba(250,250,247,0.95)"
+                    : "rgba(250,250,247,0.85)";
+                ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
+                ctx.fillStyle = isSelected || isHovered ? "#0e0e10" : "#525258";
+                ctx.textAlign = anchor.ax;
+                ctx.textBaseline = anchor.ay;
+                ctx.fillText(label, anchor.x, anchor.y);
+                labelRectsRef.current.push(rect);
               }}
               // Increase the painted hit-area so clicks/hovers are forgiving.
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               nodePointerAreaPaint={(node: any, color: string, ctx: CanvasRenderingContext2D) => {
-                const radius = Math.max(8, 6 + Math.sqrt(node.degree || 1) * 1.6);
+                if (layoutPhase !== "settled") return;
+                const radius = Math.max(8, nodeRadius(node.degree || 1) + 2);
                 ctx.fillStyle = color;
                 ctx.beginPath();
                 ctx.arc(node.x, node.y, radius, 0, 2 * Math.PI, false);

--- a/frontend/lib/graphView.ts
+++ b/frontend/lib/graphView.ts
@@ -1,0 +1,388 @@
+/**
+ * Layout, camera, and paint helpers for the knowledge-graph canvas.
+ *
+ * The wiki graph is dense (thousands of nodes, tens of thousands of edges).
+ * react-force-graph-2d will paint and simulate every edge every tick unless
+ * we scale forces and skip work. Camera fits must wait for a measured canvas
+ * and a non-degenerate node bounding box — otherwise zoomToFit locks onto a
+ * few pixels near the origin and the cluster sits in a corner.
+ */
+
+export type GraphEdgeRef = { source: string; target: string };
+
+export type GraphLayoutProfile = {
+  warmupTicks: number;
+  cooldownTicks: number;
+  cooldownTime: number;
+  alphaDecay: number;
+  alphaMin: number;
+  velocityDecay: number;
+  linkDistance: number;
+  linkStrength: number;
+  chargeStrength: number;
+  chargeDistanceMax: number;
+  chargeTheta: number;
+  useCollision: boolean;
+  showArrows: boolean;
+  maxIdleEdges: number;
+  maxLayoutEdges: number;
+};
+
+export type NodeBounds = {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+  width: number;
+  height: number;
+  count: number;
+};
+
+export type TextAnchor = {
+  x: number;
+  y: number;
+  ax: "center" | "left" | "right";
+  ay: "top" | "middle" | "bottom";
+};
+
+export type LabelRect = { x: number; y: number; w: number; h: number };
+
+const HUGE_NODES = 1200;
+const HUGE_EDGES = 12000;
+const LARGE_NODES = 600;
+const LARGE_EDGES = 4000;
+
+export function graphLayoutProfile(
+  nodeCount: number,
+  edgeCount: number,
+): GraphLayoutProfile {
+  const huge = nodeCount >= HUGE_NODES || edgeCount >= HUGE_EDGES;
+  const large = nodeCount >= LARGE_NODES || edgeCount >= LARGE_EDGES;
+
+  // warmupTicks run synchronously before the first paint. On a dense graph
+  // that blocks the main thread, so keep warmup small and make live ticks cheap.
+  if (huge) {
+    return {
+      warmupTicks: 2,
+      cooldownTicks: 28,
+      cooldownTime: 1600,
+      alphaDecay: 0.1,
+      alphaMin: 0.025,
+      velocityDecay: 0.45,
+      linkDistance: 34,
+      linkStrength: 0.16,
+      chargeStrength: -40,
+      chargeDistanceMax: 180,
+      chargeTheta: 1.15,
+      useCollision: false,
+      showArrows: false,
+      maxIdleEdges: 800,
+      maxLayoutEdges: 800,
+    };
+  }
+  if (large) {
+    return {
+      warmupTicks: 8,
+      cooldownTicks: 40,
+      cooldownTime: 2500,
+      alphaDecay: 0.055,
+      alphaMin: 0.018,
+      velocityDecay: 0.4,
+      linkDistance: 48,
+      linkStrength: 0.24,
+      chargeStrength: -90,
+      chargeDistanceMax: 280,
+      chargeTheta: 0.95,
+      useCollision: false,
+      showArrows: false,
+      maxIdleEdges: 1400,
+      maxLayoutEdges: 1400,
+    };
+  }
+  return {
+    warmupTicks: 40,
+    cooldownTicks: 160,
+    cooldownTime: 8000,
+    alphaDecay: 0.022,
+    alphaMin: 0.008,
+    velocityDecay: 0.35,
+    linkDistance: 90,
+    linkStrength: 0.4,
+    chargeStrength: -420,
+    chargeDistanceMax: 600,
+    chargeTheta: 0.81,
+    useCollision: true,
+    showArrows: true,
+    maxIdleEdges: Number.POSITIVE_INFINITY,
+    maxLayoutEdges: Number.POSITIVE_INFINITY,
+  };
+}
+
+export function nodeRadius(degree: number): number {
+  return Math.max(4, Math.min(14, 4 + Math.sqrt(Math.max(degree, 1)) * 1.6));
+}
+
+export function linkEndpointId(end: unknown): string {
+  if (typeof end === "string") return end;
+  if (end && typeof end === "object") {
+    const record = end as { slug?: unknown; id?: unknown };
+    if (typeof record.slug === "string") return record.slug;
+    if (typeof record.id === "string") return record.id;
+  }
+  return "";
+}
+
+/**
+ * Pick a force-engine backbone. Visibility sampling is not enough:
+ * react-force-graph still steps every graphData link each tick. Keep
+ * high-degree structure and cover leftover nodes, then fill to the cap.
+ */
+export function sparsifyEdges(
+  nodes: ReadonlyArray<{ slug: string; degree: number }>,
+  edges: ReadonlyArray<GraphEdgeRef>,
+  maxEdges: number,
+): GraphEdgeRef[] {
+  if (!Number.isFinite(maxEdges) || edges.length <= maxEdges) {
+    return edges.slice();
+  }
+
+  const degree = new Map<string, number>();
+  for (const node of nodes) degree.set(node.slug, node.degree);
+
+  const ranked = edges.map((edge, index) => ({
+    edge,
+    index,
+    key: `${edge.source}\0${edge.target}`,
+    score: (degree.get(edge.source) ?? 0) + (degree.get(edge.target) ?? 0),
+  }));
+  ranked.sort((a, b) => b.score - a.score || a.index - b.index);
+
+  const selected = new Set<string>();
+  const kept: GraphEdgeRef[] = [];
+
+  function take(item: (typeof ranked)[number]): boolean {
+    if (selected.has(item.key)) return false;
+    selected.add(item.key);
+    kept.push(item.edge);
+    return true;
+  }
+
+  const covered = new Set<string>();
+  for (const item of ranked) {
+    if (kept.length >= maxEdges) return kept;
+    if (covered.has(item.edge.source) && covered.has(item.edge.target)) continue;
+    if (take(item)) {
+      covered.add(item.edge.source);
+      covered.add(item.edge.target);
+    }
+  }
+  for (const item of ranked) {
+    if (kept.length >= maxEdges) break;
+    take(item);
+  }
+  return kept;
+}
+
+export function paintFocusEdges(
+  ctx: CanvasRenderingContext2D,
+  nodesBySlug: Map<string, { x?: number; y?: number }>,
+  edges: ReadonlyArray<GraphEdgeRef>,
+  focusSlug: string,
+  style: { color: string; width: number },
+): number {
+  ctx.save();
+  ctx.strokeStyle = style.color;
+  ctx.lineWidth = style.width;
+  ctx.beginPath();
+  let drawn = 0;
+  for (const edge of edges) {
+    if (edge.source !== focusSlug && edge.target !== focusSlug) continue;
+    const from = nodesBySlug.get(edge.source);
+    const to = nodesBySlug.get(edge.target);
+    if (
+      !from ||
+      !to ||
+      typeof from.x !== "number" ||
+      typeof from.y !== "number" ||
+      typeof to.x !== "number" ||
+      typeof to.y !== "number"
+    ) {
+      continue;
+    }
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+    drawn += 1;
+  }
+  ctx.stroke();
+  ctx.restore();
+  return drawn;
+}
+
+export function neighborSlugSet(
+  edges: ReadonlyArray<GraphEdgeRef>,
+  slug: string,
+): Set<string> {
+  const out = new Set<string>();
+  for (const edge of edges) {
+    if (edge.source === slug) out.add(edge.target);
+    if (edge.target === slug) out.add(edge.source);
+  }
+  return out;
+}
+
+export function collectNodeBounds(
+  nodes: ReadonlyArray<{ x?: number; y?: number }>,
+): NodeBounds | null {
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  let count = 0;
+  for (const node of nodes) {
+    const x = node.x;
+    const y = node.y;
+    if (typeof x !== "number" || typeof y !== "number") continue;
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    count += 1;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  }
+  if (count === 0) return null;
+  return {
+    minX,
+    maxX,
+    minY,
+    maxY,
+    width: maxX - minX,
+    height: maxY - minY,
+    count,
+  };
+}
+
+export function boundsAreSpread(bounds: NodeBounds): boolean {
+  if (bounds.count <= 1) return false;
+  if (bounds.count <= 3) return bounds.width + bounds.height > 1;
+  const minSpan = bounds.count < 50 ? 16 : 32;
+  return (
+    Number.isFinite(bounds.width) &&
+    Number.isFinite(bounds.height) &&
+    Math.max(bounds.width, bounds.height) >= minSpan
+  );
+}
+
+export function tryZoomToFit(
+  fg: { zoomToFit?: (ms?: number, px?: number) => void } | null,
+  nodes: ReadonlyArray<{ x?: number; y?: number }>,
+  padding = 60,
+  duration = 400,
+): boolean {
+  if (!fg?.zoomToFit) return false;
+  const bounds = collectNodeBounds(nodes);
+  if (!bounds || !boundsAreSpread(bounds)) return false;
+  fg.zoomToFit(duration, padding);
+  return true;
+}
+
+/**
+ * Force-graph has no public refresh(). Re-applying the current camera
+ * center sets ``needsRedraw`` so a settled canvas paints hover/selection.
+ */
+export function requestGraphRedraw(
+  fg: {
+    centerAt?: {
+      (): { x: number; y: number } | null | undefined;
+      (x: number, y: number): unknown;
+    };
+  } | null,
+): boolean {
+  if (!fg?.centerAt) return false;
+  const center = fg.centerAt();
+  if (!center || !Number.isFinite(center.x) || !Number.isFinite(center.y)) {
+    return false;
+  }
+  fg.centerAt(center.x, center.y);
+  return true;
+}
+
+export function shouldPaintLink(
+  sourceId: string,
+  targetId: string,
+  opts: {
+    edgeCount: number;
+    focusSlug: string | null;
+    maxIdleEdges: number;
+  },
+): boolean {
+  if (!sourceId || !targetId) return false;
+  if (opts.focusSlug) {
+    return sourceId === opts.focusSlug || targetId === opts.focusSlug;
+  }
+  if (opts.edgeCount <= opts.maxIdleEdges) return true;
+  const keep = opts.maxIdleEdges / opts.edgeCount;
+  return hash32(`${sourceId}\0${targetId}`) / 0x1_0000_0000 < keep;
+}
+
+export function rectsOverlap(a: LabelRect, b: LabelRect): boolean {
+  return !(
+    a.x + a.w < b.x ||
+    b.x + b.w < a.x ||
+    a.y + a.h < b.y ||
+    b.y + b.h < a.y
+  );
+}
+
+export function labelBox(
+  anchor: TextAnchor,
+  textW: number,
+  textH: number,
+  padX: number,
+  padY: number,
+): LabelRect {
+  let rx = anchor.x;
+  let ry = anchor.y;
+  if (anchor.ax === "center") rx -= textW / 2;
+  else if (anchor.ax === "right") rx -= textW;
+  if (anchor.ay === "middle") ry -= textH / 2;
+  else if (anchor.ay === "bottom") ry -= textH;
+  return {
+    x: rx - padX,
+    y: ry - padY,
+    w: textW + padX * 2,
+    h: textH + padY * 2,
+  };
+}
+
+export function pickLabelAnchor(
+  candidates: TextAnchor[],
+  textW: number,
+  textH: number,
+  padX: number,
+  padY: number,
+  occupied: ReadonlyArray<LabelRect>,
+  forced: boolean,
+): { anchor: TextAnchor; rect: LabelRect } | null {
+  for (const candidate of candidates) {
+    const rect = labelBox(candidate, textW, textH, padX, padY);
+    if (!occupied.some((other) => rectsOverlap(rect, other))) {
+      return { anchor: candidate, rect };
+    }
+  }
+  if (forced && candidates[0]) {
+    return {
+      anchor: candidates[0],
+      rect: labelBox(candidates[0], textW, textH, padX, padY),
+    };
+  }
+  return null;
+}
+
+function hash32(value: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}

--- a/frontend/tests/graphView.test.ts
+++ b/frontend/tests/graphView.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  boundsAreSpread,
+  collectNodeBounds,
+  graphLayoutProfile,
+  labelBox,
+  linkEndpointId,
+  neighborSlugSet,
+  nodeRadius,
+  pickLabelAnchor,
+  rectsOverlap,
+  shouldPaintLink,
+  paintFocusEdges,
+  requestGraphRedraw,
+  sparsifyEdges,
+  tryZoomToFit,
+} from "@/lib/graphView";
+
+describe("graphLayoutProfile", () => {
+  it("keeps collision and arrows on a small sparse graph", () => {
+    const profile = graphLayoutProfile(40, 80);
+    expect(profile.useCollision).toBe(true);
+    expect(profile.showArrows).toBe(true);
+    expect(profile.maxIdleEdges).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("drops arrows and collision on a dense wiki-scale graph", () => {
+    const profile = graphLayoutProfile(1854, 23739);
+    expect(profile.useCollision).toBe(false);
+    expect(profile.showArrows).toBe(false);
+    expect(profile.maxIdleEdges).toBeLessThan(1200);
+    expect(profile.maxLayoutEdges).toBeLessThanOrEqual(800);
+    expect(profile.warmupTicks).toBeLessThan(8);
+    expect(profile.cooldownTicks).toBeLessThanOrEqual(32);
+    expect(profile.alphaDecay).toBeGreaterThan(0.08);
+    expect(profile.chargeTheta).toBeGreaterThan(1);
+  });
+
+  it("caps idle edges once the graph crosses the large threshold", () => {
+    const profile = graphLayoutProfile(700, 5000);
+    expect(profile.useCollision).toBe(false);
+    expect(profile.showArrows).toBe(false);
+    expect(profile.maxIdleEdges).toBeLessThan(graphLayoutProfile(40, 80).maxIdleEdges);
+    expect(profile.maxLayoutEdges).toBeLessThan(graphLayoutProfile(40, 80).maxLayoutEdges);
+  });
+});
+
+describe("sparsifyEdges", () => {
+  it("returns a copy when the graph is already under the cap", () => {
+    const edges = [{ source: "a", target: "b" }];
+    const kept = sparsifyEdges([{ slug: "a", degree: 1 }, { slug: "b", degree: 1 }], edges, 10);
+    expect(kept).toEqual(edges);
+    expect(kept).not.toBe(edges);
+  });
+
+  it("keeps a hub backbone and stays at the cap on a wiki-scale hairball", () => {
+    const nodes = [
+      { slug: "hub", degree: 50 },
+      { slug: "spoke", degree: 40 },
+      { slug: "leaf", degree: 1 },
+      { slug: "other", degree: 1 },
+    ];
+    const edges = [
+      { source: "leaf", target: "other" },
+      { source: "hub", target: "spoke" },
+      { source: "hub", target: "leaf" },
+    ];
+    expect(sparsifyEdges(nodes, edges, 1)).toEqual([{ source: "hub", target: "spoke" }]);
+    expect(sparsifyEdges(nodes, edges, 2)).toHaveLength(2);
+  });
+
+  it("covers a leftover node before filling with more hub edges", () => {
+    const nodes = [
+      { slug: "h1", degree: 20 },
+      { slug: "h2", degree: 20 },
+      { slug: "h3", degree: 18 },
+      { slug: "leaf", degree: 1 },
+    ];
+    const edges = [
+      { source: "h1", target: "h2" },
+      { source: "h1", target: "h3" },
+      { source: "h2", target: "h3" },
+      { source: "h1", target: "leaf" },
+    ];
+    const kept = sparsifyEdges(nodes, edges, 3);
+    expect(kept).toHaveLength(3);
+    expect(kept.some((edge) => edge.source === "leaf" || edge.target === "leaf")).toBe(true);
+  });
+});
+
+describe("paintFocusEdges", () => {
+  it("strokes only edges incident to the focus node", () => {
+    const ctx = {
+      save: vi.fn(),
+      restore: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      stroke: vi.fn(),
+      strokeStyle: "",
+      lineWidth: 0,
+    };
+    const nodes = new Map([
+      ["hub", { x: 0, y: 0 }],
+      ["a", { x: 10, y: 0 }],
+      ["b", { x: 0, y: 10 }],
+      ["c", { x: 20, y: 20 }],
+    ]);
+    const drawn = paintFocusEdges(
+      ctx as unknown as CanvasRenderingContext2D,
+      nodes,
+      [
+        { source: "hub", target: "a" },
+        { source: "b", target: "hub" },
+        { source: "a", target: "c" },
+      ],
+      "hub",
+      { color: "orange", width: 1.5 },
+    );
+    expect(drawn).toBe(2);
+    expect(ctx.moveTo).toHaveBeenCalledTimes(2);
+    expect(ctx.strokeStyle).toBe("orange");
+  });
+});
+
+describe("collectNodeBounds / boundsAreSpread", () => {
+  it("rejects missing or non-finite coordinates", () => {
+    expect(
+      collectNodeBounds([{ x: Number.NaN, y: 0 }, { x: 1, y: undefined }]),
+    ).toBeNull();
+  });
+
+  it("rejects a collapsed origin cluster so zoomToFit cannot lock a corner", () => {
+    const bounds = collectNodeBounds([
+      { x: 0, y: 0 },
+      { x: 0.4, y: -0.2 },
+      { x: -0.3, y: 0.1 },
+    ]);
+    expect(bounds).not.toBeNull();
+    expect(boundsAreSpread(bounds!)).toBe(false);
+  });
+
+  it("accepts a spread layout", () => {
+    const bounds = collectNodeBounds([
+      { x: -80, y: -40 },
+      { x: 120, y: 90 },
+      { x: 10, y: 15 },
+    ]);
+    expect(boundsAreSpread(bounds!)).toBe(true);
+  });
+});
+
+describe("tryZoomToFit", () => {
+  it("does not call zoomToFit until nodes have a real span", () => {
+    const zoomToFit = vi.fn();
+    const clustered = Array.from({ length: 20 }, () => ({ x: 1, y: 1 }));
+    expect(tryZoomToFit({ zoomToFit }, clustered)).toBe(false);
+    expect(zoomToFit).not.toHaveBeenCalled();
+  });
+
+  it("fits once the bounding box is usable", () => {
+    const zoomToFit = vi.fn();
+    const nodes = [
+      { x: -100, y: -80 },
+      { x: 140, y: 90 },
+    ];
+    expect(tryZoomToFit({ zoomToFit }, nodes, 80, 200)).toBe(true);
+    expect(zoomToFit).toHaveBeenCalledWith(200, 80);
+  });
+
+  it("no-ops when the canvas instance is missing", () => {
+    expect(tryZoomToFit(null, [{ x: 0, y: 0 }, { x: 80, y: 80 }])).toBe(false);
+  });
+});
+
+describe("requestGraphRedraw", () => {
+  it("reapplies the current center so a settled canvas will paint", () => {
+    const centerAt = vi.fn() as ReturnType<typeof vi.fn> & {
+      (): { x: number; y: number };
+    };
+    centerAt.mockReturnValue({ x: 12, y: -4 });
+    expect(requestGraphRedraw({ centerAt })).toBe(true);
+    expect(centerAt).toHaveBeenLastCalledWith(12, -4);
+  });
+
+  it("no-ops without a usable camera", () => {
+    expect(requestGraphRedraw(null)).toBe(false);
+    expect(requestGraphRedraw({ centerAt: () => ({ x: Number.NaN, y: 0 }) })).toBe(
+      false,
+    );
+  });
+});
+
+describe("shouldPaintLink", () => {
+  it("keeps every idle edge on a small graph", () => {
+    expect(
+      shouldPaintLink("a", "b", {
+        edgeCount: 10,
+        focusSlug: null,
+        maxIdleEdges: Number.POSITIVE_INFINITY,
+      }),
+    ).toBe(true);
+  });
+
+  it("when a node is focused, paints only its incident edges", () => {
+    const opts = { edgeCount: 23739, focusSlug: "catalog-residual", maxIdleEdges: 2200 };
+    expect(shouldPaintLink("catalog-residual", "marionette", opts)).toBe(true);
+    expect(shouldPaintLink("other", "unrelated", opts)).toBe(false);
+  });
+
+  it("samples idle edges deterministically under the cap", () => {
+    const opts = { edgeCount: 20000, focusSlug: null, maxIdleEdges: 2000 };
+    const kept = Array.from({ length: 400 }, (_, i) =>
+      shouldPaintLink(`s${i}`, `t${i}`, opts),
+    ).filter(Boolean).length;
+    expect(kept).toBeGreaterThan(10);
+    expect(kept).toBeLessThan(120);
+    expect(shouldPaintLink("s0", "t0", opts)).toBe(shouldPaintLink("s0", "t0", opts));
+  });
+});
+
+describe("link and neighbor helpers", () => {
+  it("reads slugs from either string or object endpoints", () => {
+    expect(linkEndpointId("alpha")).toBe("alpha");
+    expect(linkEndpointId({ slug: "beta", id: "ignored" })).toBe("beta");
+    expect(linkEndpointId({ id: "gamma" })).toBe("gamma");
+    expect(linkEndpointId(null)).toBe("");
+  });
+
+  it("builds an O(1) neighbor set", () => {
+    const neighbors = neighborSlugSet(
+      [
+        { source: "hub", target: "a" },
+        { source: "b", target: "hub" },
+        { source: "c", target: "d" },
+      ],
+      "hub",
+    );
+    expect([...neighbors].sort()).toEqual(["a", "b"]);
+  });
+
+  it("grows node radius with degree but stays capped", () => {
+    expect(nodeRadius(1)).toBeGreaterThanOrEqual(4);
+    expect(nodeRadius(100)).toBeLessThanOrEqual(14);
+    expect(nodeRadius(100)).toBeGreaterThan(nodeRadius(4));
+  });
+});
+
+describe("label collision", () => {
+  it("picks the first non-overlapping anchor and skips the rest when unforced", () => {
+    const occupied = [labelBox({ x: 0, y: 10, ax: "center", ay: "top" }, 40, 10, 2, 1)];
+    const chosen = pickLabelAnchor(
+      [
+        { x: 0, y: 10, ax: "center", ay: "top" },
+        { x: 80, y: 0, ax: "left", ay: "middle" },
+      ],
+      40,
+      10,
+      2,
+      1,
+      occupied,
+      false,
+    );
+    expect(chosen?.anchor.x).toBe(80);
+  });
+
+  it("forces the first anchor when every slot collides", () => {
+    const box = labelBox({ x: 0, y: 0, ax: "center", ay: "top" }, 20, 8, 1, 1);
+    const chosen = pickLabelAnchor(
+      [{ x: 0, y: 0, ax: "center", ay: "top" }],
+      20,
+      8,
+      1,
+      1,
+      [box],
+      true,
+    );
+    expect(chosen?.anchor.x).toBe(0);
+    expect(rectsOverlap(box, chosen!.rect)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Stop the force layout from simulating every wikilink; dense graphs now use a hub backbone so the float stays responsive.
- Fit the camera only after the canvas has a real size and the nodes have actually spread, which was parking the cluster in a corner.
- While the layout is moving, paint dots only; full edges and the selected neighborhood come back after settle.

## Test plan
- [x] `npx vitest run` and `npx tsc --noEmit` in `frontend/`
- [ ] Reload `/graph` on a large wiki: no corner-zoom, short smooth float, `layout N edges` in the stats
- [ ] Select a node and confirm its real neighborhood still draws
- [ ] Recenter / relax still work