### PR TITLE
fix: fit the knowledge graph to the canvas

### DIFF
--- a/frontend/app/graph/page.tsx
+++ b/frontend/app/graph/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
 import Link from "next/link";
 import {
   fetchGraph,
@@ -9,38 +9,38 @@ import {
   type GraphResponse,
   type GraphNode,
 } from "@/lib/api";
-import { fitForceGraphCamera } from "@/lib/graphCamera";
+import {
+  captureCamera,
+  fitForceGraphCamera,
+  undoLibraryAutoZoom,
+  type CameraPose,
+} from "@/lib/graphCamera";
 import { useTenant } from "@/lib/useTenant";
 
-let pinningCamera = false;
-
-function pinDefaultCamera(fg: {
-  zoom?: (k?: number, ms?: number) => unknown;
-  centerAt?: (x?: number, y?: number, ms?: number) => void;
-} | null) {
-  if (!fg?.zoom || !fg.centerAt || pinningCamera) return;
-  pinningCamera = true;
-  try {
-    fg.zoom(1, 0);
-    fg.centerAt(0, 0, 0);
-  } finally {
-    pinningCamera = false;
-  }
-}
-
-/** force-graph auto-zoom: 4 / cbrt(n). That is the ~5s snap to a tiny cluster. */
-function undoHeuristicZoom(
+function settleGraphCamera(
   fg: {
-    zoom?: (k?: number, ms?: number) => unknown;
-    centerAt?: (x?: number, y?: number, ms?: number) => void;
+    graphData?: () => { nodes?: { degree?: number; x?: number; y?: number }[] };
+    zoom?: (k?: number, ms?: number) => number | unknown;
+    centerAt?: (x?: number, y?: number, ms?: number) => unknown;
+    zoomToFit?: (
+      ms?: number,
+      px?: number,
+      nodeFilter?: (node: { degree?: number; x?: number; y?: number }) => boolean,
+    ) => void;
   } | null,
-  nodeCount: number,
+  autoFitDoneRef: MutableRefObject<boolean>,
+  fittedPoseRef: MutableRefObject<CameraPose | null>,
 ) {
-  if (!fg?.zoom || nodeCount <= 0) return;
-  const k = fg.zoom();
-  if (typeof k !== "number" || !Number.isFinite(k)) return;
-  if (Math.abs(k - 4 / Math.cbrt(nodeCount)) > 0.05) return;
-  pinDefaultCamera(fg);
+  if (!fg) return;
+  const nodeCount = fg.graphData?.()?.nodes?.length ?? 0;
+  if (autoFitDoneRef.current) {
+    undoLibraryAutoZoom(fg, nodeCount, fittedPoseRef.current);
+    return;
+  }
+  if (fitForceGraphCamera(fg, 40, 0)) {
+    autoFitDoneRef.current = true;
+    fittedPoseRef.current = captureCamera(fg);
+  }
 }
 
 // react-force-graph-2d is canvas-based, so it must be loaded client-side
@@ -116,10 +116,8 @@ export default function GraphPage() {
   // can skip labels that would overlap already-painted ones. Reset every frame
   // in onRenderFramePre.
   const labelRectsRef = useRef<Array<{ x: number; y: number; w: number; h: number }>>([]);
-  // Keep the default k=1 camera until the user hits Recenter. force-graph
-  // otherwise applies `4 / cbrt(n)` after warmup, which is the late zoom-out.
-  const holdInitialCameraRef = useRef(true);
-  const nodeCountRef = useRef(0);
+  const autoFitDoneRef = useRef(false);
+  const fittedPoseRef = useRef<ReturnType<typeof captureCamera>>(null);
   const [size, setSize] = useState({ w: 800, h: 600 });
 
   useEffect(() => {
@@ -210,22 +208,16 @@ export default function GraphPage() {
     return set;
   }, [filtered, selectedSlug, selectedNeighbors, labelMode]);
 
-  nodeCountRef.current = filtered?.nodes.length ?? 0;
-
   useEffect(() => {
+    autoFitDoneRef.current = false;
+    fittedPoseRef.current = null;
     if (!filtered?.nodes.length) return;
-    holdInitialCameraRef.current = true;
-    const pin = () => {
-      if (!holdInitialCameraRef.current) return;
-      undoHeuristicZoom(fgRef.current, nodeCountRef.current);
-    };
-    pin();
-    const id = window.setInterval(pin, 100);
-    const stop = window.setTimeout(() => window.clearInterval(id), 20000);
-    return () => {
-      window.clearInterval(id);
-      window.clearTimeout(stop);
-    };
+    // Engine stop is the real settle; this is only a backup if it never fires.
+    const t = window.setTimeout(
+      () => settleGraphCamera(fgRef.current, autoFitDoneRef, fittedPoseRef),
+      5500,
+    );
+    return () => window.clearTimeout(t);
   }, [filtered]);
 
   // Tune the d3-force layout when graph data changes. Defaults are tuned for
@@ -246,7 +238,6 @@ export default function GraphPage() {
         return r + 14; // generous radius so labels also have room
       }).strength(0.9));
       fg.d3ReheatSimulation();
-      undoHeuristicZoom(fg, filtered.nodes.length);
     });
   }, [filtered]);
 
