### PR TITLE
feat: rank retrieval by selective-forgetting importance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,15 @@
 name: CI
 
-# Runs on every PR + every push to main. Tests must be green before
+# Runs on every PR + every push to main or dev. Tests must be green before
 # anything merges — this is part of how we signal "this OSS project is
-# real, not a weekend prototype."
+# real, not a weekend prototype." Dev is the working branch; main is the
+# production deploy line (Render autoDeploy + Vercel).
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 # Cancel superseded runs to save minutes on rapid push cycles.
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ backend/.lint-swarms.json
 # Wiki runtime state (when WIKI_ROOT points inside the repo, e.g. wiki-demo/)
 **/.share-tokens.json
 **/.share-token-stats.json
+**/.page-access.json
 **/.lint/
 
 # Node

--- a/backend/app/importance.py
+++ b/backend/app/importance.py
@@ -1,0 +1,285 @@
+"""Selective Forgetting-style importance scoring (arXiv 2608.28978).
+
+Paper Experiment 2: recency + frequency + centrality + age, then prune the
+low-importance tail. For this wiki that is RANKING + lint suggestion — never
+silent deletion, never entity-extraction Graph RAG.
+
+Access counts live in a gitignored sidecar next to the tenant wiki root so
+hits never dirty markdown or the tracked worktree.
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from .config import settings
+
+
+RECENCY_WEIGHT = 0.35
+FREQUENCY_WEIGHT = 0.25
+CENTRALITY_WEIGHT = 0.20
+FRESHNESS_WEIGHT = 0.20
+RECENCY_HALF_LIFE_DAYS = 90.0
+FRESHNESS_HALF_LIFE_DAYS = 365.0
+DORMANT_SCORE_MAX = 0.10
+
+_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class AccessRecord:
+    hits: int = 0
+    last_accessed_at: str | None = None
+
+
+@dataclass(frozen=True)
+class ImportanceBreakdown:
+    recency: float
+    frequency: float
+    centrality: float
+    freshness: float
+    score: float
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def exponential_decay(days: float, half_life_days: float) -> float:
+    """exp(-ln(2) * days / half_life). 0 days → 1; one half-life → 0.5."""
+    if days <= 0:
+        return 1.0
+    if half_life_days <= 0:
+        return 0.0
+    return _clamp01(math.exp(-math.log(2.0) * days / half_life_days))
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        dt = None
+        for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y/%m/%d"):
+            try:
+                dt = datetime.strptime(text, fmt)
+                break
+            except ValueError:
+                continue
+        if dt is None:
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _days_since(value: str | None, now: datetime) -> float | None:
+    dt = _parse_timestamp(value)
+    if dt is None:
+        return None
+    return max(0.0, (now - dt).total_seconds() / 86400.0)
+
+
+def _log1p_ratio(value: int, maximum: int) -> float:
+    if maximum <= 0 or value <= 0:
+        return 0.0
+    return _clamp01(math.log1p(value) / math.log1p(maximum))
+
+
+def _as_access_record(value: object) -> AccessRecord:
+    if isinstance(value, AccessRecord):
+        return value
+    if not isinstance(value, Mapping):
+        return AccessRecord()
+    hits_raw = value.get("hits", 0)
+    try:
+        hits = int(hits_raw or 0)
+    except (TypeError, ValueError):
+        hits = 0
+    if hits < 0:
+        hits = 0
+    last = value.get("last_accessed_at")
+    last_s = str(last) if last else None
+    return AccessRecord(hits=hits, last_accessed_at=last_s)
+
+
+def _page_degree(page: Any) -> int:
+    links_in = getattr(page, "links_in", None) or []
+    links_out = getattr(page, "links_out", None) or []
+    return len(links_in) + len(links_out)
+
+
+def score_page(
+    page: Any,
+    access: AccessRecord | Mapping[str, Any] | None = None,
+    *,
+    max_hits: int,
+    max_degree: int,
+    now: datetime | None = None,
+) -> ImportanceBreakdown:
+    """Pure page score. No I/O. Components and total are clamped to [0, 1]."""
+    clock = now or datetime.now(timezone.utc)
+    rec = _as_access_record(access)
+    created = getattr(page, "created", None)
+    updated = getattr(page, "updated", None)
+
+    recency_src = rec.last_accessed_at or updated or created
+    recency_days = _days_since(recency_src, clock)
+    recency = (
+        0.0
+        if recency_days is None
+        else exponential_decay(recency_days, RECENCY_HALF_LIFE_DAYS)
+    )
+
+    frequency = _log1p_ratio(rec.hits, max_hits)
+
+    centrality = _log1p_ratio(_page_degree(page), max_degree)
+
+    freshness_src = updated or created
+    freshness_days = _days_since(freshness_src, clock)
+    freshness = (
+        0.0
+        if freshness_days is None
+        else exponential_decay(freshness_days, FRESHNESS_HALF_LIFE_DAYS)
+    )
+
+    recency = _clamp01(recency)
+    frequency = _clamp01(frequency)
+    centrality = _clamp01(centrality)
+    freshness = _clamp01(freshness)
+    score = _clamp01(
+        RECENCY_WEIGHT * recency
+        + FREQUENCY_WEIGHT * frequency
+        + CENTRALITY_WEIGHT * centrality
+        + FRESHNESS_WEIGHT * freshness
+    )
+    return ImportanceBreakdown(
+        recency=recency,
+        frequency=frequency,
+        centrality=centrality,
+        freshness=freshness,
+        score=score,
+    )
+
+
+def score_pages(
+    pages: Iterable[Any],
+    access_map: Mapping[str, AccessRecord | Mapping[str, Any]] | None = None,
+    now: datetime | None = None,
+) -> dict[str, ImportanceBreakdown]:
+    """Score a corpus. max_hits and max_degree are computed once."""
+    page_list = list(pages)
+    records = access_map or {}
+    clock = now or datetime.now(timezone.utc)
+    max_hits = 0
+    max_degree = 0
+    for page in page_list:
+        rec = _as_access_record(records.get(getattr(page, "slug", "")))
+        if rec.hits > max_hits:
+            max_hits = rec.hits
+        degree = _page_degree(page)
+        if degree > max_degree:
+            max_degree = degree
+    out: dict[str, ImportanceBreakdown] = {}
+    for page in page_list:
+        slug = getattr(page, "slug", "")
+        out[slug] = score_page(
+            page,
+            records.get(slug),
+            max_hits=max_hits,
+            max_degree=max_degree,
+            now=clock,
+        )
+    return out
+
+
+def _access_path() -> Path:
+    return settings.wiki_root / ".page-access.json"
+
+
+def _ensure_sidecar_ignored() -> None:
+    """Append .page-access.json to the wiki-root gitignore if missing.
+
+    Hosted bootstrap also writes this via persistence._ensure_tenant_gitignore.
+    Query-path writes still have to cover existing clones that never re-bootstrap.
+    """
+    try:
+        gi = settings.wiki_root / ".gitignore"
+        existing = gi.read_text(encoding="utf-8") if gi.exists() else ""
+        rules = {line.strip() for line in existing.splitlines()}
+        if ".page-access.json" in rules:
+            return
+        addendum = (
+            ("\n" if existing and not existing.endswith("\n") else "")
+            + "# Page access counters are runtime bookkeeping, not wiki content.\n"
+            + ".page-access.json\n"
+        )
+        gi.write_text(existing + addendum, encoding="utf-8")
+    except OSError:
+        return
+
+
+def _read_raw() -> dict[str, dict]:
+    path = _access_path()
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, dict] = {}
+    for key, val in raw.items():
+        if isinstance(val, dict):
+            out[str(key)] = val
+    return out
+
+
+def _write_raw(data: dict[str, dict]) -> None:
+    path = _access_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def load_access() -> dict[str, AccessRecord]:
+    """Fail-soft read of the access sidecar. Never raises."""
+    try:
+        with _LOCK:
+            raw = _read_raw()
+        return {slug: _as_access_record(val) for slug, val in raw.items()}
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return {}
+
+
+def record_access(slugs: Iterable[str], now: datetime | None = None) -> None:
+    """Increment hits and stamp last_accessed_at. Never raises. Never writes markdown."""
+    try:
+        wanted = [str(s) for s in slugs if s]
+        if not wanted:
+            return
+        stamp = (now or datetime.now(timezone.utc)).isoformat()
+        with _LOCK:
+            raw = _read_raw()
+            for slug in wanted:
+                rec = _as_access_record(raw.get(slug))
+                raw[slug] = {
+                    "hits": rec.hits + 1,
+                    "last_accessed_at": stamp,
+                }
+            _ensure_sidecar_ignored()
+            _write_raw(raw)
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return

--- a/backend/app/lint.py
+++ b/backend/app/lint.py
@@ -1,5 +1,5 @@
 """Wiki lint: surface contradictions, stale claims, orphans, missing pages,
