### PR TITLE
fix: keep named wiki titles in query context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ ordered newest-first.
 
 ## Unreleased
 
+## 0.2.3. Named titles survive query retrieval
+
+`query_wiki` could answer a question that named *State, Not Tokens* from
+Marionette hub pages and never load `state-not-tokens-research`. Long
+questions kept commas on terms (`State,`), scored unigrams in huge hub
+bodies above the named title, then importance-ranked 2-hop expansion
+evicted the paper. Agents read that as "the wiki does not have the paper."
+
+- **Phrase-aware keyword rank.** Tokens are alphanumeric-folded. A
+  multi-word title or slug phrase in the query outranks hub bag-of-words
+  matches.
+- **Reserved keyword hits.** Top keyword pages stay in synthesizer
+  context even when they are not the three graph-walk anchors.
+- **Outbound neighbors of the top hit.** A linked bench/entity page is
+  not dropped solely because a high-centrality hub scores higher.
+- **Synthesizer contract.** A named work missing from CONTEXT is a
+  retrieval miss, not proof the wiki lacks it.
+- Patch bump to **0.2.3**.
+
+## 0.2.2. Hosted health, tokens, and index ranking
+
+Shipped on `main` ahead of this tag.
+
 - **Public `/healthz` is liveness-only.** The footer status link and
   Render/Docker probes no longer return `page_count`, process RSS, or
   tenant-volume disk bytes. Those are shared-service fingerprints, not

--- a/SPEC.md
+++ b/SPEC.md
@@ -327,9 +327,13 @@ markdown links).
 
 ### `GET /wiki/search?q={query}&limit={n}`
 
-Keyword search across visible pages. The reference implementation scores
-title hits at 5×, tag hits at 2×, and body-occurrence hits at 1× (capped
-at 5 per term). Servers MAY substitute a different ranker.
+Keyword search across visible pages. The reference implementation folds
+punctuation, scores title-token hits at 5×, tag-token hits at 2×, and
+body-token hits at 1× (capped at 5 per term), then adds a bonus when a
+multi-word title or slug phrase appears in the query. Query context
+reserves those keyword hits (and a few outbound neighbors of the top
+hit) before filling remaining slots by keyword score, then importance.
+Servers MAY substitute a different ranker.
 
 Query parameters:
 

--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -217,7 +217,9 @@ Answer the user's question using ONLY the wiki pages provided as CONTEXT
 below. Each page is delimited by "===== PAGE: <title> (slug: <slug>) =====".
 
 Hard rules:
-- Cite specific pages inline by their title in brackets, e.g. [[Calibrated Honesty]].
+- Cite specific pages inline by their title in brackets, e.g. [[Calibrated Honesty]],
+  and only pages present in CONTEXT. If a named work is not among those pages,
+  say it was not in this retrieval set — do not conclude the wiki lacks it.
 - If the wiki does not contain enough information to answer, say so explicitly
   and suggest what source the user could ingest to close the gap.
 - Do not invent biographical or factual claims that are not in the context.
@@ -234,6 +236,12 @@ Hard rules:
 CATALOG_SLUGS = frozenset({"index", "log"})
 MAX_PAGE_CHARS = 8_000
 MAX_CONTEXT_PAGES = 12
+# Keep extra keyword hits beyond graph-walk anchors so a named title that
+# ranks 4th still reaches the synthesizer. Importance fill uses the rest.
+KEYWORD_RESERVE = 6
+# After a named hit, keep a few of its direct wikilink neighbors so the
+# matching bench/entity page is not evicted by high-centrality hubs.
+TOP_NEIGHBOR_RESERVE = 2
 _TRUNCATION_NOTE = "\n\n[truncated]"
 
 
