### PR TITLE
fix: stop the knowledge graph from zooming itself out

### DIFF
--- a/frontend/app/graph/page.tsx
+++ b/frontend/app/graph/page.tsx
@@ -9,7 +9,24 @@ import {
   type GraphResponse,
   type GraphNode,
 } from "@/lib/api";
+import { fitForceGraphCamera } from "@/lib/graphCamera";
 import { useTenant } from "@/lib/useTenant";
+
+let pinningCamera = false;
+
+function pinDefaultCamera(fg: {
+  zoom?: (k?: number, ms?: number) => unknown;
+  centerAt?: (x?: number, y?: number, ms?: number) => void;
+} | null) {
+  if (!fg?.zoom || !fg.centerAt || pinningCamera) return;
+  pinningCamera = true;
+  try {
+    fg.zoom(1, 0);
+    fg.centerAt(0, 0, 0);
+  } finally {
+    pinningCamera = false;
+  }
+}
 
 // react-force-graph-2d is canvas-based, so it must be loaded client-side
 // only. ``next/dynamic`` returns a ``LoadableComponent`` HOC that does
@@ -84,6 +101,9 @@ export default function GraphPage() {
   // can skip labels that would overlap already-painted ones. Reset every frame
   // in onRenderFramePre.
   const labelRectsRef = useRef<Array<{ x: number; y: number; w: number; h: number }>>([]);
+  // Keep the default k=1 camera until the user hits Recenter. force-graph
+  // otherwise applies `4 / cbrt(n)` after warmup, which is the late zoom-out.
+  const holdInitialCameraRef = useRef(true);
   const [size, setSize] = useState({ w: 800, h: 600 });
 
   useEffect(() => {
@@ -174,6 +194,23 @@ export default function GraphPage() {
     return set;
   }, [filtered, selectedSlug, selectedNeighbors, labelMode]);
 
+  useEffect(() => {
+    if (!filtered?.nodes.length) return;
+    holdInitialCameraRef.current = true;
+    const pin = () => {
+      if (!holdInitialCameraRef.current) return;
+      pinDefaultCamera(fgRef.current);
+    };
+    pin();
+    // Keep k=1 through force-graph's delayed node-count auto-zoom.
+    const id = window.setInterval(pin, 150);
+    const stop = window.setTimeout(() => window.clearInterval(id), 12000);
+    return () => {
+      window.clearInterval(id);
+      window.clearTimeout(stop);
+    };
+  }, [filtered]);
+
   // Tune the d3-force layout when graph data changes. Defaults are tuned for
   // sparse graphs; our wiki graph has avg degree ~9, which collapses without
   // stronger repulsion + a collision force.
@@ -192,12 +229,8 @@ export default function GraphPage() {
         return r + 14; // generous radius so labels also have room
       }).strength(0.9));
       fg.d3ReheatSimulation();
+      pinDefaultCamera(fg);
     });
