### PR TITLE
fix: keep healthz to liveness only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ ordered newest-first.
 
 ## Unreleased
 
+- **Public `/healthz` is liveness-only.** The footer status link and
+  Render/Docker probes no longer return `page_count`, process RSS, or
+  tenant-volume disk bytes. Those are shared-service fingerprints, not
+  per-viewer stats (and `page_count` included private pages). Operators
+  still get them on authenticated `GET /owner/healthz`; hosted tenant
+  owners see only their current wiki's page count, not the platform disk.
 - **Hosted personal-LLM tokens are headless owner credentials.** Private-tier
   tokens minted from Owner → Personal LLM URL (`/<tenant>/llm?t=…`) now
   resolve to `viewer_is_owner=true`, so Cursor/Marionette MCP can
@@ -20,7 +26,7 @@ ordered newest-first.
   calls ``reload_index()`` (which warmed every connected wiki into RAM);
   it ``invalidate_index()``s instead. Per-tenant WikiIndex objects are
   now LRU-capped (`WIKI_INDEX_CACHE_MAX`, default 8; demo tenants pinned).
-  `/healthz` reports `rss_mb` + warm index counts. Hosted blueprint plan
+  Operator `GET /owner/healthz` reports `rss_mb`. Hosted blueprint plan
   bumped Starter → Standard (2 GB) after a 512 MiB OOM on 2026-07-26.
 - **Share-token hit counters no longer block GitHub smart-pull.**
   `resolve()` used to rewrite tracked `.share-tokens.json` on every

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Then start the dev servers:
 
 Open <http://localhost:3000>. Paste the `OWNER_TOKEN` from
 `backend/.env` on the `/owner` page to authenticate. The backend's
-<http://localhost:8000/healthz> should respond with `{"status":"ok",…}`.
+<http://localhost:8000/healthz> should respond with `{"status":"ok"}`.
 
 For the cloud path instead, see [scripts/deploy.md](scripts/deploy.md).
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@
 
 Endpoints (LLM-facing, vendor-neutral):
 
-  GET  /healthz
+  GET  /healthz                   — public liveness ({"status":"ok"})
   GET  /wiki/manifest.json        — list of pages visible to the viewer
   GET  /wiki/page/{slug}          — full page (frontmatter + body + cross-refs)
   GET  /wiki/search?q=...         — keyword search across visible pages
@@ -10,6 +10,7 @@ Endpoints (LLM-facing, vendor-neutral):
 
 Owner-only (requires Authorization: Bearer <OWNER_TOKEN>):
 
+  GET  /owner/healthz             — wiki size; volume/RSS for operators only
   POST /owner/ingest              — drop a new raw/ source into the wiki
   POST /owner/page                — create or update a wiki page
   PATCH /owner/page/{slug}/tier   — change a page's tier
@@ -558,18 +559,33 @@ def _volume_stats() -> dict:
     }
 
 
-@app.get("/healthz")
-def healthz() -> dict:
-    """Public liveness. No tenant identities, wiki_root, or tenant counts."""
+def _owner_health_payload(viewer: Viewer) -> dict:
+    """Current-wiki size is fine for an owner. Volume/RSS describe the
+    whole process (and on hosted, the shared tenant disk) — only the
+    static ``OWNER_TOKEN`` path (label ``owner``) or OSS single-tenant
+    may see those."""
     payload: dict = {
         "status": "ok",
         "page_count": len(index.all_pages()),
     }
-    rss = _rss_mb()
-    if rss is not None:
-        payload["rss_mb"] = rss
-    payload.update(_volume_stats())
+    if settings.single_tenant_mode or viewer.label == "owner":
+        rss = _rss_mb()
+        if rss is not None:
+            payload["rss_mb"] = rss
+        payload.update(_volume_stats())
     return payload
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    """Public liveness for Render/Docker/MCP. No wiki size or disk."""
+    return {"status": "ok"}
+
+
+@app.get("/owner/healthz")
+def owner_healthz(viewer: Viewer = Depends(require_owner)) -> dict:
+    """Authenticated diagnostics. Public ``/healthz`` stays status-only."""
+    return _owner_health_payload(viewer)
 
 
 def _api_base_url() -> str:

--- a/backend/app/tenants.py
+++ b/backend/app/tenants.py
@@ -520,7 +520,7 @@ class TenantManager:
     def indexed_tenant_ids(self) -> list[str]:
         """Ids of tenants that currently hold a warm WikiIndex in RAM.
 
-        Used by ``/healthz`` memory diagnostics. Does not trigger loads.
+        Used by owner health diagnostics. Does not trigger loads.
         """
         if not self._loaded:
             return []