-broken provenance, missing index entries.
+broken provenance, missing index entries, and dormant (low-importance) pages.
 
 The prototype implements deterministic structural checks. Semantic checks
 (contradictions, stale claims that need LLM judgment) are left as a v2.
@@ -10,8 +10,15 @@ import re
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Mapping
 
 from .config import settings
+from .importance import (
+    DORMANT_SCORE_MAX,
+    AccessRecord,
+    load_access,
+    score_pages,
+)
 from .wiki import LinkResolver, Page, _slugify, _strip_date_prefix, index
 
 
@@ -55,6 +62,62 @@ def _stale_pages(pages: list[Page], days: int = 30) -> list[dict]:
             )
     out.sort(key=lambda r: r["age_days"], reverse=True)
     return out
+
+
+_CATALOG_SLUGS = frozenset({"index", "log"})
+_DORMANT_EXCLUDED_SECTIONS = frozenset({"root", "queries"})
+_DORMANT_CAP = 50
+
+
+def _dormant_pages(
+    pages: list[Page],
+    access_map: Mapping[str, AccessRecord | dict] | None = None,
+    now: datetime | None = None,
+    *,
+    min_score: float = DORMANT_SCORE_MAX,
+    limit: int = _DORMANT_CAP,
+) -> list[dict]:
+    """Low-importance tail (paper s_min). Suggestion to review, not a delete list."""
+    records = access_map if access_map is not None else load_access()
+    breakdowns = score_pages(pages, records, now=now)
+    out: list[dict] = []
+    for p in pages:
+        if p.slug in _CATALOG_SLUGS:
+            continue
+        if p.section in _DORMANT_EXCLUDED_SECTIONS:
+            continue
+        if any(t.lower() == "foundational" for t in p.tags):
+            continue
+        breakdown = breakdowns.get(p.slug)
+        if breakdown is None or breakdown.score >= min_score:
+            continue
+        rec = records.get(p.slug)
+        if isinstance(rec, AccessRecord):
+            hits = rec.hits
+            last_accessed = rec.last_accessed_at
+        elif isinstance(rec, dict):
+            try:
+                hits = int(rec.get("hits") or 0)
+            except (TypeError, ValueError):
+                hits = 0
+            last_accessed = rec.get("last_accessed_at")
+        else:
+            hits = 0
+            last_accessed = None
+        out.append(
+            {
+                "slug": p.slug,
+                "title": p.title,
+                "section": p.section,
+                "score": round(breakdown.score, 3),
+                "hits": hits,
+                "degree": len(p.links_in) + len(p.links_out),
+                "last_accessed_at": last_accessed,
+                "last_dated": p.updated or p.created,
+            }
+        )
+    out.sort(key=lambda r: r["score"])
+    return out[:limit]
 
 
 _WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