-
-    // onEngineStop sometimes doesn't fire when the simulation is rewarmed by
-    // dependencies. Belt-and-suspenders: explicit zoom-to-fit after a delay.
-    const t = setTimeout(() => fgRef.current?.zoomToFit?.(500, 60), 1500);
-    return () => clearTimeout(t);
   }, [filtered]);
 
   return (
@@ -310,7 +343,10 @@ export default function GraphPage() {
             {LABEL_MODE_TEXT[labelMode]}
           </button>
           <button
-            onClick={() => fgRef.current?.zoomToFit?.(500, 80)}
+            onClick={() => {
+              holdInitialCameraRef.current = false;
+              fitForceGraphCamera(fgRef.current, 80, 400);
+            }}
             className="text-xs px-2 py-1 rounded border border-paper-soft text-ink-muted hover:border-ink hover:text-ink"
             title="Fit graph to view"
           >
@@ -349,9 +385,9 @@ export default function GraphPage() {
               d3VelocityDecay={0.35}
               warmupTicks={80}
               onEngineStop={() => {
-                fgRef.current?.zoomToFit?.(500, 60);
-                // Reset the per-frame label-rect accumulator so the new
-                // post-settle frame starts clean.
+                if (holdInitialCameraRef.current) {
+                  pinDefaultCamera(fgRef.current);
+                }
                 labelRectsRef.current = [];
               }}
               onRenderFramePre={() => {

--- a/frontend/app/graph/page.tsx
+++ b/frontend/app/graph/page.tsx
@@ -28,6 +28,21 @@ function pinDefaultCamera(fg: {
   }
 }
 
+/** force-graph auto-zoom: 4 / cbrt(n). That is the ~5s snap to a tiny cluster. */
+function undoHeuristicZoom(
+  fg: {
+    zoom?: (k?: number, ms?: number) => unknown;
+    centerAt?: (x?: number, y?: number, ms?: number) => void;
+  } | null,
+  nodeCount: number,
+) {
+  if (!fg?.zoom || nodeCount <= 0) return;
+  const k = fg.zoom();
+  if (typeof k !== "number" || !Number.isFinite(k)) return;
+  if (Math.abs(k - 4 / Math.cbrt(nodeCount)) > 0.05) return;
+  pinDefaultCamera(fg);
+}
+
 // react-force-graph-2d is canvas-based, so it must be loaded client-side
 // only. ``next/dynamic`` returns a ``LoadableComponent`` HOC that does
 // NOT forward refs to the wrapped component — which silently breaks the
@@ -104,6 +119,7 @@ export default function GraphPage() {
   // Keep the default k=1 camera until the user hits Recenter. force-graph
   // otherwise applies `4 / cbrt(n)` after warmup, which is the late zoom-out.
   const holdInitialCameraRef = useRef(true);
+  const nodeCountRef = useRef(0);
   const [size, setSize] = useState({ w: 800, h: 600 });
 
   useEffect(() => {
@@ -194,17 +210,18 @@ export default function GraphPage() {
     return set;
   }, [filtered, selectedSlug, selectedNeighbors, labelMode]);
 
+  nodeCountRef.current = filtered?.nodes.length ?? 0;
+
   useEffect(() => {
     if (!filtered?.nodes.length) return;
     holdInitialCameraRef.current = true;
     const pin = () => {
       if (!holdInitialCameraRef.current) return;
-      pinDefaultCamera(fgRef.current);
+      undoHeuristicZoom(fgRef.current, nodeCountRef.current);
     };
     pin();
-    // Keep k=1 through force-graph's delayed node-count auto-zoom.
-    const id = window.setInterval(pin, 150);
-    const stop = window.setTimeout(() => window.clearInterval(id), 12000);
+    const id = window.setInterval(pin, 100);
+    const stop = window.setTimeout(() => window.clearInterval(id), 20000);
     return () => {
       window.clearInterval(id);
       window.clearTimeout(stop);
@@ -229,7 +246,7 @@ export default function GraphPage() {
         return r + 14; // generous radius so labels also have room
       }).strength(0.9));
       fg.d3ReheatSimulation();
-      pinDefaultCamera(fg);
+      undoHeuristicZoom(fg, filtered.nodes.length);
     });
   }, [filtered]);
 
@@ -386,15 +403,15 @@ export default function GraphPage() {
               warmupTicks={80}
               onEngineStop={() => {
                 if (holdInitialCameraRef.current) {
-                  pinDefaultCamera(fgRef.current);
+                  undoHeuristicZoom(fgRef.current, nodeCountRef.current);
                 }
                 labelRectsRef.current = [];
               }}
               onRenderFramePre={() => {
-                // Clear the painted-label rect list at the start of every
-                // render frame so collision detection only considers labels
-                // drawn this frame.
                 labelRectsRef.current = [];
+                if (holdInitialCameraRef.current) {
+                  undoHeuristicZoom(fgRef.current, nodeCountRef.current);
+                }
               }}
               linkColor={(link: unknown) => {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/lib/graphCamera.ts
+++ b/frontend/lib/graphCamera.ts
@@ -171,6 +171,7 @@ export function undoLibraryAutoZoom(
 ): boolean {
   if (!fg?.zoom) return false;
   const k = fg.zoom();
+  if (typeof k !== "number") return false;
   if (!isLibraryNodeCountZoom(k, nodeCount)) return false;
   return restoreDefaultCamera(fg);
 }

--- a/frontend/lib/graphCamera.ts
+++ b/frontend/lib/graphCamera.ts
@@ -1,0 +1,176 @@
+export type CameraNode = {
+  degree?: number;
+  x?: number;
+  y?: number;
+};
+
+export type NodeBounds = {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+  width: number;
+  height: number;
+  count: number;
+};
+
+export function collectNodeBounds(
+  nodes: ReadonlyArray<{ x?: number; y?: number }>,
+): NodeBounds | null {
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  let count = 0;
+  for (const node of nodes) {
+    if (typeof node.x !== "number" || typeof node.y !== "number") continue;
+    if (!Number.isFinite(node.x) || !Number.isFinite(node.y)) continue;
+    minX = Math.min(minX, node.x);
+    maxX = Math.max(maxX, node.x);
+    minY = Math.min(minY, node.y);
+    maxY = Math.max(maxY, node.y);
+    count += 1;
+  }
+  if (count === 0) return null;
+  return { minX, maxX, minY, maxY, width: maxX - minX, height: maxY - minY, count };
+}
+
+export function boundsAreSpread(bounds: NodeBounds | null): boolean {
+  if (!bounds || bounds.count < 2) return false;
+  return bounds.width > 8 || bounds.height > 8;
+}
+
+function percentile(sorted: number[], q: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.max(
+    0,
+    Math.min(sorted.length - 1, Math.round(q * (sorted.length - 1))),
+  );
+  return sorted[idx];
+}
+
+function bulkFence(sorted: number[]): { lo: number; hi: number } {
+  const p10 = percentile(sorted, 0.1);
+  const p90 = percentile(sorted, 0.9);
+  const span = Math.max(40, p90 - p10);
+  return { lo: p10 - 0.5 * span, hi: p90 + 0.5 * span };
+}
+
+/**
+ * Camera-only: ignore isolates and far-flung outliers when fitting.
+ * Does not move any nodes.
+ */
+export function mainMassNodeFilter(
+  nodes: ReadonlyArray<CameraNode>,
+): (node: CameraNode) => boolean {
+  const connected = nodes.filter((node) => {
+    if ((node.degree ?? 0) <= 0) return false;
+    if (typeof node.x !== "number" || typeof node.y !== "number") return false;
+    return Number.isFinite(node.x) && Number.isFinite(node.y);
+  });
+
+  if (connected.length < 8) {
+    return (node) => (node.degree ?? 0) > 0;
+  }
+
+  const xs = connected.map((node) => node.x as number).sort((a, b) => a - b);
+  const ys = connected.map((node) => node.y as number).sort((a, b) => a - b);
+  const xFence = bulkFence(xs);
+  const yFence = bulkFence(ys);
+
+  return (node) => {
+    if ((node.degree ?? 0) <= 0) return false;
+    if (typeof node.x !== "number" || typeof node.y !== "number") return false;
+    if (!Number.isFinite(node.x) || !Number.isFinite(node.y)) return false;
+    return (
+      node.x >= xFence.lo &&
+      node.x <= xFence.hi &&
+      node.y >= yFence.lo &&
+      node.y <= yFence.hi
+    );
+  };
+}
+
+export function tryZoomToFit(
+  fg: {
+    graphData?: () => { nodes?: CameraNode[] };
+    zoomToFit?: (
+      ms?: number,
+      px?: number,
+      nodeFilter?: (node: CameraNode) => boolean,
+    ) => void;
+  } | null,
+  nodes: ReadonlyArray<CameraNode>,
+  padding = 60,
+  duration = 0,
+): boolean {
+  if (!fg?.zoomToFit) return false;
+  const filter = mainMassNodeFilter(nodes);
+  const included = nodes.filter(filter);
+  if (!boundsAreSpread(collectNodeBounds(included))) return false;
+  fg.zoomToFit(duration, padding, filter);
+  return true;
+}
+
+export function fitForceGraphCamera(
+  fg: {
+    graphData?: () => { nodes?: CameraNode[] };
+    zoomToFit?: (
+      ms?: number,
+      px?: number,
+      nodeFilter?: (node: CameraNode) => boolean,
+    ) => void;
+  } | null,
+  padding = 60,
+  duration = 0,
+): boolean {
+  const nodes = fg?.graphData?.()?.nodes ?? [];
+  return tryZoomToFit(fg, nodes, padding, duration);
+}
+
+/** force-graph's built-in onFinishUpdate heuristic: `4 / cbrt(nodeCount)`. */
+export const LIBRARY_ZOOM2NODES_FACTOR = 4;
+
+export function libraryNodeCountZoom(nodeCount: number): number {
+  if (nodeCount <= 0) return 1;
+  return LIBRARY_ZOOM2NODES_FACTOR / Math.cbrt(nodeCount);
+}
+
+export function isLibraryNodeCountZoom(
+  k: number | null | undefined,
+  nodeCount: number,
+  epsilon = 0.03,
+): boolean {
+  if (typeof k !== "number" || !Number.isFinite(k) || nodeCount <= 0) {
+    return false;
+  }
+  return Math.abs(k - libraryNodeCountZoom(nodeCount)) <= epsilon;
+}
+
+type ZoomableGraph = {
+  zoom?: (k?: number, ms?: number) => number | unknown;
+  centerAt?: (x?: number, y?: number, ms?: number) => void;
+};
+
+export function restoreDefaultCamera(fg: ZoomableGraph | null): boolean {
+  if (!fg || typeof fg.zoom !== "function" || typeof fg.centerAt !== "function") {
+    return false;
+  }
+  fg.zoom(1, 0);
+  fg.centerAt(0, 0, 0);
+  return true;
+}
+
+/**
+ * Undo force-graph's node-count auto-zoom without touching layout.
+ * Returns true when the heuristic zoom was detected and reset.
+ */
+export function undoLibraryAutoZoom(
+  fg: ZoomableGraph | null,
+  nodeCount: number,
+): boolean {
+  if (!fg?.zoom) return false;
+  const k = fg.zoom();
+  if (!isLibraryNodeCountZoom(k, nodeCount)) return false;
+  return restoreDefaultCamera(fg);
+}

--- a/frontend/tests/graphCamera.test.ts
+++ b/frontend/tests/graphCamera.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  collectNodeBounds,
+  fitForceGraphCamera,
+  libraryNodeCountZoom,
+  mainMassNodeFilter,
+  tryZoomToFit,
+  undoLibraryAutoZoom,
+} from "@/lib/graphCamera";
+
+function grid(count: number, degree = 2): Array<{ degree: number; x: number; y: number }> {
+  return Array.from({ length: count }, (_, i) => ({
+    degree,
+    x: (i % 10) * 20,
+    y: Math.floor(i / 10) * 20,
+  }));
+}
+
+describe("mainMassNodeFilter", () => {
+  it("excludes degree-zero nodes without moving anything", () => {
+    const nodes = [
+      ...grid(12),
+      { degree: 0, x: -8000, y: 9000 },
+    ];
+    const snapshot = nodes.map((n) => ({ ...n }));
+    const filter = mainMassNodeFilter(nodes);
+    expect(filter(nodes[nodes.length - 1])).toBe(false);
+    expect(nodes.filter(filter)).toHaveLength(12);
+    expect(nodes).toEqual(snapshot);
+  });
+
+  it("excludes far outliers while keeping the dense cluster", () => {
+    const nodes = [
+      ...grid(20),
+      { degree: 4, x: 12000, y: -11000 },
+    ];
+    const filter = mainMassNodeFilter(nodes);
+    expect(filter(nodes[nodes.length - 1])).toBe(false);
+    expect(nodes.filter(filter).length).toBe(20);
+    const bounds = collectNodeBounds(nodes.filter(filter))!;
+    expect(bounds.width).toBeLessThan(250);
+    expect(bounds.height).toBeLessThan(250);
+  });
+
+  it("keeps elongated cluster arms inside the camera mass", () => {
+    const nodes = [
+      ...grid(20),
+      { degree: 3, x: 200, y: 20 },
+      { degree: 3, x: 20, y: 30 },
+    ];
+    const filter = mainMassNodeFilter(nodes);
+    expect(filter(nodes[nodes.length - 2])).toBe(true);
+    expect(filter(nodes[nodes.length - 1])).toBe(true);
+  });
+});
+
+describe("tryZoomToFit", () => {
+  it("fits the main mass with a zero-duration camera move", () => {
+    const nodes = [
+      ...grid(12),
+      { degree: 0, x: 9000, y: -8000 },
+    ];
+    const zoomToFit = vi.fn();
+    expect(tryZoomToFit({ zoomToFit }, nodes, 60, 0)).toBe(true);
+    expect(zoomToFit).toHaveBeenCalledTimes(1);
+    expect(zoomToFit.mock.calls[0][0]).toBe(0);
+    expect(zoomToFit.mock.calls[0][1]).toBe(60);
+    const filter = zoomToFit.mock.calls[0][2] as (n: (typeof nodes)[number]) => boolean;
+    expect(nodes.filter(filter)).toHaveLength(12);
+    expect(nodes[nodes.length - 1].x).toBe(9000);
+  });
+
+  it("does not zoom until the cluster has a real span", () => {
+    const zoomToFit = vi.fn();
+    expect(tryZoomToFit({ zoomToFit }, [{ x: 0, y: 0 }, { x: 0, y: 0 }])).toBe(
+      false,
+    );
+    expect(zoomToFit).not.toHaveBeenCalled();
+  });
+});
+
+describe("fitForceGraphCamera", () => {
+  it("reads live nodes from graphData and does not mutate them", () => {
+    const nodes = [
+      ...grid(12),
+      { degree: 0, x: 9000, y: -8000 },
+    ];
+    const snapshot = nodes.map((n) => ({ ...n }));
+    const zoomToFit = vi.fn();
+    expect(
+      fitForceGraphCamera({ zoomToFit, graphData: () => ({ nodes }) }, 60, 0),
+    ).toBe(true);
+    expect(zoomToFit).toHaveBeenCalledWith(0, 60, expect.any(Function));
+    expect(nodes).toEqual(snapshot);
+  });
+});
+
+describe("undoLibraryAutoZoom", () => {
+  it("resets force-graph's 4/cbrt(n) heuristic back to the default camera", () => {
+    const nodeCount = 1878;
+    const heuristic = libraryNodeCountZoom(nodeCount);
+    expect(heuristic).toBeCloseTo(4 / Math.cbrt(1878), 8);
+    let k = heuristic;
+    const fg = {
+      zoom: Object.assign(
+        (next?: number) => {
+          if (next === undefined) return k;
+          k = next;
+          return k;
+        },
+        {},
+      ),
+      centerAt: vi.fn(),
+    };
+    expect(undoLibraryAutoZoom(fg, nodeCount)).toBe(true);
+    expect(k).toBe(1);
+    expect(fg.centerAt).toHaveBeenCalledWith(0, 0, 0);
+  });
+
+  it("leaves a non-heuristic camera alone", () => {
+    let k = 1;
+    const fg = {
+      zoom: Object.assign((next?: number) => {
+        if (next === undefined) return k;
+        k = next;
+        return k;
+      }, {}),
+      centerAt: vi.fn(),
+    };
+    expect(undoLibraryAutoZoom(fg, 1878)).toBe(false);
+    expect(k).toBe(1);
+    expect(fg.centerAt).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- The graph starts at a good camera, then ~5s later force-graph applies `4 / cbrt(nodeCount)` and the cluster shrinks into empty canvas.
- Hold the default camera and undo that heuristic on render. Recenter still fits on click. Layout forces are unchanged.

## Test plan
- [ ] Open /graph on production after deploy
- [ ] Confirm on-load framing stays put for 10+ seconds
- [ ] Recenter still works