@@ -361,8 +352,10 @@ export default function GraphPage() {
           </button>
           <button
             onClick={() => {
-              holdInitialCameraRef.current = false;
-              fitForceGraphCamera(fgRef.current, 80, 400);
+              if (fitForceGraphCamera(fgRef.current, 40, 400)) {
+                autoFitDoneRef.current = true;
+                fittedPoseRef.current = captureCamera(fgRef.current);
+              }
             }}
             className="text-xs px-2 py-1 rounded border border-paper-soft text-ink-muted hover:border-ink hover:text-ink"
             title="Fit graph to view"
@@ -402,15 +395,17 @@ export default function GraphPage() {
               d3VelocityDecay={0.35}
               warmupTicks={80}
               onEngineStop={() => {
-                if (holdInitialCameraRef.current) {
-                  undoHeuristicZoom(fgRef.current, nodeCountRef.current);
-                }
+                settleGraphCamera(fgRef.current, autoFitDoneRef, fittedPoseRef);
                 labelRectsRef.current = [];
               }}
               onRenderFramePre={() => {
                 labelRectsRef.current = [];
-                if (holdInitialCameraRef.current) {
-                  undoHeuristicZoom(fgRef.current, nodeCountRef.current);
+                if (autoFitDoneRef.current) {
+                  settleGraphCamera(
+                    fgRef.current,
+                    autoFitDoneRef,
+                    fittedPoseRef,
+                  );
                 }
               }}
               linkColor={(link: unknown) => {

--- a/frontend/lib/graphCamera.ts
+++ b/frontend/lib/graphCamera.ts
@@ -115,6 +115,8 @@ export function tryZoomToFit(
 export function fitForceGraphCamera(
   fg: {
     graphData?: () => { nodes?: CameraNode[] };
+    zoom?: (k?: number, ms?: number) => number | unknown;
+    centerAt?: (x?: number, y?: number, ms?: number) => unknown;
     zoomToFit?: (
       ms?: number,
       px?: number,
@@ -126,6 +128,42 @@ export function fitForceGraphCamera(
 ): boolean {
   const nodes = fg?.graphData?.()?.nodes ?? [];
   return tryZoomToFit(fg, nodes, padding, duration);
+}
+
+export type CameraPose = { k: number; x: number; y: number };
+
+export function captureCamera(
+  fg: {
+    zoom?: (k?: number, ms?: number) => number | unknown;
+    centerAt?: (x?: number, y?: number, ms?: number) => unknown;
+  } | null,
+): CameraPose | null {
+  if (!fg?.zoom || !fg.centerAt) return null;
+  const k = fg.zoom();
+  const center = fg.centerAt();
+  if (typeof k !== "number" || !Number.isFinite(k)) return null;
+  if (
+    !center ||
+    typeof center !== "object" ||
+    typeof (center as { x?: number }).x !== "number" ||
+    typeof (center as { y?: number }).y !== "number"
+  ) {
+    return null;
+  }
+  return { k, x: (center as { x: number }).x, y: (center as { y: number }).y };
+}
+
+export function applyCamera(
+  fg: {
+    zoom?: (k?: number, ms?: number) => number | unknown;
+    centerAt?: (x?: number, y?: number, ms?: number) => unknown;
+  } | null,
+  pose: CameraPose,
+): boolean {
+  if (!fg?.zoom || !fg.centerAt) return false;
+  fg.zoom(pose.k, 0);
+  fg.centerAt(pose.x, pose.y, 0);
+  return true;
 }
 
 /** force-graph's built-in onFinishUpdate heuristic: `4 / cbrt(nodeCount)`. */
@@ -168,10 +206,12 @@ export function restoreDefaultCamera(fg: ZoomableGraph | null): boolean {
 export function undoLibraryAutoZoom(
   fg: ZoomableGraph | null,
   nodeCount: number,
+  restore: CameraPose | null = null,
 ): boolean {
   if (!fg?.zoom) return false;
   const k = fg.zoom();
   if (typeof k !== "number") return false;
   if (!isLibraryNodeCountZoom(k, nodeCount)) return false;
+  if (restore) return applyCamera(fg, restore);
   return restoreDefaultCamera(fg);
 }

--- a/frontend/tests/graphCamera.test.ts
+++ b/frontend/tests/graphCamera.test.ts
@@ -117,18 +117,44 @@ describe("undoLibraryAutoZoom", () => {
     expect(fg.centerAt).toHaveBeenCalledWith(0, 0, 0);
   });
 
-  it("leaves a non-heuristic camera alone", () => {
-    let k = 1;
+  it("restores a saved fitted pose instead of k=1 when one is provided", () => {
+    const nodeCount = 1878;
+    let k = libraryNodeCountZoom(nodeCount);
+    let x = 0;
+    let y = 0;
     const fg = {
-      zoom: Object.assign((next?: number) => {
+      zoom: (next?: number) => {
         if (next === undefined) return k;
         k = next;
         return k;
-      }, {}),
+      },
+      centerAt: (nx?: number, ny?: number) => {
+        if (nx === undefined && ny === undefined) return { x, y };
+        if (nx !== undefined) x = nx;
+        if (ny !== undefined) y = ny;
+        return { x, y };
+      },
+    };
+    expect(
+      undoLibraryAutoZoom(fg, nodeCount, { k: 0.72, x: 12, y: -8 }),
+    ).toBe(true);
+    expect(k).toBe(0.72);
+    expect(x).toBe(12);
+    expect(y).toBe(-8);
+  });
+
+  it("leaves a non-heuristic camera alone", () => {
+    let k = 0.72;
+    const fg = {
+      zoom: (next?: number) => {
+        if (next === undefined) return k;
+        k = next;
+        return k;
+      },
       centerAt: vi.fn(),
     };
-    expect(undoLibraryAutoZoom(fg, 1878)).toBe(false);
-    expect(k).toBe(1);
+    expect(undoLibraryAutoZoom(fg, 1878, { k: 0.72, x: 0, y: 0 })).toBe(false);
+    expect(k).toBe(0.72);
     expect(fg.centerAt).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Default zoom was locked at k=1, so the settled brain was cropped.
- Fit once after layout cooldown, then keep that framing if force-graph tries 4/cbrt(n) again.

## Test plan
- [ ] /graph: after ~5s the full cluster fills the canvas and stays put
- [ ] Recenter still works