--- a/backend/tests/test_auth_boundaries.py
+++ b/backend/tests/test_auth_boundaries.py
@@ -59,6 +59,8 @@ def test_require_owner_endpoints_reject_public(client):
     # And rejects a wrong bearer
     r = client.post("/owner/reload", headers={"Authorization": "Bearer wrong"})
     assert r.status_code in (401, 403)
+    r = client.get("/owner/healthz")
+    assert r.status_code in (401, 403)
 
 
 def test_preview_as_downgrades_owner(client, owner_headers):

--- a/backend/tests/test_hosted_multitenant.py
+++ b/backend/tests/test_hosted_multitenant.py
@@ -310,21 +310,49 @@ def test_tenants_public_list_excludes_default(multi_tenant_app):
     assert "default" not in ids
 
 
-def test_healthz_reports_tenant_volume(multi_tenant_app):
+def test_healthz_is_public_liveness_only(multi_tenant_app):
     r = multi_tenant_app.get("/healthz")
     assert r.status_code == 200
     data = r.json()
-    assert data["status"] == "ok"
-    assert data["disk_total_bytes"] > 0
-    assert data["disk_free_bytes"] >= 0
-    assert data["disk_used_bytes"] >= 0
+    assert data == {"status": "ok"}
     for leaked in (
+        "page_count",
+        "rss_mb",
+        "disk_total_bytes",
+        "disk_used_bytes",
+        "disk_free_bytes",
         "wiki_root",
         "indexed_tenant_ids",
         "indexed_tenants",
         "tenant_count",
         "tenant_dir_count",
         "preexisting_dir_count",
+    ):
+        assert leaked not in data, leaked
+
+
+def test_owner_healthz_rejects_public(multi_tenant_app):
+    r = multi_tenant_app.get("/owner/healthz")
+    assert r.status_code in (401, 403)
+
+
+def test_owner_healthz_session_owner_sees_page_count_not_volume(multi_tenant_app):
+    """A tenant owner is not the platform operator. Their page count is
+    their wiki; disk/RSS describe the shared Render volume and process."""
+    _set_session_user(multi_tenant_app, "alice", login="alice")
+    r = multi_tenant_app.get("/t/alice/owner/healthz")
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["status"] == "ok"
+    assert isinstance(data.get("page_count"), int)
+    for leaked in (
+        "rss_mb",
+        "disk_total_bytes",
+        "disk_used_bytes",
+        "disk_free_bytes",
+        "wiki_root",
+        "indexed_tenant_ids",
+        "indexed_tenants",
     ):
         assert leaked not in data, leaked
 

--- a/backend/tests/test_query_and_ingest.py
+++ b/backend/tests/test_query_and_ingest.py
@@ -139,8 +139,15 @@ def test_well_known_manifest_is_self_describing(client):
     assert "SPEC.md" in data["spec_url"]
 
 
-def test_healthz_reports_page_count(client):
+def test_healthz_is_public_liveness_only(client):
     r = client.get("/healthz")
+    assert r.status_code == 200
+    data = r.json()
+    assert data == {"status": "ok"}
+
+
+def test_owner_healthz_reports_page_count_and_volume(client, owner_headers):
+    r = client.get("/owner/healthz", headers=owner_headers)
     assert r.status_code == 200
     data = r.json()
     assert data["status"] == "ok"
@@ -151,3 +158,8 @@ def test_healthz_reports_page_count(client):
     assert data["disk_free_bytes"] >= 0
     for leaked in ("wiki_root", "indexed_tenant_ids", "indexed_tenants"):
         assert leaked not in data, leaked
+
+
+def test_owner_healthz_rejects_public(client):
+    r = client.get("/owner/healthz")
+    assert r.status_code in (401, 403)

--- a/scripts/deploy.md
+++ b/scripts/deploy.md
@@ -70,7 +70,7 @@ deploying:
 
 Click **Apply**. Wait ~90 seconds for the build. Render gives you a
 URL like `https://portable-llm-wiki-backend-XXXX.onrender.com`. Hit
-`/healthz` on it — you should see `{"status":"ok",…}`.
+`/healthz` on it — you should see `{"status":"ok"}`.
 
 ### Step 3 — Note your `OWNER_TOKEN`
 


### PR DESCRIPTION
## Summary
- Public `GET /healthz` (footer status, Render/Docker/MCP probes) now returns only `{"status":"ok"}`.
- `page_count`, process RSS, and shared tenant-volume disk bytes were service-wide fingerprints, not per-viewer stats — and `page_count` included private pages on the bound index.
- Authenticated `GET /owner/healthz` keeps current-wiki page count for tenant owners. Volume/RSS stay on the OSS / platform `OWNER_TOKEN` path only.

## Test plan
- [x] `pytest` healthz + owner-auth cases (OSS public/owner, hosted public, hosted session owner)
- [ ] After merge, `curl https://portablellm.wiki/api/backend/healthz` is `{"status":"ok"}` only
- [ ] Render health check still passes (status-only JSON)