@@ -144,5 +207,6 @@ def lint_wiki() -> dict:
         "missing_pages": _missing_pages(pages),
         "broken_provenance": _broken_provenance(pages),
         "missing_index_entries": _missing_index_entries(pages),
+        "dormant": _dormant_pages(pages),
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }

--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -44,6 +44,7 @@ from typing import AsyncIterator, Awaitable, Callable, Iterable
 import httpx
 
 from .config import settings
+from .importance import load_access, record_access, score_pages
 from .wiki import Page, index
 
 logger = logging.getLogger(__name__)
@@ -244,7 +245,7 @@ def _select_context_pages(
     question: str,
     viewer_tier: str,
     max_anchors: int = 3,
-    hops: int = 1,
+    hops: int = 2,
     max_total: int = MAX_CONTEXT_PAGES,
 ) -> tuple[list[Page], dict]:
     """Graph-aware retrieval.
@@ -253,10 +254,14 @@ def _select_context_pages(
       1. Keyword-score visible pages → take top `max_anchors` as ANCHORS,
          skipping catalog hubs (index, log).
       2. Expand each anchor `hops` steps along wikilinks (in/out) → SUBGRAPH,
-         still skipping catalog hubs.
-      3. If subgraph is thin (<3 pages), backfill with foundational pages
+         still skipping catalog hubs. Default hops=2 (1-hop is too shallow;
+         3+ explodes through hubs).
+      3. Rank non-anchor expanded slugs by importance.score descending and
+         keep only the remaining context slots.
+      4. If chosen is still thin (<3 pages), backfill with foundational pages
          (tagged 'foundational' or in projects/overview).
-      4. Hard-cap at `max_total` pages so we don't blow the LLM context.
+      5. Hard-cap at `max_total` pages so we don't blow the LLM context.
+      6. Record access on the chosen slugs (fail-soft sidecar).
 
     Returns (pages_in_order, retrieval_debug_dict). Anchors come first.
     """