@@ -252,12 +260,15 @@ def _select_context_pages(
 
     Strategy:
       1. Keyword-score visible pages → take top `max_anchors` as ANCHORS,
-         skipping catalog hubs (index, log).
+         skipping catalog hubs (index, log). Also reserve additional
+         high-scoring keyword hits so a named title cannot be evicted by
+         hub expansion. Reserve a few 1-hop neighbors of the top hit so
+         the matching entity/bench page survives hub fill.
       2. Expand each anchor `hops` steps along wikilinks (in/out) → SUBGRAPH,
          still skipping catalog hubs. Default hops=2 (1-hop is too shallow;
          3+ explodes through hubs).
-      3. Rank non-anchor expanded slugs by importance.score descending and
-         keep only the remaining context slots.
+      3. Rank non-reserved expanded slugs by keyword score, then
+         importance.score, and keep only the remaining context slots.
       4. If chosen is still thin (<3 pages), backfill with foundational pages
          (tagged 'foundational' or in projects/overview).
       5. Hard-cap at `max_total` pages so we don't blow the LLM context.
@@ -266,17 +277,41 @@ def _select_context_pages(
     Returns (pages_in_order, retrieval_debug_dict). Anchors come first.
     """
     scored = index.keyword_search(
-        question, viewer_tier=viewer_tier, limit=max_anchors * 8
+        question, viewer_tier=viewer_tier, limit=max(max_anchors * 8, KEYWORD_RESERVE * 2)
     )
     score_by_slug = {p.slug: score for p, score in scored}
-    anchors: list[Page] = []
+    reserved: list[Page] = []
     for p, _score in scored:
         if _is_catalog_slug(p.slug):
             continue
-        anchors.append(p)
-        if len(anchors) >= max_anchors:
+        reserved.append(p)
+        if len(reserved) >= min(max(max_anchors, KEYWORD_RESERVE), max_total):
             break
+    anchors = reserved[:max_anchors]
     anchor_slugs = [p.slug for p in anchors]
+    reserved_slugs = [p.slug for p in reserved]
+    breakdowns = score_pages(index.visible_pages(viewer_tier), load_access())
+
+    neighbor_budget = min(TOP_NEIGHBOR_RESERVE, max(0, max_total - len(reserved_slugs)))
+    if neighbor_budget and reserved:
+        top = reserved[0]
+        neighbor_candidates = []
+        seen_neighbors = set(reserved_slugs)
+        for slug in top.links_out:
+            if slug in seen_neighbors or _is_catalog_slug(slug):
+                continue
+            if index.get(slug) is None:
+                continue
+            seen_neighbors.add(slug)
+            neighbor_candidates.append(slug)
+        neighbor_candidates.sort(
+            key=lambda s: (
+                score_by_slug.get(s, 0.0),
+                breakdowns[s].score if s in breakdowns else 0.0,
+            ),
+            reverse=True,
+        )
+        reserved_slugs.extend(neighbor_candidates[:neighbor_budget])
 
     if anchors:
         subgraph = index.subgraph(
@@ -290,16 +325,18 @@ def _select_context_pages(
     else:
         subgraph = {"nodes": [], "edges": [], "anchors": []}
         expanded_slugs = []
-
-    breakdowns = score_pages(index.visible_pages(viewer_tier), load_access())
-    remaining_slots = max(0, max_total - len(anchor_slugs))
+    remaining_slots = max(0, max_total - len(reserved_slugs))
+    expanded_slugs = [s for s in expanded_slugs if s not in reserved_slugs]
     expanded_slugs.sort(
-        key=lambda s: breakdowns[s].score if s in breakdowns else 0.0,
+        key=lambda s: (
+            score_by_slug.get(s, 0.0),
+            breakdowns[s].score if s in breakdowns else 0.0,
+        ),
         reverse=True,
     )
     expanded_slugs = expanded_slugs[:remaining_slots]
 
-    ordered_slugs: list[str] = anchor_slugs + expanded_slugs
+    ordered_slugs: list[str] = reserved_slugs + expanded_slugs
 
     if len(ordered_slugs) < 3:
         for page in index.visible_pages(viewer_tier):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -199,7 +199,7 @@ def _maybe_start_tenant_pull_poller(_persistence):
 
 app = FastAPI(
     title="Portable LLM Wiki",
-    version="0.2.2",
+    version="0.2.3",
     description=(
         "Vendor-neutral HTTP transport for a Karpathy-style personal LLM wiki. "
         "Any LLM client that can fetch URLs can read the wiki via this API."

--- a/backend/app/wiki.py
+++ b/backend/app/wiki.py
@@ -11,7 +11,7 @@ import os
 import re
 import threading
 import time
-from collections import deque
+from collections import Counter, deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -33,6 +33,9 @@ _STALE_CHECK_INTERVAL_S: float = float(
 )
 
 WIKILINK_RE = re.compile(r"\[\[([^\]\|]+?)(?:\|([^\]]+))?\]\]")
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_TITLE_PHRASE_PER_WORD = 40.0
+_SLUG_PHRASE_BONUS = 40.0
 PAGE_TYPES = (
     "entity",
     "concept",
@@ -48,6 +51,40 @@ def _slugify(title: str) -> str:
     s = title.strip().lower()
     s = re.sub(r"[^a-z0-9]+", "-", s)
     return s.strip("-")
+
+
+def _tokens(text: str) -> list[str]:
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _folded_text(text: str) -> str:
+    return " ".join(_tokens(text))
+
+
+def _best_ngram_bonus(query_folded: str, words: list[str]) -> float:
+    for n in range(min(4, len(words)), 1, -1):
+        for i in range(len(words) - n + 1):
+            phrase = " ".join(words[i : i + n])
+            if phrase in query_folded:
+                return _TITLE_PHRASE_PER_WORD * n
+    return 0.0
+
+
+def _phrase_bonus(query_folded: str, title: str, slug: str) -> float:
+    """Boost pages whose multi-word title or slug appears in the query.
+
+    Unigram scoring on long questions otherwise ranks huge hub bodies
+    above the page the question named.
+    """
+    if not query_folded:
+        return 0.0
+    bonus = _best_ngram_bonus(query_folded, _tokens(title))
+    slug_words = [part for part in slug.lower().split("-") if part]
+    if len(slug_words) >= 2 and " ".join(slug_words) in query_folded:
+        bonus = max(bonus, _SLUG_PHRASE_BONUS)
+    elif slug_words:
+        bonus = max(bonus, _best_ngram_bonus(query_folded, slug_words))
+    return bonus
 
 
 # Dated pages (decisions, sources) carry a ``YYYY-MM-DD`` filename/slug prefix
@@ -431,25 +468,22 @@ class WikiIndex:
         return out[:limit]
 
     def keyword_search(self, query: str, viewer_tier: str, limit: int = 20) -> list[tuple[Page, float]]:
-        q = query.strip().lower()
-        if not q:
-            return []
-        terms = [t for t in re.split(r"\s+", q) if t]
+        query_folded = _folded_text(query)
+        terms = _tokens(query)
         if not terms:
             return []
         results: list[tuple[Page, float]] = []
         for page in self.visible_pages(viewer_tier):
-            score = 0.0
-            haystack_title = page.title.lower()
-            haystack_body = page.body.lower()
-            haystack_tags = " ".join(page.tags).lower()
+            score = _phrase_bonus(query_folded, page.title, page.slug)
+            title_tokens = set(_tokens(page.title))
+            tag_tokens = set(_tokens(" ".join(page.tags)))
+            body_counts = Counter(_tokens(page.body))
             for term in terms:
-                if term in haystack_title:
+                if term in title_tokens:
                     score += 5.0
-                if term in haystack_tags:
+                if term in tag_tokens:
                     score += 2.0
-                count = haystack_body.count(term)
-                score += min(count, 5) * 1.0
+                score += min(body_counts.get(term, 0), 5) * 1.0
             if score > 0:
                 results.append((page, score))
         if not results:

--- a/backend/tests/test_query_context_budget.py
+++ b/backend/tests/test_query_context_budget.py
@@ -126,3 +126,169 @@ updated: 2020-01-01
             if path.exists():
                 path.unlink()
         wiki_index.reload()
+
+
+_NAMED_TITLE_QUERY = (
+    "What prior findings, metrics, papers, repositories, and methodological "
+    "decisions exist for State, Not Tokens, durable repository-scale agent "
+    "reasoning, concurrency ceilings, and a possible extreme-scale Linux "
+    "kernel follow-on benchmark?"
+)
+
+_HUB_UNIGRAMS = (
+    "findings metrics papers repositories methodological decisions durable "
+    "repository scale agent reasoning concurrency ceilings extreme scale "
+    "linux kernel follow benchmark prior exist possible "
+) * 8
+
+_PAGE_TEMPLATE = """---
+type: entity
+title: {title}
+tier: public
+created: 2020-01-01
+updated: 2020-01-01
+---
+
+{body}
+"""
+
+
+def _write_named_title_fixture(wiki_root: Path) -> list[Path]:
+    """Hub pages that win bag-of-words scoring against a named research title."""
+    paths = []
+    for slug, title in (
+        ("product-hub-one", "Product Hub One"),
+        ("product-hub-two", "Product Hub Two"),
+        ("product-hub-three", "Product Hub Three"),
+    ):
+        path = wiki_root / "wiki" / "entities" / f"{slug}.md"
+        path.write_text(
+            _PAGE_TEMPLATE.format(
+                title=title,
+                body=(
+                    f"{_HUB_UNIGRAMS} see [[Product Hub One]] [[Product Hub Two]] "
+                    "[[Product Hub Three]] [[State Not Tokens Research]]."
+                ),
+            ),
+            encoding="utf-8",
+        )
+        paths.append(path)
+    research = wiki_root / "wiki" / "entities" / "state-not-tokens-research.md"
+    research.write_text(
+        _PAGE_TEMPLATE.format(
+            title="State Not Tokens Research",
+            body="Paper v12. Mean pass 91.1 percent. About 2.28 times published SOTA.",
+        ),
+        encoding="utf-8",
+    )
+    paths.append(research)
+    return paths
+
+
+def test_keyword_search_ranks_named_title_above_unigram_hubs(wiki_root: Path):
+    """A query that names a multi-word title must rank that page first.
+
+    Production miss: the long State, Not Tokens question ranked Marionette
+    hubs above state-not-tokens-research because terms kept commas and
+    scored unigrams in huge bodies.
+    """
+    paths = _write_named_title_fixture(wiki_root)
+    try:
+        wiki_index.reload()
+        ranked = [
+            page.slug
+            for page, _score in wiki_index.keyword_search(
+                _NAMED_TITLE_QUERY, viewer_tier="public", limit=10
+            )
+        ]
+        assert ranked[0] == "state-not-tokens-research"
+        quoted = [
+            page.slug
+            for page, _score in wiki_index.keyword_search(
+                '"State, Not Tokens"', viewer_tier="public", limit=5
+            )
+        ]
+        assert quoted[0] == "state-not-tokens-research"
+    finally:
+        for path in paths:
+            if path.exists():
+                path.unlink()
+        wiki_index.reload()
+
+
+def test_select_context_keeps_named_title_when_hubs_dominate_unigrams(
+    wiki_root: Path,
+):
+    """Query context must keep the named page even when only three slots exist."""
+    paths = _write_named_title_fixture(wiki_root)
+    try:
+        wiki_index.reload()
+        pages, debug = llm._select_context_pages(
+            _NAMED_TITLE_QUERY,
+            viewer_tier="public",
+            max_total=3,
+        )
+        slugs = [page.slug for page in pages]
+        assert "state-not-tokens-research" in slugs
+        assert any(
+            anchor["slug"] == "state-not-tokens-research"
+            for anchor in debug["anchors"]
+        )
+    finally:
+        for path in paths:
+            if path.exists():
+                path.unlink()
+        wiki_index.reload()
+
+
+def test_select_context_keeps_named_hit_neighbor_over_extra_hubs(
+    wiki_root: Path,
+):
+    """The bench page linked from the named paper must survive hub fill."""
+    paths: list[Path] = []
+    for i in range(1, 7):
+        path = wiki_root / "wiki" / "entities" / f"product-hub-{i}.md"
+        path.write_text(
+            _PAGE_TEMPLATE.format(
+                title=f"Product Hub {i}",
+                body=(
+                    f"{_HUB_UNIGRAMS} see [[State Not Tokens Research]] "
+                    "[[Product Hub 1]] [[Product Hub 2]]."
+                ),
+            ),
+            encoding="utf-8",
+        )
+        paths.append(path)
+    research = wiki_root / "wiki" / "entities" / "state-not-tokens-research.md"
+    research.write_text(
+        _PAGE_TEMPLATE.format(
+            title="State Not Tokens Research",
+            body="Paper v12. Validated on [[NL2Repo Bench]].",
+        ),
+        encoding="utf-8",
+    )
+    paths.append(research)
+    bench = wiki_root / "wiki" / "entities" / "nl2repo-bench.md"
+    bench.write_text(
+        _PAGE_TEMPLATE.format(
+            title="NL2Repo Bench",
+            body="Independent repository-scale pytest suite.",
+        ),
+        encoding="utf-8",
+    )
+    paths.append(bench)
+    try:
+        wiki_index.reload()
+        pages, _debug = llm._select_context_pages(
+            _NAMED_TITLE_QUERY,
+            viewer_tier="public",
+            max_total=8,
+        )
+        slugs = [page.slug for page in pages]
+        assert "state-not-tokens-research" in slugs
+        assert "nl2repo-bench" in slugs
+    finally:
+        for path in paths:
+            if path.exists():
+                path.unlink()
+        wiki_index.reload()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portable-llm-wiki-frontend",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portable-llm-wiki-frontend",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@types/d3-force": "^3.0.10",
         "@vercel/analytics": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-llm-wiki-frontend",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "scripts": {
     "dev": "next dev -H 0.0.0.0 -p 3000",


### PR DESCRIPTION
## Why

`query_wiki` could answer a question that named State, Not Tokens from Marionette hub pages and never load `state-not-tokens-research`. Agents treated that as the wiki lacking the paper. The pages were present. Retrieval ranked long unigram hub bodies above the named title, then importance-ranked 2-hop fill evicted it.

## Scope

- Fold punctuation in keyword tokens and bonus multi-word title/slug phrases.
- Reserve top keyword hits so a named page stays in synthesizer context.
- Keep a few outbound neighbors of the top hit.
- Synthesizer prompt: a named work missing from CONTEXT is a retrieval miss, not absence.
- Version **0.2.3**. Changelog and SPEC ranker note.

## Tradeoffs

Importance ranking and hops=2 stay. Query relevance now beats hub centrality for the named hit. Outbound neighbor reserve cannot force `nl2repo-bench` into a 12-page window when the paper links dozens of hubs; the research page itself carries the 91.1% / 2.28× figures.

## Blast radius

`/wiki/search` and `/wiki/query` ranking. Catalog hubs stay omitted. Existing importance-neighbor test still prefers the accessed leaf when keyword scores tie.

## Verification

- `cd backend && .venv/bin/python -m pytest tests -q` — 490 passed.
- `cd frontend && npx vitest run && npx tsc --noEmit` — 208 passed.
- Same production question against the personal corpus: `state-not-tokens-research` is now the first keyword hit and a query anchor.