@@ -286,6 +291,14 @@ def _select_context_pages(
         subgraph = {"nodes": [], "edges": [], "anchors": []}
         expanded_slugs = []
 
+    breakdowns = score_pages(index.visible_pages(viewer_tier), load_access())
+    remaining_slots = max(0, max_total - len(anchor_slugs))
+    expanded_slugs.sort(
+        key=lambda s: breakdowns[s].score if s in breakdowns else 0.0,
+        reverse=True,
+    )
+    expanded_slugs = expanded_slugs[:remaining_slots]
+
     ordered_slugs: list[str] = anchor_slugs + expanded_slugs
 
     if len(ordered_slugs) < 3:
@@ -307,6 +320,8 @@ def _select_context_pages(
         p = index.get(s)
         if p is not None:
             chosen.append(p)
+
+    record_access(p.slug for p in chosen)
 
     subgraph_slugs = {n["slug"] for n in subgraph.get("nodes", [])}
     omitted_catalog: list[dict] = []
@@ -339,6 +354,16 @@ def _select_context_pages(
         "omitted_catalog": omitted_catalog,
         "total_pages_in_context": len(chosen),
         "edge_count": len(subgraph.get("edges", [])),
+        "importance": [
+            {
+                "slug": p.slug,
+                "score": round(
+                    breakdowns[p.slug].score if p.slug in breakdowns else 0.0,
+                    3,
+                ),
+            }
+            for p in chosen
+        ],
     }
     return chosen, retrieval_debug
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,7 @@ from .capture import (
     capture_paste,
 )
 from .config import VALID_TIERS, settings
+from .importance import record_access
 from .lint import lint_wiki
 from .llm import run_query
 from .orchestrator import (
@@ -638,6 +639,7 @@ def manifest(viewer: Viewer = Depends(current_viewer)) -> ManifestResponse:
 def get_page(slug: str, viewer: Viewer = Depends(current_viewer)) -> dict:
     _refresh()
     page = _page_or_404(slug, viewer)
+    record_access((page.slug,))
     rendered_body = render_page_html_safe(page.body)
     base = _api_base_url()
     return {

--- a/backend/app/persistence.py
+++ b/backend/app/persistence.py
@@ -757,7 +757,11 @@ def _ensure_tenant_gitignore(root: Path) -> None:
     gi = root / ".gitignore"
     existing = gi.read_text(encoding="utf-8") if gi.exists() else ""
     existing_rules = {line.strip() for line in existing.splitlines()}
-    required_rules = ("tenant.json", ".share-token-stats.json")
+    required_rules = (
+        "tenant.json",
+        ".share-token-stats.json",
+        ".page-access.json",
+    )
     missing_rules = [rule for rule in required_rules if rule not in existing_rules]
     if not missing_rules:
         return
@@ -777,6 +781,13 @@ def _ensure_tenant_gitignore(root: Path) -> None:
             [
                 "# Share-token hit counters are runtime bookkeeping, not wiki content.",
                 ".share-token-stats.json",
+            ]
+        )
+    if ".page-access.json" in missing_rules:
+        addendum_lines.extend(
+            [
+                "# Page access counters are runtime bookkeeping, not wiki content.",
+                ".page-access.json",
             ]
         )
     addendum = (
@@ -1183,8 +1194,11 @@ def _split_porcelain_dirt(cwd: Path) -> tuple[list[str], list[str]]:
 # Paths whose only meaningful dirt is share-token hit bookkeeping.
 # ``.share-token-stats.json`` is gitignored in normal setups; included
 # so a mis-tracked sidecar never alone blocks a fast-forward.
+_RUNTIME_SIDECAR_PATHS = frozenset(
+    {".share-token-stats.json", ".page-access.json"}
+)
 _SHARE_TOKEN_BOOKKEEPING_PATHS = frozenset(
-    {".share-tokens.json", ".share-token-stats.json"}
+    {".share-tokens.json"} | _RUNTIME_SIDECAR_PATHS
 )
 
 
@@ -1262,7 +1276,7 @@ def _is_share_tokens_hits_only_dirt(cwd: Path, tracked_paths: list[str]) -> bool
     if not normalized or not normalized.issubset(_SHARE_TOKEN_BOOKKEEPING_PATHS):
         return False
     # Sidecar-only dirt (if somehow tracked) is always bookkeeping.
-    if normalized == {".share-token-stats.json"}:
+    if normalized.issubset(_RUNTIME_SIDECAR_PATHS):
         return True
     if ".share-tokens.json" not in normalized:
         return False

--- a/backend/app/wiki.py
+++ b/backend/app/wiki.py
@@ -20,6 +20,7 @@ from typing import Iterable
 import frontmatter
 
 from .config import TIER_ORDER, VALID_TIERS, settings
+from .importance import load_access, score_pages
 
 # How long a freshness verdict is trusted before we re-walk the corpus.
 # Under load, ``reload_if_stale`` would otherwise rglob+stat every markdown
@@ -451,7 +452,18 @@ class WikiIndex:
                 score += min(count, 5) * 1.0
             if score > 0:
                 results.append((page, score))
-        results.sort(key=lambda r: r[1], reverse=True)
+        if not results:
+            return []
+        # Keyword term weights stay primary. Importance is a secondary key
+        # among pages that already matched — it must not swamp the query.
+        breakdowns = score_pages((p for p, _ in results), load_access())
+        results.sort(
+            key=lambda r: (
+                r[1],
+                breakdowns[r[0].slug].score if r[0].slug in breakdowns else 0.0,
+            ),
+            reverse=True,
+        )
         return results[:limit]
 
     # ---------- internals ----------

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -238,3 +238,17 @@ def _reset_share_tokens(wiki_root: Path):
     for path in (store, stats):
         if path.exists():
             path.unlink()
+
+
+@pytest.fixture(autouse=True)
+def _reset_page_access(wiki_root: Path):
+    """Each test starts with a clean page-access sidecar."""
+    path = wiki_root / ".page-access.json"
+    tmp = wiki_root / ".page-access.json.tmp"
+    for candidate in (path, tmp):
+        if candidate.exists():
+            candidate.unlink()
+    yield
+    for candidate in (path, tmp):
+        if candidate.exists():
+            candidate.unlink()

--- a/backend/tests/test_importance.py
+++ b/backend/tests/test_importance.py
@@ -1,0 +1,228 @@
+"""Hermetic tests for Selective Forgetting-style importance scoring."""
+from __future__ import annotations
+
+import json
+import math
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from app import importance, lint
+from app.importance import (
+    AccessRecord,
+    exponential_decay,
+    load_access,
+    record_access,
+    score_page,
+    score_pages,
+)
+from app.wiki import Page
+
+
+NOW = datetime(2026, 9, 2, tzinfo=timezone.utc)
+
+
+def _ns(
+    slug: str,
+    *,
+    created: str | None = None,
+    updated: str | None = None,
+    links_in: list[str] | None = None,
+    links_out: list[str] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        slug=slug,
+        created=created,
+        updated=updated,
+        links_in=links_in or [],
+        links_out=links_out or [],
+    )
+
+
+def _pg(
+    slug: str,
+    title: str,
+    *,
+    section: str = "entities",
+    created: str | None = "2018-01-01",
+    updated: str | None = "2018-01-01",
+    tags: list[str] | None = None,
+    links_in: list[str] | None = None,
+    links_out: list[str] | None = None,
+) -> Page:
+    return Page(
+        slug=slug,
+        title=title,
+        rel_path=f"wiki/{section}/{slug}.md",
+        section=section,
+        page_type="entity",
+        tier="public",
+        created=created,
+        updated=updated,
+        sources=[],
+        tags=tags or [],
+        body="",
+        excerpt="",
+        links_in=links_in or [],
+        links_out=links_out or [],
+    )
+
+
+def test_exponential_decay_zero_one_half_life_and_huge():
+    assert exponential_decay(0, 90) == 1.0
+    assert exponential_decay(90, 90) == 0.5
+    assert exponential_decay(1e9, 90) < 1e-12
+
+
+def test_missing_timestamps_zero_recency_and_freshness():
+    page = _ns("bare")
+    breakdown = score_page(page, None, max_hits=0, max_degree=0, now=NOW)
+    assert breakdown.recency == 0.0
+    assert breakdown.freshness == 0.0
+
+
+def test_frequency_zero_hits_and_sole_max():
+    cold = _ns("cold")
+    hot = _ns("hot")
+    scores = score_pages(
+        [cold, hot],
+        {"hot": AccessRecord(hits=7), "cold": AccessRecord(hits=0)},
+        now=NOW,
+    )
+    assert scores["cold"].frequency == 0.0
+    assert scores["hot"].frequency == 1.0
+
+
+def test_centrality_isolated_and_max_degree():
+    isolated = _ns("iso")
+    hub = _ns("hub", links_in=["a"], links_out=["b", "c"])
+    scores = score_pages([isolated, hub], {}, now=NOW)
+    assert scores["iso"].centrality == 0.0
+    assert scores["hub"].centrality == 1.0
+
+
+def test_paper_weights_centrality_cannot_outrank_recency_frequency():
+    central_only = _ns("hub", links_in=["a", "b", "c"], links_out=["d", "e"])
+    recent_frequent = _ns("hot")
+    scores = score_pages(
+        [central_only, recent_frequent],
+        {
+            "hot": AccessRecord(
+                hits=10, last_accessed_at="2026-09-02T00:00:00+00:00"
+            )
+        },
+        now=NOW,
+    )
+    assert scores["hub"].centrality == 1.0
+    assert scores["hot"].recency == 1.0
+    assert scores["hot"].frequency == 1.0
+    assert scores["hot"].score > scores["hub"].score
+    assert math.isclose(scores["hub"].score, 0.20)
+    assert math.isclose(scores["hot"].score, 0.60)
+
+
+def test_last_write_wins_newer_updated_scores_higher():
+    older = _ns(
+        "old",
+        created="2020-01-01",
+        updated="2020-01-01",
+        links_out=["x"],
+    )
+    newer = _ns(
+        "new",
+        created="2020-01-01",
+        updated="2026-08-01",
+        links_out=["x"],
+    )
+    access = {
+        "old": AccessRecord(hits=5, last_accessed_at="2026-08-01T00:00:00+00:00"),
+        "new": AccessRecord(hits=5, last_accessed_at="2026-08-01T00:00:00+00:00"),
+    }
+    scores = score_pages([older, newer], access, now=NOW)
+    assert scores["new"].freshness > scores["old"].freshness
+    assert scores["new"].score > scores["old"].score
+
+
+def test_sidecar_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(importance, "settings", SimpleNamespace(wiki_root=tmp_path))
+    stamp = datetime(2026, 9, 2, 12, 0, tzinfo=timezone.utc)
+    record_access(["alpha", "beta"], now=stamp)
+    loaded = load_access()
+    assert loaded["alpha"].hits == 1
+    assert loaded["beta"].hits == 1
+    assert loaded["alpha"].last_accessed_at == stamp.isoformat()
+    record_access(["alpha"], now=stamp)
+    assert load_access()["alpha"].hits == 2
+    raw = json.loads((tmp_path / ".page-access.json").read_text(encoding="utf-8"))
+    assert raw["alpha"]["hits"] == 2
+    gi = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert any(line.strip() == ".page-access.json" for line in gi.splitlines())
+
+
+def test_corrupt_sidecar_loads_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(importance, "settings", SimpleNamespace(wiki_root=tmp_path))
+    (tmp_path / ".page-access.json").write_text("{not-json", encoding="utf-8")
+    assert load_access() == {}
+
+
+def test_record_access_never_raises_on_replace_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(importance, "settings", SimpleNamespace(wiki_root=tmp_path))
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("denied")
+
+    monkeypatch.setattr(importance.os, "replace", _boom)
+    record_access(["x"])
+
+
+def test_dormant_old_isolated_yes_hot_hub_and_catalogs_no():
+    old = _pg("old-iso", "Old Isolated")
+    hot = _pg(
+        "hot-hub",
+        "Hot Hub",
+        created="2026-09-01",
+        updated="2026-09-01",
+        links_in=["a", "b", "c"],
+        links_out=["d", "e"],
+    )
+    idx = _pg("index", "Index", section="root")
+    log = _pg("log", "Log", section="entities")
+    foundational = _pg("found", "Foundational Old", tags=["Foundational"])
+    query = _pg("q", "Old Query", section="queries")
+    access = {
+        "hot-hub": AccessRecord(
+            hits=50, last_accessed_at="2026-09-02T00:00:00+00:00"
+        )
+    }
+    out = lint._dormant_pages(
+        [old, hot, idx, log, foundational, query], access, now=NOW
+    )
+    assert [row["slug"] for row in out] == ["old-iso"]
+    row = out[0]
+    assert row["hits"] == 0
+    assert row["degree"] == 0
+    assert row["score"] < 0.10
+    assert row["last_dated"] == "2018-01-01"
+    assert row["last_accessed_at"] is None
+
+
+def test_lint_wiki_includes_dormant_key(client):
+    report = lint.lint_wiki()
+    assert "dormant" in report
+    assert isinstance(report["dormant"], list)
+    slugs = {row["slug"] for row in report["dormant"]}
+    assert "index" not in slugs
+    assert "log" not in slugs
+
+
+def test_get_page_records_access(client):
+    r = client.get("/wiki/page/public-entity")
+    assert r.status_code == 200
+    access = load_access()
+    assert access["public-entity"].hits == 1
+    assert access["public-entity"].last_accessed_at
+
+
+def test_graph_listing_does_not_record_access(client, wiki_root):
+    assert client.get("/wiki/graph").status_code == 200
+    assert client.get("/wiki/graph/public-entity").status_code == 200
+    assert not (wiki_root / ".page-access.json").exists()

--- a/backend/tests/test_persistence_tenant.py
+++ b/backend/tests/test_persistence_tenant.py
@@ -165,6 +165,9 @@ def test_clone_into_repo_with_existing_gitignore_appends_tenant_rule(
     assert any(
         line.strip() == ".share-token-stats.json" for line in gi_text.splitlines()
     ), f"share-token stats must be gitignored after bootstrap; got:\n{gi_text}"
+    assert any(
+        line.strip() == ".page-access.json" for line in gi_text.splitlines()
+    ), f"page-access sidecar must be gitignored after bootstrap; got:\n{gi_text}"
 
 
 def test_clone_already_has_tenant_json_rule_no_duplicate_append(

--- a/backend/tests/test_query_context_budget.py
+++ b/backend/tests/test_query_context_budget.py
@@ -1,7 +1,7 @@
 """Query synthesizer must not dump catalog hubs or unbounded page bodies.
 
 Index and Log are catalogs (they link to, or accumulate, the whole corpus).
-Bidirectional 1-hop expansion therefore pulls them into almost every query.
+Bidirectional expansion therefore pulls them into almost every query.
 Their full bodies are what blew a 200k-token Anthropic limit in production.
 """
 from __future__ import annotations
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from app import llm
+from app.importance import record_access
 from app.main import index as wiki_index
 
 
@@ -40,6 +41,7 @@ def test_select_context_pages_skips_catalog_hubs(client):
     assert "public-entity" in slugs
     assert "index" not in slugs
     assert "log" not in slugs
+    assert debug["hops"] == 2
     omitted = {item["slug"] for item in debug.get("omitted_catalog") or []}
     assert "index" in omitted
 
@@ -66,4 +68,61 @@ def test_context_block_caps_page_bodies(wiki_root: Path):
         assert len(block) < llm.MAX_PAGE_CHARS * (llm.MAX_CONTEXT_PAGES + 1)
     finally:
         entity.write_text(original, encoding="utf-8")
+        wiki_index.reload()
+
+
+def test_expanded_neighbors_prefer_higher_importance(wiki_root: Path, client):
+    """When the cap cannot keep every neighbor, rank by importance.score."""
+    hub = wiki_root / "wiki" / "entities" / "importance-hub.md"
+    high = wiki_root / "wiki" / "entities" / "importance-high.md"
+    low = wiki_root / "wiki" / "entities" / "importance-low.md"
+    page = """---
+type: entity
+title: {title}
+tier: public
+created: 2020-01-01
+updated: 2020-01-01
+---
+
+{body}
+"""
+    hub.write_text(
+        page.format(
+            title="Importance Hub",
+            body="UNIQUEIMPORTANCEANCHOR see [[Importance High]] and [[Importance Low]].",
+        ),
+        encoding="utf-8",
+    )
+    high.write_text(
+        page.format(title="Importance High", body="High neighbor."),
+        encoding="utf-8",
+    )
+    low.write_text(
+        page.format(title="Importance Low", body="Low neighbor."),
+        encoding="utf-8",
+    )
+    try:
+        wiki_index.reload()
+        record_access(["importance-high"])
+        pages, debug = llm._select_context_pages(
+            "UNIQUEIMPORTANCEANCHOR",
+            viewer_tier="public",
+            max_total=2,
+        )
+        slugs = [p.slug for p in pages]
+        assert slugs[0] == "importance-hub"
+        assert "importance-high" in slugs
+        assert "importance-low" not in slugs
+        assert debug["hops"] == 2
+        chosen_importance = {item["slug"]: item["score"] for item in debug["importance"]}
+        assert chosen_importance["importance-high"] > chosen_importance.get(
+            "importance-low", -1.0
+        )
+        block = llm._build_context_block(pages)
+        assert "UNIQUEIMPORTANCEANCHOR" in block
+        assert "===== PAGE:" in block
+    finally:
+        for path in (hub, high, low):
+            if path.exists():
+                path.unlink()
         wiki_index.reload()

--- a/frontend/app/owner/page.tsx
+++ b/frontend/app/owner/page.tsx
@@ -912,6 +912,10 @@ function OwnerPageInner({ tenant }: { tenant?: string }) {
                   <div className="text-xs text-ink-muted">stale</div>
                 </div>
                 <div>
+                  <div className="font-semibold">{(lint.dormant ?? []).length}</div>
+                  <div className="text-xs text-ink-muted">dormant</div>
+                </div>
+                <div>
                   <div className="font-semibold">{lint.missing_pages.length}</div>
                   <div className="text-xs text-ink-muted">missing</div>
                 </div>
@@ -930,6 +934,18 @@ function OwnerPageInner({ tenant }: { tenant?: string }) {
                 title="Stale (>30d since updated/created)"
                 items={lint.stale.map((s) => `${s.title} · ${s.age_days}d (${s.last_dated})`)}
               />
+              <LintGroup
+                title="Dormant (low importance — recency, access, centrality)"
+                items={(lint.dormant ?? []).map(
+                  (d) =>
+                    `${d.title} · score=${d.score.toFixed(3)} · hits=${d.hits} · degree=${d.degree}`
+                )}
+              />
+              {(lint.dormant ?? []).length > 0 && (
+                <p className="mt-2 text-xs text-ink-muted">
+                  Dormant pages are a suggestion to review, not a delete list.
+                </p>
+              )}
               <LintGroup
                 title="Missing pages (≥3 mentions, no page)"
                 items={lint.missing_pages.map((m) => `${m.title} · ${m.mentions}×`)}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -56,8 +56,10 @@ export type QueryRetrievalDebug = {
   hops: number;
   anchors: { slug: string; title: string; score: number }[];
   expanded: { slug: string; title: string }[];
+  omitted_catalog?: { slug: string; title: string }[];
   total_pages_in_context: number;
   edge_count: number;
+  importance?: { slug: string; score: number }[];
 };
 
 export type QueryResponse = {
@@ -88,6 +90,16 @@ export type LintReport = {
   missing_pages: { title: string; mentions: number }[];
   broken_provenance: { slug: string; title: string; missing_source: string }[];
   missing_index_entries: { slug?: string; title?: string; section?: string; reason?: string }[];
+  dormant?: {
+    slug: string;
+    title: string;
+    section: string;
+    score: number;
+    hits: number;
+    degree: number;
+    last_accessed_at: string | null;
+    last_dated: string | null;
+  }[];
   generated_at: string;
 };
 


### PR DESCRIPTION
## Summary

- Rank query context and keyword search by recency, access frequency, graph centrality, and freshness (arXiv 2608.28978), without extracting a second graph or auto-deleting pages.
- Expand retrieval to 2 hops, then take the top 12 by that score. Owner lint surfaces a capped dormant list as a review suggestion.
- Run GitHub Actions CI on `dev` as well as `main`, so the working branch is not a test blind spot.

## Test plan

- [x] Targeted pytest (`test_importance`, query context budget, lint, persistence gitignore) green locally
- [x] CI on `dev` push green (backend pytest, frontend vitest+build, mcp)
- [ ] CI on this PR green
- [ ] After merge: Render `/healthz` and a live query with `hops === 2` / `importance` on portablellm.wiki