### PR TITLE
fix: keep the full knowledge graph responsive

### DIFF
--- a/frontend/app/graph/page.tsx
+++ b/frontend/app/graph/page.tsx
@@ -180,7 +180,7 @@ export default function GraphPage() {
       <div className="mt-4 flex gap-2 flex-wrap items-center">
         <span className="text-xs text-ink-muted uppercase tracking-wider">Filter:</span>
         <button
-          onClick={() => setSectionFilter("")}
+          onClick={() => { setSectionFilter(""); setSelectedSlug(null); }}
           className={`text-xs px-2 py-1 rounded border ${
             sectionFilter === ""
               ? "border-ink text-ink"
@@ -192,7 +192,7 @@ export default function GraphPage() {
         {Object.entries(sectionCounts).map(([s, n]) => (
           <button
             key={s}
-            onClick={() => setSectionFilter(s)}
+            onClick={() => { setSectionFilter(s); setSelectedSlug(null); }}
             className={`text-xs px-2 py-1 rounded border flex items-center gap-1.5 ${
               sectionFilter === s
                 ? "border-ink text-ink"

--- a/frontend/app/graph/page.tsx
+++ b/frontend/app/graph/page.tsx
@@ -1,69 +1,18 @@
 "use client";
 
-import dynamic from "next/dynamic";
-import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import ForceGraphCanvas, {
+  type ForceGraphCanvasHandle,
+  type GraphLabelMode,
+} from "@/components/ForceGraphCanvas";
 import {
   fetchGraph,
   fetchManifest,
   type GraphResponse,
   type GraphNode,
 } from "@/lib/api";
-import {
-  captureCamera,
-  fitForceGraphCamera,
-  undoLibraryAutoZoom,
-  type CameraPose,
-} from "@/lib/graphCamera";
 import { useTenant } from "@/lib/useTenant";
-
-function settleGraphCamera(
-  fg: {
-    graphData?: () => { nodes?: { degree?: number; x?: number; y?: number }[] };
-    zoom?: (k?: number, ms?: number) => number | unknown;
-    centerAt?: (x?: number, y?: number, ms?: number) => unknown;
-    zoomToFit?: (
-      ms?: number,
-      px?: number,
-      nodeFilter?: (node: { degree?: number; x?: number; y?: number }) => boolean,
-    ) => void;
-  } | null,
-  autoFitDoneRef: MutableRefObject<boolean>,
-  fittedPoseRef: MutableRefObject<CameraPose | null>,
-) {
-  if (!fg) return;
-  const nodeCount = fg.graphData?.()?.nodes?.length ?? 0;
-  if (autoFitDoneRef.current) {
-    undoLibraryAutoZoom(fg, nodeCount, fittedPoseRef.current);
-    return;
-  }
-  if (fitForceGraphCamera(fg, 40, 0)) {
-    autoFitDoneRef.current = true;
-    fittedPoseRef.current = captureCamera(fg);
-  }
-}
-
-// react-force-graph-2d is canvas-based, so it must be loaded client-side
-// only. ``next/dynamic`` returns a ``LoadableComponent`` HOC that does
-// NOT forward refs to the wrapped component — which silently breaks the
-// "recenter" / "relax" buttons (``fgRef.current`` never gets
-// ``zoomToFit`` / ``d3ReheatSimulation``). Wrapping the dynamic import in
-// ``forwardRef`` does not help because the ref still lands on the
-// LoadableComponent wrapper. Instead we dynamically import
-// ``ForceGraphCanvas``, a thin client component that statically imports
-// ForceGraph2D and accepts ``graphRef`` as a regular prop.
-//
-// See https://nextjs.org/docs/app/api-reference/functions/dynamic-imports
-// — "ref attribute" caveat.
-const ForceGraphCanvas = dynamic(
-  () => import("@/components/ForceGraphCanvas"),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="text-sm text-ink-muted p-4">loading graph…</div>
-    ),
-  },
-);
 
 const SECTION_COLORS: Record<string, string> = {
   entities: "#3b82f6",
@@ -83,15 +32,8 @@ const TIER_RING: Record<string, string> = {
   private: "#ef4444",
 };
 
-// How permanent (always-painted) labels are chosen. Cycles in this order so a
-// single button can reach every state:
-//   hubs — top-degree nodes + current selection (the calm default)
-//   all  — every node labelled (busy, but complete)
-//   off  — no permanent labels at all; only hover/selection reveal a name
-type LabelMode = "hubs" | "all" | "off";
-
-const LABEL_MODE_ORDER: LabelMode[] = ["hubs", "all", "off"];
-const LABEL_MODE_TEXT: Record<LabelMode, string> = {
+const LABEL_MODE_ORDER: GraphLabelMode[] = ["hubs", "all", "off"];
+const LABEL_MODE_TEXT: Record<GraphLabelMode, string> = {
   hubs: "labels: hubs only",
   all: "labels: all",
   off: "labels: off",
@@ -99,51 +41,46 @@ const LABEL_MODE_TEXT: Record<LabelMode, string> = {
 
 export default function GraphPage() {
   const tenant = useTenant();
-  const [graph, setGraph] = useState<GraphResponse | null>(null);
+  const tenantScope = tenant ?? "";
+  const [loadedGraph, setLoadedGraph] = useState<{
+    tenantScope: string;
+    value: GraphResponse;
+  } | null>(null);
+  const graph = loadedGraph?.tenantScope === tenantScope ? loadedGraph.value : null;
   const [viewerTier, setViewerTier] = useState<string>("public");
   const [isOwner, setIsOwner] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [hoveredSlug, setHoveredSlug] = useState<string | null>(null);
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const [sectionFilter, setSectionFilter] = useState<string>("");
-  const [labelMode, setLabelMode] = useState<LabelMode>("off");
-  const wrapperRef = useRef<HTMLDivElement | null>(null);
-  // The ForceGraph2D instance exposes d3Force(...) and zoomToFit() — keep a ref.
-  // The library's exported type is loose; using `any` here is intentional.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const fgRef = useRef<any>(null);
-  // Per-frame accumulator for painted label rectangles so collision avoidance
-  // can skip labels that would overlap already-painted ones. Reset every frame
-  // in onRenderFramePre.
-  const labelRectsRef = useRef<Array<{ x: number; y: number; w: number; h: number }>>([]);
-  const autoFitDoneRef = useRef(false);
-  const fittedPoseRef = useRef<ReturnType<typeof captureCamera>>(null);
-  const [size, setSize] = useState({ w: 800, h: 600 });
+  const [labelMode, setLabelMode] = useState<GraphLabelMode>("off");
+  const graphRef = useRef<ForceGraphCanvasHandle | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    setSelectedSlug(null);
+    setSectionFilter("");
     fetchGraph(tenant)
-      .then(setGraph)
-      .catch((e) => setError((e as Error).message));
+      .then((value) => {
+        if (!cancelled) setLoadedGraph({ tenantScope, value });
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setError(error instanceof Error ? error.message : "failed to load graph");
+        }
+      });
     fetchManifest(tenant)
       .then((m) => {
-        setViewerTier(m.viewer_tier);
-        setIsOwner(m.viewer_is_owner);
+        if (!cancelled) {
+          setViewerTier(m.viewer_tier);
+          setIsOwner(m.viewer_is_owner);
+        }
       })
       .catch(() => {
         /* badge already surfaces this */
       });
-  }, [tenant]);
-
-  useEffect(() => {
-    if (!wrapperRef.current) return;
-    const ro = new ResizeObserver((entries) => {
-      const r = entries[0]?.contentRect;
-      if (!r) return;
-      setSize({ w: r.width, h: Math.max(500, r.height) });
-    });
-    ro.observe(wrapperRef.current);
-    return () => ro.disconnect();
-  }, []);
+    return () => { cancelled = true; };
+  }, [tenant, tenantScope]);
 
   const filtered = useMemo(() => {
     if (!graph) return null;
@@ -157,14 +94,6 @@ export default function GraphPage() {
       anchors: graph.anchors,
     };
   }, [graph, sectionFilter]);
-
-  const data = useMemo(() => {
-    if (!filtered) return { nodes: [], links: [] };
-    return {
-      nodes: filtered.nodes.map((n) => ({ ...n, id: n.slug })),
-      links: filtered.edges.map((e) => ({ source: e.source, target: e.target })),
-    };
-  }, [filtered]);
 
   const selectedNode = useMemo(
     () => filtered?.nodes.find((n) => n.slug === selectedSlug) ?? null,
@@ -187,59 +116,6 @@ export default function GraphPage() {
     for (const n of graph.nodes) out[n.section] = (out[n.section] || 0) + 1;
     return out;
   }, [graph]);
-
-  // Decide which nodes get a permanent label vs. hover-only.
-  //   off  — nothing permanent; hover/selection still reveal a name.
-  //   all  — every node labelled.
-  //   hubs — top-degree nodes plus the current selection's neighborhood.
-  // The hubs default avoids the "labels piled on top of each other" problem on
-  // dense graphs while keeping the view readable.
-  const labelSet = useMemo(() => {
-    if (!filtered || labelMode === "off") return new Set<string>();
-    if (labelMode === "all") return new Set(filtered.nodes.map((n) => n.slug));
-    const set = new Set<string>();
-    const sorted = [...filtered.nodes].sort((a, b) => b.degree - a.degree);
-    // Show top 6 by degree as permanent labels.
-    for (const n of sorted.slice(0, 6)) set.add(n.slug);
-    if (selectedSlug) {
-      set.add(selectedSlug);
-      for (const n of selectedNeighbors) set.add(n.slug);
-    }
-    return set;
-  }, [filtered, selectedSlug, selectedNeighbors, labelMode]);
-
-  useEffect(() => {
-    autoFitDoneRef.current = false;
-    fittedPoseRef.current = null;
-    if (!filtered?.nodes.length) return;
-    // Engine stop is the real settle; this is only a backup if it never fires.
-    const t = window.setTimeout(
-      () => settleGraphCamera(fgRef.current, autoFitDoneRef, fittedPoseRef),
-      5500,
-    );
-    return () => window.clearTimeout(t);
-  }, [filtered]);
-
-  // Tune the d3-force layout when graph data changes. Defaults are tuned for
-  // sparse graphs; our wiki graph has avg degree ~9, which collapses without
-  // stronger repulsion + a collision force.
-  useEffect(() => {
-    if (!fgRef.current || !filtered || filtered.nodes.length === 0) return;
-    const fg = fgRef.current;
-    const linkF = fg.d3Force("link");
-    if (linkF) linkF.distance(90).strength(0.4);
-    const chargeF = fg.d3Force("charge");
-    if (chargeF) chargeF.strength(-420).distanceMax(600);
-    // Inject a collision force keyed to node radius so nodes don't overlap.
-    import("d3-force").then(({ forceCollide }) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      fg.d3Force("collision", forceCollide((d: any) => {
-        const r = 4 + Math.sqrt(d.degree || 1) * 1.6;
-        return r + 14; // generous radius so labels also have room
-      }).strength(0.9));
-      fg.d3ReheatSimulation();
-    });
-  }, [filtered]);
 
   return (
     <div className="max-w-7xl mx-auto px-5 py-6">
@@ -351,222 +227,37 @@ export default function GraphPage() {
             {LABEL_MODE_TEXT[labelMode]}
           </button>
           <button
-            onClick={() => {
-              if (fitForceGraphCamera(fgRef.current, 40, 400)) {
-                autoFitDoneRef.current = true;
-                fittedPoseRef.current = captureCamera(fgRef.current);
-              }
-            }}
+            onClick={() => graphRef.current?.recenter()}
             className="text-xs px-2 py-1 rounded border border-paper-soft text-ink-muted hover:border-ink hover:text-ink"
             title="Fit graph to view"
           >
-            ⤢ recenter
+            recenter
           </button>
           <button
-            onClick={() => fgRef.current?.d3ReheatSimulation?.()}
+            onClick={() => graphRef.current?.relax()}
             className="text-xs px-2 py-1 rounded border border-paper-soft text-ink-muted hover:border-ink hover:text-ink"
             title="Re-run layout simulation"
           >
-            ↻ relax
+            relax
           </button>
         </span>
       </div>
 
-      <div className="mt-4 grid lg:grid-cols-[1fr_320px] gap-5">
-        <div
-          ref={wrapperRef}
-          className="bg-white border border-paper-soft rounded-xl overflow-hidden"
-          style={{ height: "78vh", minHeight: 600 }}
-        >
-          {data.nodes.length === 0 ? (
+      <div className="mt-4 grid lg:grid-cols-[minmax(0,1fr)_320px] gap-5">
+        <div className="min-w-0 bg-white border border-paper-soft rounded-xl overflow-hidden h-[78vh] min-h-[600px]">
+          {!graph || filtered?.nodes.length === 0 ? (
             <div className="h-full flex items-center justify-center text-sm text-ink-muted">
               {graph ? "no pages match the current filter" : "loading…"}
             </div>
           ) : (
             <ForceGraphCanvas
-              graphRef={fgRef}
-              width={size.w}
-              height={size.h}
-              graphData={data}
-              backgroundColor="#fafaf7"
-              nodeRelSize={6}
-              cooldownTicks={300}
-              d3AlphaDecay={0.018}
-              d3VelocityDecay={0.35}
-              warmupTicks={80}
-              onEngineStop={() => {
-                settleGraphCamera(fgRef.current, autoFitDoneRef, fittedPoseRef);
-                labelRectsRef.current = [];
-              }}
-              onRenderFramePre={() => {
-                labelRectsRef.current = [];
-                if (autoFitDoneRef.current) {
-                  settleGraphCamera(
-                    fgRef.current,
-                    autoFitDoneRef,
-                    fittedPoseRef,
-                  );
-                }
-              }}
-              linkColor={(link: unknown) => {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const l = link as any;
-                const sSlug = typeof l.source === "object" ? l.source.slug : l.source;
-                const tSlug = typeof l.target === "object" ? l.target.slug : l.target;
-                if (
-                  selectedSlug &&
-                  (sSlug === selectedSlug || tSlug === selectedSlug)
-                ) {
-                  return "rgba(255,106,0,0.55)";
-                }
-                if (selectedSlug) return "rgba(14,14,16,0.06)";
-                return "rgba(14,14,16,0.12)";
-              }}
-              linkWidth={(link: unknown) => {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const l = link as any;
-                const sSlug = typeof l.source === "object" ? l.source.slug : l.source;
-                const tSlug = typeof l.target === "object" ? l.target.slug : l.target;
-                if (
-                  selectedSlug &&
-                  (sSlug === selectedSlug || tSlug === selectedSlug)
-                ) {
-                  return 1.6;
-                }
-                return 0.6;
-              }}
-              linkDirectionalArrowLength={3}
-              linkDirectionalArrowRelPos={0.92}
-              onNodeHover={(node: unknown) => {
-                const n = node as { slug?: string } | null;
-                setHoveredSlug(n?.slug ?? null);
-                if (wrapperRef.current) {
-                  wrapperRef.current.style.cursor = n ? "pointer" : "default";
-                }
-              }}
-              onNodeClick={(node: unknown) => {
-                const n = node as { slug?: string } | null;
-                if (n?.slug) setSelectedSlug(n.slug);
-              }}
-              onBackgroundClick={() => setSelectedSlug(null)}
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              nodeCanvasObject={(node: any, ctx: CanvasRenderingContext2D, scale: number) => {
-                const radius = Math.max(4, Math.min(14, 4 + Math.sqrt(node.degree || 1) * 1.6));
-                const isSelected = node.slug === selectedSlug;
-                const isHovered = node.slug === hoveredSlug;
-                const isNeighbor =
-                  !!selectedSlug &&
-                  selectedNeighbors.some((nb) => nb.slug === node.slug);
-                const fill = SECTION_COLORS[node.section] || SECTION_COLORS.other;
-                const ring = TIER_RING[node.tier] || "#999";
-
-                ctx.beginPath();
-                ctx.arc(node.x, node.y, radius, 0, 2 * Math.PI, false);
-                ctx.fillStyle = fill;
-                ctx.globalAlpha =
-                  selectedSlug && !(isSelected || isNeighbor) ? 0.18 : 1.0;
-                ctx.fill();
-                ctx.lineWidth = isSelected ? 3 : isHovered ? 2 : 1.5;
-                ctx.strokeStyle = isSelected ? "#0e0e10" : ring;
-                ctx.stroke();
-                ctx.globalAlpha = 1.0;
-
-                const shouldLabel =
-                  isSelected ||
-                  isHovered ||
-                  labelSet.has(node.slug) ||
-                  (labelMode !== "off" && scale > 1.6);
-                if (shouldLabel) {
-                  const fullTitle = node.title as string;
-                  const label =
-                    isSelected || isHovered || scale > 2 || fullTitle.length <= 26
-                      ? fullTitle
-                      : fullTitle.slice(0, 24) + "…";
-                  const fontSize = Math.max(9, 11 / Math.max(0.6, scale));
-                  ctx.font = `${isSelected || isHovered ? "600 " : ""}${fontSize}px ui-sans-serif`;
-                  const padX = 4 / scale;
-                  const padY = 2 / scale;
-                  const textW = ctx.measureText(label).width;
-                  const textH = fontSize;
-                  const gap = 4 / scale;
-
-                  // Try several anchor positions around the node, in priority
-                  // order: below, above, right, left. Pick the first that
-                  // doesn't overlap an already-painted label this frame.
-                  // Selected/hovered always paints (and dominates everything).
-                  const candidates = [
-                    { x: node.x, y: node.y + radius + gap, ax: "center" as const, ay: "top" as const },
-                    { x: node.x, y: node.y - radius - gap, ax: "center" as const, ay: "bottom" as const },
-                    { x: node.x + radius + gap, y: node.y, ax: "left" as const, ay: "middle" as const },
-                    { x: node.x - radius - gap, y: node.y, ax: "right" as const, ay: "middle" as const },
-                  ];
-
-                  function rectFor(c: (typeof candidates)[number]) {
-                    let rx = c.x;
-                    let ry = c.y;
-                    if (c.ax === "center") rx -= textW / 2;
-                    else if (c.ax === "right") rx -= textW;
-                    if (c.ay === "middle") ry -= textH / 2;
-                    else if (c.ay === "bottom") ry -= textH;
-                    return {
-                      x: rx - padX,
-                      y: ry - padY,
-                      w: textW + padX * 2,
-                      h: textH + padY * 2,
-                    };
-                  }
-
-                  function overlaps(
-                    a: { x: number; y: number; w: number; h: number },
-                    b: { x: number; y: number; w: number; h: number }
-                  ) {
-                    return !(
-                      a.x + a.w < b.x ||
-                      b.x + b.w < a.x ||
-                      a.y + a.h < b.y ||
-                      b.y + b.h < a.y
-                    );
-                  }
-
-                  const forced = isSelected || isHovered;
-                  let chosen: { rect: { x: number; y: number; w: number; h: number }; c: (typeof candidates)[number] } | null = null;
-                  for (const c of candidates) {
-                    const r = rectFor(c);
-                    const collision = labelRectsRef.current.some((other) => overlaps(r, other));
-                    if (!collision) {
-                      chosen = { rect: r, c };
-                      break;
-                    }
-                  }
-                  // If everything collides and the label isn't forced (selected/
-                  // hovered), skip drawing it — keeps dense clusters readable.
-                  if (!chosen && forced) {
-                    chosen = { rect: rectFor(candidates[0]), c: candidates[0] };
-                  }
-
-                  if (chosen) {
-                    const { rect, c } = chosen;
-                    ctx.fillStyle = forced
-                      ? "rgba(250,250,247,0.95)"
-                      : "rgba(250,250,247,0.85)";
-                    ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
-                    ctx.fillStyle = forced ? "#0e0e10" : "#525258";
-                    ctx.textAlign = c.ax;
-                    ctx.textBaseline = c.ay;
-                    ctx.fillText(label, c.x, c.y);
-                    labelRectsRef.current.push(rect);
-                  }
-                }
-              }}
-              // Increase the painted hit-area so clicks/hovers are forgiving.
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              nodePointerAreaPaint={(node: any, color: string, ctx: CanvasRenderingContext2D) => {
-                const radius = Math.max(8, 6 + Math.sqrt(node.degree || 1) * 1.6);
-                ctx.fillStyle = color;
-                ctx.beginPath();
-                ctx.arc(node.x, node.y, radius, 0, 2 * Math.PI, false);
-                ctx.fill();
-              }}
+              ref={graphRef}
+              graph={graph}
+              tenant={tenant}
+              sectionFilter={sectionFilter}
+              selectedSlug={selectedSlug}
+              labelMode={labelMode}
+              onSelect={setSelectedSlug}
             />
           )}
         </div>

--- a/frontend/components/ForceGraphCanvas.tsx
+++ b/frontend/components/ForceGraphCanvas.tsx
@@ -1,20 +1,693 @@
 "use client";
 
-import ForceGraph2D from "react-force-graph-2d";
-import type { MutableRefObject } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import type { GraphEdge, GraphNode, GraphResponse } from "@/lib/api";
+import {
+  buildSpatialGrid,
+  fitCamera,
+  hitTestSpatialGrid,
+  interpolatePositions,
+  nodeRadius,
+  screenToWorld,
+  zoomAroundPoint,
+  type Camera,
+  type SpatialGrid,
+  type Viewport,
+} from "@/lib/graphGeometry";
+import {
+  initialGraphPositions,
+  layoutNodes,
+  positionsFromResponse,
+  readCachedLayout,
+  topologyFingerprint,
+  visibleLinks,
+  writeCachedLayout,
+  type GraphPosition,
+  type LayoutResponse,
+  type LayoutStart,
+} from "@/lib/graphLayout";
 
-// Thin client wrapper so the graph page can dynamic-import canvas code while
-// still reaching the real ForceGraph2D instance. next/dynamic's
-// LoadableComponent does not forward refs; graphRef is a regular prop instead.
-type ForceGraphCanvasProps = {
-  graphRef: MutableRefObject<unknown>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} & Record<string, any>;
+export type GraphLabelMode = "hubs" | "all" | "off";
+export type ForceGraphCanvasHandle = Readonly<{
+  recenter(): void;
+  relax(): void;
+}>;
 
-export default function ForceGraphCanvas({
-  graphRef,
-  ...props
-}: ForceGraphCanvasProps) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return <ForceGraph2D ref={graphRef as any} {...props} />;
+type ForceGraphCanvasProps = Readonly<{
+  graph: GraphResponse;
+  tenant?: string;
+  sectionFilter: string;
+  selectedSlug: string | null;
+  labelMode: GraphLabelMode;
+  onSelect(slug: string | null): void;
+}>;
+
+type PointerGesture = {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  camera: Camera;
+  nodeId: string | null;
+  moved: boolean;
+};
+
+const SECTION_COLORS: Readonly<Record<string, string>> = {
+  entities: "#3b82f6",
+  concepts: "#8b5cf6",
+  decisions: "#10b981",
+  sources: "#94a3b8",
+  queries: "#f59e0b",
+  projects: "#ff6a00",
+  root: "#0e0e10",
+  other: "#6b7280",
+};
+
+const TIER_RING: Readonly<Record<string, string>> = {
+  public: "#10b981",
+  recruiter: "#3b82f6",
+  friend: "#8b5cf6",
+  private: "#ef4444",
+};
+
+const LAYOUT_MOTION_MS = 220;
+const CAMERA_MOTION_MS = 220;
+const TEXT_CACHE_LIMIT = 512;
+
+function edgePath(edges: ReadonlyArray<GraphEdge>, positions: ReadonlyMap<string, GraphPosition>): Path2D {
+  const path = new Path2D();
+  for (const edge of edges) {
+    const source = positions.get(edge.source);
+    const target = positions.get(edge.target);
+    if (!source || !target) continue;
+    path.moveTo(source.x, source.y);
+    path.lineTo(target.x, target.y);
+  }
+  return path;
 }
+
+function pointInCanvas(
+  event: Pick<PointerEvent, "clientX" | "clientY">,
+  canvas: HTMLCanvasElement,
+): GraphPosition {
+  const rect = canvas.getBoundingClientRect();
+  return { x: event.clientX - rect.left, y: event.clientY - rect.top };
+}
+
+function rectanglesOverlap(
+  left: Readonly<{ x: number; y: number; width: number; height: number }>,
+  right: Readonly<{ x: number; y: number; width: number; height: number }>,
+): boolean {
+  return !(
+    left.x + left.width < right.x ||
+    right.x + right.width < left.x ||
+    left.y + left.height < right.y ||
+    right.y + right.height < left.y
+  );
+}
+
+const ForceGraphCanvas = forwardRef<ForceGraphCanvasHandle, ForceGraphCanvasProps>(
+  function ForceGraphCanvas(
+    { graph, tenant, sectionFilter, selectedSlug, labelMode, onSelect },
+    ref,
+  ) {
+    const hostRef = useRef<HTMLDivElement | null>(null);
+    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const viewportRef = useRef<Viewport>({ width: 1, height: 1 });
+    const cameraRef = useRef<Camera>({ x: 0, y: 0, scale: 1 });
+    const positionsRef = useRef<Map<string, GraphPosition>>(new Map());
+    const spatialGridRef = useRef<SpatialGrid>(new Map());
+    const baselinePathRef = useRef<Path2D | null>(null);
+    const focusedPathRef = useRef<Path2D | null>(null);
+    const visibleNodesRef = useRef<GraphNode[]>([]);
+    const rankedNodesRef = useRef<GraphNode[]>([]);
+    const visibleEdgesRef = useRef<GraphEdge[]>([]);
+    const nodesByIdRef = useRef<Map<string, GraphNode>>(new Map());
+    const adjacencyRef = useRef<Map<string, Set<string>>>(new Map());
+    const selectedSlugRef = useRef(selectedSlug);
+    const labelModeRef = useRef(labelMode);
+    const hoverRef = useRef<string | null>(null);
+    const workerRef = useRef<Worker | null>(null);
+    const generationRef = useRef(0);
+    const drawFrameRef = useRef<number | null>(null);
+    const positionIndexesDirtyRef = useRef(false);
+    const motionFrameRef = useRef<number | null>(null);
+    const cameraFrameRef = useRef<number | null>(null);
+    const pointerRef = useRef<PointerGesture | null>(null);
+    const textWidthsRef = useRef<Map<string, number>>(new Map());
+    const reducedMotionRef = useRef(false);
+    const userNavigatedRef = useRef(false);
+    const layoutReadyRef = useRef(false);
+    const topologyRef = useRef("");
+    const tenantRef = useRef(tenant);
+    const drawRef = useRef<() => void>(() => undefined);
+    const startLayoutRef = useRef<() => void>(() => undefined);
+
+    const fingerprint = useMemo(() => topologyFingerprint(graph), [graph]);
+    const nodesById = useMemo(
+      () => new Map(graph.nodes.map((node) => [node.slug, node])),
+      [graph],
+    );
+    const adjacency = useMemo(() => {
+      const result = new Map<string, Set<string>>();
+      for (const edge of graph.edges) {
+        const source = result.get(edge.source) ?? new Set<string>();
+        source.add(edge.target);
+        result.set(edge.source, source);
+        const target = result.get(edge.target) ?? new Set<string>();
+        target.add(edge.source);
+        result.set(edge.target, target);
+      }
+      return result;
+    }, [graph]);
+    const visibleNodes = useMemo(
+      () => sectionFilter
+        ? graph.nodes.filter((node) => node.section === sectionFilter)
+        : graph.nodes,
+      [graph, sectionFilter],
+    );
+    const visibleNodeIds = useMemo(
+      () => new Set(visibleNodes.map((node) => node.slug)),
+      [visibleNodes],
+    );
+    const rankedNodes = useMemo(
+      () => [...visibleNodes].sort((left, right) => right.degree - left.degree),
+      [visibleNodes],
+    );
+    const visibleEdges = useMemo(
+      () => visibleLinks(graph.edges, visibleNodeIds),
+      [graph, visibleNodeIds],
+    );
+
+    const rebuildPositionIndexes = useCallback(() => {
+      positionIndexesDirtyRef.current = false;
+      const nodeIds = visibleNodesRef.current.map((node) => node.slug);
+      spatialGridRef.current = buildSpatialGrid(nodeIds, positionsRef.current);
+      baselinePathRef.current = edgePath(visibleEdgesRef.current, positionsRef.current);
+      const selected = selectedSlugRef.current;
+      focusedPathRef.current = selected
+        ? edgePath(
+            visibleEdgesRef.current.filter(
+              (edge) => edge.source === selected || edge.target === selected,
+            ),
+            positionsRef.current,
+          )
+        : null;
+    }, []);
+
+    const requestDraw = useCallback(() => {
+      if (drawFrameRef.current !== null) return;
+      drawFrameRef.current = window.requestAnimationFrame(() => {
+        drawFrameRef.current = null;
+        if (positionIndexesDirtyRef.current) rebuildPositionIndexes();
+        drawRef.current();
+      });
+    }, [rebuildPositionIndexes]);
+
+    const measureText = useCallback((context: CanvasRenderingContext2D, key: string, text: string) => {
+      const cache = textWidthsRef.current;
+      const cached = cache.get(key);
+      if (cached !== undefined) {
+        cache.delete(key);
+        cache.set(key, cached);
+        return cached;
+      }
+      const width = context.measureText(text).width;
+      cache.set(key, width);
+      if (cache.size > TEXT_CACHE_LIMIT) {
+        const oldest = cache.keys().next().value;
+        if (typeof oldest === "string") cache.delete(oldest);
+      }
+      return width;
+    }, []);
+
+    drawRef.current = () => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const context = canvas.getContext("2d");
+      if (!context) return;
+      const viewport = viewportRef.current;
+      const dpr = Math.min(2, Math.max(1, window.devicePixelRatio || 1));
+      const camera = cameraRef.current;
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
+      context.clearRect(0, 0, viewport.width, viewport.height);
+      context.fillStyle = "#fafaf7";
+      context.fillRect(0, 0, viewport.width, viewport.height);
+      context.save();
+      context.translate(camera.x, camera.y);
+      context.scale(camera.scale, camera.scale);
+      if (baselinePathRef.current) {
+        context.strokeStyle = "rgba(14,14,16,0.12)";
+        context.lineWidth = 0.7 / camera.scale;
+        context.stroke(baselinePathRef.current);
+      }
+      if (focusedPathRef.current) {
+        context.strokeStyle = "rgba(255,106,0,0.65)";
+        context.lineWidth = 1.8 / camera.scale;
+        context.stroke(focusedPathRef.current);
+      }
+      const selected = selectedSlugRef.current;
+      const hovered = hoverRef.current;
+      const neighbors = selected ? adjacencyRef.current.get(selected) ?? new Set<string>() : new Set<string>();
+      for (const node of visibleNodesRef.current) {
+        const position = positionsRef.current.get(node.slug);
+        if (!position) continue;
+        const isSelected = node.slug === selected;
+        const isHovered = node.slug === hovered;
+        const isNeighbor = neighbors.has(node.slug);
+        context.globalAlpha = selected && !isSelected && !isNeighbor ? 0.2 : 1;
+        context.beginPath();
+        context.arc(position.x, position.y, nodeRadius(node.degree), 0, Math.PI * 2);
+        context.fillStyle = SECTION_COLORS[node.section] ?? SECTION_COLORS.other;
+        context.fill();
+        context.lineWidth = isSelected ? 3 : isHovered ? 2 : 1.5;
+        context.strokeStyle = isSelected ? "#0e0e10" : TIER_RING[node.tier] ?? "#999999";
+        context.stroke();
+      }
+      context.globalAlpha = 1;
+      context.restore();
+
+      const forcedIds = [selected, hovered].filter((id): id is string => id !== null);
+      const maxLabels = Math.max(1, Math.min(180, Math.floor((viewport.width * viewport.height) / 4_000)));
+      const mode = labelModeRef.current;
+      const onScreen = mode === "off" ? [] : rankedNodesRef.current.filter((node) => {
+        const position = positionsRef.current.get(node.slug);
+        if (!position) return false;
+        const x = camera.x + position.x * camera.scale;
+        const y = camera.y + position.y * camera.scale;
+        return x >= 0 && x <= viewport.width && y >= 0 && y <= viewport.height;
+      });
+      const ordinary = mode === "hubs" ? onScreen.slice(0, 12) : onScreen.slice(0, maxLabels * 2);
+      const candidateIds = [...new Set([...forcedIds, ...ordinary.map((node) => node.slug)])];
+      const occupied: Array<{ x: number; y: number; width: number; height: number }> = [];
+      let painted = 0;
+      for (const id of candidateIds) {
+        const forced = forcedIds.includes(id);
+        if (!forced && painted >= maxLabels) break;
+        const node = nodesByIdRef.current.get(id);
+        const position = positionsRef.current.get(id);
+        if (!node || !position) continue;
+        const title = forced || camera.scale > 2 || node.title.length <= 28
+          ? node.title
+          : `${node.title.slice(0, 26)}…`;
+        const font = forced ? "600 12px ui-sans-serif" : "11px ui-sans-serif";
+        context.font = font;
+        const width = measureText(context, `${forced ? "600" : "400"}\u0000${title}`, title);
+        const screenX = camera.x + position.x * camera.scale;
+        const screenY = camera.y + position.y * camera.scale;
+        const radius = nodeRadius(node.degree) * camera.scale;
+        const rect = { x: screenX - width / 2 - 4, y: screenY + radius + 4, width: width + 8, height: 17 };
+        if (!forced && occupied.some((other) => rectanglesOverlap(rect, other))) continue;
+        context.fillStyle = forced ? "rgba(250,250,247,0.96)" : "rgba(250,250,247,0.86)";
+        context.fillRect(rect.x, rect.y, rect.width, rect.height);
+        context.fillStyle = forced ? "#0e0e10" : "#525258";
+        context.textAlign = "center";
+        context.textBaseline = "top";
+        context.fillText(title, screenX, rect.y + 2);
+        occupied.push(rect);
+        painted += 1;
+      }
+    };
+
+    const cancelCameraMotion = useCallback(() => {
+      if (cameraFrameRef.current !== null) window.cancelAnimationFrame(cameraFrameRef.current);
+      cameraFrameRef.current = null;
+    }, []);
+
+    const animateCamera = useCallback((target: Camera) => {
+      cancelCameraMotion();
+      if (reducedMotionRef.current) {
+        cameraRef.current = target;
+        requestDraw();
+        return;
+      }
+      const start = cameraRef.current;
+      const startedAt = performance.now();
+      const step = (now: number) => {
+        const progress = Math.min(1, (now - startedAt) / CAMERA_MOTION_MS);
+        const eased = 1 - Math.pow(1 - progress, 3);
+        cameraRef.current = {
+          x: start.x + (target.x - start.x) * eased,
+          y: start.y + (target.y - start.y) * eased,
+          scale: start.scale + (target.scale - start.scale) * eased,
+        };
+        requestDraw();
+        if (progress < 1) cameraFrameRef.current = window.requestAnimationFrame(step);
+        else cameraFrameRef.current = null;
+      };
+      cameraFrameRef.current = window.requestAnimationFrame(step);
+    }, [cancelCameraMotion, requestDraw]);
+
+    const recenter = useCallback((animate = true) => {
+      const target = fitCamera(
+        visibleNodesRef.current,
+        positionsRef.current,
+        viewportRef.current,
+      );
+      if (animate) animateCamera(target);
+      else {
+        cameraRef.current = target;
+        requestDraw();
+      }
+    }, [animateCamera, requestDraw]);
+
+    const finishLayout = useCallback((response: LayoutResponse) => {
+      if (response.generation !== generationRef.current) return;
+      generationRef.current += 1;
+      workerRef.current?.terminate();
+      workerRef.current = null;
+      layoutReadyRef.current = true;
+      if (response.kind === "error") {
+        if (!userNavigatedRef.current) recenter(false);
+        requestDraw();
+        return;
+      }
+      const target = positionsFromResponse(response);
+      if (target.size !== graph.nodes.length || graph.nodes.some((node) => !target.has(node.slug))) {
+        if (!userNavigatedRef.current) recenter(false);
+        return;
+      }
+      writeCachedLayout(tenantRef.current, topologyRef.current, target);
+      const start = new Map(positionsRef.current);
+      const applyFinal = () => {
+        positionsRef.current = target;
+        rebuildPositionIndexes();
+        requestDraw();
+        if (!userNavigatedRef.current) recenter(false);
+      };
+      if (reducedMotionRef.current) {
+        applyFinal();
+        return;
+      }
+      if (motionFrameRef.current !== null) window.cancelAnimationFrame(motionFrameRef.current);
+      const startedAt = performance.now();
+      const step = (now: number) => {
+        const progress = Math.min(1, (now - startedAt) / LAYOUT_MOTION_MS);
+        positionsRef.current = interpolatePositions(start, target, progress);
+        rebuildPositionIndexes();
+        requestDraw();
+        if (progress < 1) motionFrameRef.current = window.requestAnimationFrame(step);
+        else {
+          motionFrameRef.current = null;
+          applyFinal();
+        }
+      };
+      motionFrameRef.current = window.requestAnimationFrame(step);
+    }, [graph.nodes, rebuildPositionIndexes, recenter, requestDraw]);
+
+    const startLayout = useCallback(() => {
+      if (motionFrameRef.current !== null) window.cancelAnimationFrame(motionFrameRef.current);
+      motionFrameRef.current = null;
+      workerRef.current?.terminate();
+      workerRef.current = null;
+      generationRef.current += 1;
+      const generation = generationRef.current;
+      if (typeof Worker === "undefined") {
+        layoutReadyRef.current = true;
+        if (!userNavigatedRef.current) recenter(false);
+        requestDraw();
+        return;
+      }
+      try {
+        const worker = new Worker(new URL("../workers/graphLayout.worker.ts", import.meta.url), { type: "module" });
+        workerRef.current = worker;
+        worker.onmessage = (event: MessageEvent<LayoutResponse>) => finishLayout(event.data);
+        worker.onerror = () => finishLayout({ kind: "error", generation, message: "layout worker failed" });
+        const message: LayoutStart = {
+          kind: "start",
+          generation,
+          nodes: layoutNodes(graph, positionsRef.current),
+          links: graph.edges.map((edge) => ({ source: edge.source, target: edge.target })),
+        };
+        worker.postMessage(message);
+      } catch {
+        finishLayout({ kind: "error", generation, message: "layout worker unavailable" });
+      }
+    }, [finishLayout, graph, recenter, requestDraw]);
+    startLayoutRef.current = startLayout;
+
+    useImperativeHandle(ref, () => ({
+      recenter: () => {
+        userNavigatedRef.current = true;
+        recenter(true);
+      },
+      relax: () => startLayoutRef.current(),
+    }), [recenter]);
+
+    useEffect(() => {
+      const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+      const update = () => { reducedMotionRef.current = query.matches; };
+      update();
+      query.addEventListener("change", update);
+      return () => query.removeEventListener("change", update);
+    }, []);
+
+    useEffect(() => {
+      nodesByIdRef.current = nodesById;
+      adjacencyRef.current = adjacency;
+    }, [adjacency, nodesById]);
+
+    useEffect(() => {
+      selectedSlugRef.current = selectedSlug;
+      focusedPathRef.current = selectedSlug
+        ? edgePath(
+            visibleEdgesRef.current.filter(
+              (edge) => edge.source === selectedSlug || edge.target === selectedSlug,
+            ),
+            positionsRef.current,
+          )
+        : null;
+      requestDraw();
+    }, [requestDraw, selectedSlug]);
+
+    useEffect(() => {
+      labelModeRef.current = labelMode;
+      requestDraw();
+    }, [labelMode, requestDraw]);
+
+    useEffect(() => {
+      visibleNodesRef.current = visibleNodes;
+      rankedNodesRef.current = rankedNodes;
+      visibleEdgesRef.current = visibleEdges;
+      rebuildPositionIndexes();
+      if (layoutReadyRef.current) recenter(true);
+      else requestDraw();
+    }, [rankedNodes, rebuildPositionIndexes, recenter, requestDraw, visibleEdges, visibleNodes]);
+
+    useEffect(() => {
+      topologyRef.current = fingerprint;
+      tenantRef.current = tenant;
+      userNavigatedRef.current = false;
+      const cached = readCachedLayout(tenant, fingerprint);
+      positionsRef.current = cached ?? initialGraphPositions(graph);
+      layoutReadyRef.current = cached !== null;
+      rebuildPositionIndexes();
+      if (cached) recenter(false);
+      else startLayout();
+      return () => {
+        generationRef.current += 1;
+        workerRef.current?.terminate();
+        workerRef.current = null;
+        if (motionFrameRef.current !== null) window.cancelAnimationFrame(motionFrameRef.current);
+        motionFrameRef.current = null;
+      };
+    }, [fingerprint, graph, rebuildPositionIndexes, recenter, startLayout, tenant]);
+
+    useEffect(() => {
+      const host = hostRef.current;
+      const canvas = canvasRef.current;
+      if (!host || !canvas) return;
+      const observer = new ResizeObserver((entries) => {
+        const rect = entries[0]?.contentRect;
+        if (!rect) return;
+        const previous = viewportRef.current;
+        const viewport = {
+          width: Math.max(1, Math.floor(rect.width)),
+          height: Math.max(1, Math.floor(rect.height)),
+        };
+        viewportRef.current = viewport;
+        const dpr = Math.min(2, Math.max(1, window.devicePixelRatio || 1));
+        canvas.width = Math.round(viewport.width * dpr);
+        canvas.height = Math.round(viewport.height * dpr);
+        canvas.style.width = `${viewport.width}px`;
+        canvas.style.height = `${viewport.height}px`;
+        if (previous.width <= 1 && layoutReadyRef.current && !userNavigatedRef.current) recenter(false);
+        else {
+          cameraRef.current = {
+            ...cameraRef.current,
+            x: cameraRef.current.x + (viewport.width - previous.width) / 2,
+            y: cameraRef.current.y + (viewport.height - previous.height) / 2,
+          };
+          requestDraw();
+        }
+      });
+      observer.observe(host);
+      return () => observer.disconnect();
+    }, [recenter, requestDraw]);
+
+    useEffect(() => () => {
+      if (drawFrameRef.current !== null) window.cancelAnimationFrame(drawFrameRef.current);
+      if (cameraFrameRef.current !== null) window.cancelAnimationFrame(cameraFrameRef.current);
+      drawFrameRef.current = null;
+      cameraFrameRef.current = null;
+      workerRef.current?.terminate();
+    }, []);
+
+    const hitTest = useCallback((point: GraphPosition) => {
+      const world = screenToWorld(point, cameraRef.current);
+      return hitTestSpatialGrid(
+        spatialGridRef.current,
+        positionsRef.current,
+        nodesByIdRef.current,
+        world,
+        9 / cameraRef.current.scale,
+      );
+    }, []);
+
+    const handlePointerDown = (event: ReactPointerEvent<HTMLCanvasElement>) => {
+      if (event.button !== 0 || pointerRef.current) return;
+      cancelCameraMotion();
+      const point = pointInCanvas(event.nativeEvent, event.currentTarget);
+      pointerRef.current = {
+        pointerId: event.pointerId,
+        startX: point.x,
+        startY: point.y,
+        camera: cameraRef.current,
+        nodeId: hitTest(point),
+        moved: false,
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+    };
+
+    const handlePointerMove = (event: ReactPointerEvent<HTMLCanvasElement>) => {
+      const point = pointInCanvas(event.nativeEvent, event.currentTarget);
+      const gesture = pointerRef.current;
+      if (!gesture || gesture.pointerId !== event.pointerId) {
+        const hovered = hitTest(point);
+        if (hovered !== hoverRef.current) {
+          hoverRef.current = hovered;
+          event.currentTarget.style.cursor = hovered ? "pointer" : "grab";
+          requestDraw();
+        }
+        return;
+      }
+      const dx = point.x - gesture.startX;
+      const dy = point.y - gesture.startY;
+      if (Math.hypot(dx, dy) > 3) gesture.moved = true;
+      if (!gesture.moved) return;
+      if (gesture.nodeId) {
+        if (gesture.moved && workerRef.current) {
+          generationRef.current += 1;
+          workerRef.current.terminate();
+          workerRef.current = null;
+          layoutReadyRef.current = true;
+        }
+        if (motionFrameRef.current !== null) window.cancelAnimationFrame(motionFrameRef.current);
+        motionFrameRef.current = null;
+        userNavigatedRef.current = true;
+        positionsRef.current.set(gesture.nodeId, screenToWorld(point, cameraRef.current));
+        positionIndexesDirtyRef.current = true;
+      } else {
+        userNavigatedRef.current = true;
+        cameraRef.current = { ...gesture.camera, x: gesture.camera.x + dx, y: gesture.camera.y + dy };
+      }
+      event.currentTarget.style.cursor = "grabbing";
+      requestDraw();
+    };
+
+    const finishPointer = (event: ReactPointerEvent<HTMLCanvasElement>, cancelled: boolean) => {
+      const gesture = pointerRef.current;
+      if (!gesture || gesture.pointerId !== event.pointerId) return;
+      pointerRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      event.currentTarget.style.cursor = "grab";
+      if (cancelled) return;
+      if (gesture.nodeId) {
+        if (!gesture.moved) onSelect(gesture.nodeId);
+        else writeCachedLayout(tenantRef.current, topologyRef.current, positionsRef.current);
+      } else if (!gesture.moved) onSelect(null);
+    };
+
+    useEffect(() => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const handleWheel = (event: WheelEvent) => {
+        event.preventDefault();
+        cancelCameraMotion();
+        userNavigatedRef.current = true;
+        const point = pointInCanvas(event, canvas);
+        const delta = event.deltaY * (event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? viewportRef.current.height : 1);
+        cameraRef.current = zoomAroundPoint(
+          cameraRef.current,
+          point,
+          cameraRef.current.scale * Math.exp(-delta * 0.0015),
+        );
+        requestDraw();
+      };
+      canvas.addEventListener("wheel", handleWheel, { passive: false });
+      return () => canvas.removeEventListener("wheel", handleWheel);
+    }, [cancelCameraMotion, requestDraw]);
+
+    const handleKeyDown = (event: ReactKeyboardEvent<HTMLCanvasElement>) => {
+      cancelCameraMotion();
+      const camera = cameraRef.current;
+      const pan = 36;
+      if (event.key === "Escape") onSelect(null);
+      else if (event.key === "0") {
+        userNavigatedRef.current = true;
+        recenter(false);
+      }
+      else if (event.key === "+" || event.key === "=") {
+        userNavigatedRef.current = true;
+        cameraRef.current = zoomAroundPoint(camera, { x: viewportRef.current.width / 2, y: viewportRef.current.height / 2 }, camera.scale * 1.2);
+      } else if (event.key === "-" || event.key === "_") {
+        userNavigatedRef.current = true;
+        cameraRef.current = zoomAroundPoint(camera, { x: viewportRef.current.width / 2, y: viewportRef.current.height / 2 }, camera.scale / 1.2);
+      } else if (event.key === "ArrowLeft") {
+        userNavigatedRef.current = true;
+        cameraRef.current = { ...camera, x: camera.x + pan };
+      } else if (event.key === "ArrowRight") {
+        userNavigatedRef.current = true;
+        cameraRef.current = { ...camera, x: camera.x - pan };
+      } else if (event.key === "ArrowUp") {
+        userNavigatedRef.current = true;
+        cameraRef.current = { ...camera, y: camera.y + pan };
+      } else if (event.key === "ArrowDown") {
+        userNavigatedRef.current = true;
+        cameraRef.current = { ...camera, y: camera.y - pan };
+      } else return;
+      event.preventDefault();
+      requestDraw();
+    };
+
+    return (
+      <div ref={hostRef} className="h-full w-full min-w-0 bg-[#fafaf7]">
+        <canvas
+          ref={canvasRef}
+          className="block h-full w-full touch-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent"
+          role="application"
+          tabIndex={0}
+          aria-label="Knowledge graph. Drag to pan or move nodes. Scroll to zoom. Arrow keys pan, plus and minus zoom, zero recenters, and Escape clears selection."
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={(event) => finishPointer(event, false)}
+          onPointerCancel={(event) => finishPointer(event, true)}
+          onLostPointerCapture={() => { pointerRef.current = null; }}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+    );
+  },
+);
+
+export default ForceGraphCanvas;

--- a/frontend/lib/graphGeometry.ts
+++ b/frontend/lib/graphGeometry.ts
@@ -1,0 +1,130 @@
+import type { GraphNode } from "@/lib/api";
+import type { GraphPosition, GraphPositions } from "@/lib/graphLayout";
+import { mainMassNodeFilter } from "@/lib/graphCamera";
+
+export type Camera = Readonly<{ x: number; y: number; scale: number }>;
+export type Viewport = Readonly<{ width: number; height: number }>;
+
+export function nodeRadius(degree: number): number {
+  return Math.max(4, Math.min(14, 4 + Math.sqrt(Math.max(1, degree)) * 1.6));
+}
+
+export function fitCamera(
+  nodes: ReadonlyArray<Pick<GraphNode, "slug" | "degree">>,
+  positions: GraphPositions,
+  viewport: Viewport,
+  padding = 40,
+): Camera {
+  if (nodes.length === 0 || viewport.width <= 0 || viewport.height <= 0) {
+    return { x: 0, y: 0, scale: 1 };
+  }
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  const positioned = nodes.map((node) => ({ ...node, ...positions.get(node.slug) }));
+  const mainMass = positioned.filter(mainMassNodeFilter(positioned));
+  const fittedNodes = mainMass.length > 0 ? mainMass : nodes;
+  for (const node of fittedNodes) {
+    const position = positions.get(node.slug);
+    if (!position) continue;
+    const radius = nodeRadius(node.degree);
+    minX = Math.min(minX, position.x - radius);
+    maxX = Math.max(maxX, position.x + radius);
+    minY = Math.min(minY, position.y - radius);
+    maxY = Math.max(maxY, position.y + radius);
+  }
+  if (!Number.isFinite(minX)) return { x: 0, y: 0, scale: 1 };
+  const worldWidth = Math.max(32, maxX - minX);
+  const worldHeight = Math.max(32, maxY - minY);
+  const usableWidth = Math.max(1, viewport.width - padding * 2);
+  const usableHeight = Math.max(1, viewport.height - padding * 2);
+  const scale = Math.max(0.04, Math.min(4, usableWidth / worldWidth, usableHeight / worldHeight));
+  return {
+    x: viewport.width / 2 - ((minX + maxX) / 2) * scale,
+    y: viewport.height / 2 - ((minY + maxY) / 2) * scale,
+    scale,
+  };
+}
+
+export function screenToWorld(point: GraphPosition, camera: Camera): GraphPosition {
+  return { x: (point.x - camera.x) / camera.scale, y: (point.y - camera.y) / camera.scale };
+}
+
+export function zoomAroundPoint(
+  camera: Camera,
+  point: GraphPosition,
+  scale: number,
+): Camera {
+  const boundedScale = Math.max(0.03, Math.min(8, scale));
+  const world = screenToWorld(point, camera);
+  return {
+    x: point.x - world.x * boundedScale,
+    y: point.y - world.y * boundedScale,
+    scale: boundedScale,
+  };
+}
+
+const GRID_CELL = 48;
+export type SpatialGrid = ReadonlyMap<string, ReadonlyArray<string>>;
+
+export function buildSpatialGrid(nodeIds: ReadonlyArray<string>, positions: GraphPositions): SpatialGrid {
+  const mutable = new Map<string, string[]>();
+  for (const id of nodeIds) {
+    const position = positions.get(id);
+    if (!position) continue;
+    const key = `${Math.floor(position.x / GRID_CELL)},${Math.floor(position.y / GRID_CELL)}`;
+    const entries = mutable.get(key);
+    if (entries) entries.push(id);
+    else mutable.set(key, [id]);
+  }
+  return mutable;
+}
+
+export function hitTestSpatialGrid(
+  grid: SpatialGrid,
+  positions: GraphPositions,
+  nodesById: ReadonlyMap<string, Pick<GraphNode, "degree">>,
+  point: GraphPosition,
+  worldTolerance: number,
+): string | null {
+  const reach = Math.max(1, Math.ceil(worldTolerance / GRID_CELL));
+  const centerX = Math.floor(point.x / GRID_CELL);
+  const centerY = Math.floor(point.y / GRID_CELL);
+  let winner: string | null = null;
+  let winnerDistance = Infinity;
+  for (let dx = -reach; dx <= reach; dx += 1) {
+    for (let dy = -reach; dy <= reach; dy += 1) {
+      for (const id of grid.get(`${centerX + dx},${centerY + dy}`) ?? []) {
+        const position = positions.get(id);
+        const node = nodesById.get(id);
+        if (!position || !node) continue;
+        const distance = Math.hypot(point.x - position.x, point.y - position.y);
+        const hitRadius = Math.max(nodeRadius(node.degree), worldTolerance);
+        if (distance <= hitRadius && distance < winnerDistance) {
+          winner = id;
+          winnerDistance = distance;
+        }
+      }
+    }
+  }
+  return winner;
+}
+
+export function interpolatePositions(
+  from: GraphPositions,
+  to: GraphPositions,
+  progress: number,
+): Map<string, GraphPosition> {
+  const bounded = Math.max(0, Math.min(1, progress));
+  const eased = 1 - Math.pow(1 - bounded, 3);
+  return new Map(
+    Array.from(to, ([id, target]) => {
+      const start = from.get(id) ?? target;
+      return [id, {
+        x: start.x + (target.x - start.x) * eased,
+        y: start.y + (target.y - start.y) * eased,
+      }];
+    }),
+  );
+}

--- a/frontend/lib/graphLayout.ts
+++ b/frontend/lib/graphLayout.ts
@@ -1,0 +1,129 @@
+import type { GraphEdge, GraphResponse } from "@/lib/api";
+
+export type GraphPosition = Readonly<{ x: number; y: number }>;
+export type GraphPositions = ReadonlyMap<string, GraphPosition>;
+export type LayoutNode = Readonly<{ id: string; degree: number; x: number; y: number }>;
+export type LayoutStart = Readonly<{
+  kind: "start";
+  generation: number;
+  nodes: LayoutNode[];
+  links: GraphEdge[];
+}>;
+export type LayoutSuccess = Readonly<{
+  kind: "positions";
+  generation: number;
+  positions: Array<Readonly<{ id: string; x: number; y: number }>>;
+}>;
+export type LayoutFailure = Readonly<{
+  kind: "error";
+  generation: number;
+  message: string;
+}>;
+export type LayoutResponse = LayoutSuccess | LayoutFailure;
+
+const CACHE_LIMIT = 4;
+const SINGLE_TENANT_SCOPE = "single-tenant";
+const layoutCache = new Map<string, Map<string, GraphPosition>>();
+let activeTenantScope: string | null = null;
+
+function tenantScope(tenant?: string): string {
+  return tenant || SINGLE_TENANT_SCOPE;
+}
+
+function cacheKey(tenant: string | undefined, fingerprint: string): string {
+  return `${tenantScope(tenant)}\u0000${fingerprint}`;
+}
+
+export function activateLayoutCacheTenant(tenant?: string): void {
+  const nextScope = tenantScope(tenant);
+  if (activeTenantScope === nextScope) return;
+  activeTenantScope = nextScope;
+  for (const key of layoutCache.keys()) {
+    if (!key.startsWith(`${nextScope}\u0000`)) layoutCache.delete(key);
+  }
+}
+
+export function readCachedLayout(
+  tenant: string | undefined,
+  fingerprint: string,
+): Map<string, GraphPosition> | null {
+  activateLayoutCacheTenant(tenant);
+  const key = cacheKey(tenant, fingerprint);
+  const cached = layoutCache.get(key);
+  if (!cached) return null;
+  layoutCache.delete(key);
+  layoutCache.set(key, cached);
+  return new Map(cached);
+}
+
+export function writeCachedLayout(
+  tenant: string | undefined,
+  fingerprint: string,
+  positions: GraphPositions,
+): void {
+  activateLayoutCacheTenant(tenant);
+  const key = cacheKey(tenant, fingerprint);
+  layoutCache.delete(key);
+  layoutCache.set(key, new Map(positions));
+  while (layoutCache.size > CACHE_LIMIT) {
+    const oldest = layoutCache.keys().next().value;
+    if (typeof oldest !== "string") break;
+    layoutCache.delete(oldest);
+  }
+}
+
+export function clearLayoutCacheForTests(): void {
+  layoutCache.clear();
+  activeTenantScope = null;
+}
+
+function hashText(text: string, seed = 2166136261): number {
+  let hash = seed;
+  for (let index = 0; index < text.length; index += 1) {
+    hash = Math.imul(hash ^ text.charCodeAt(index), 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function topologyFingerprint(graph: GraphResponse): string {
+  const nodes = graph.nodes.map((node) => node.slug).sort();
+  const edges = graph.edges.map((edge) => `${edge.source}\u0001${edge.target}`).sort();
+  let hash = hashText(`${nodes.length}:${edges.length}`);
+  for (const node of nodes) hash = hashText(node, hash);
+  for (const edge of edges) hash = hashText(edge, hash);
+  return `${nodes.length}-${edges.length}-${hash.toString(36)}`;
+}
+
+export function stableInitialPosition(rank = 0): GraphPosition {
+  const angle = rank * Math.PI * (3 - Math.sqrt(5));
+  const radius = 10 * Math.sqrt(0.5 + rank);
+  return { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius };
+}
+
+export function initialGraphPositions(graph: GraphResponse): Map<string, GraphPosition> {
+  return new Map(graph.nodes.map((node, rank) => [node.slug, stableInitialPosition(rank)]));
+}
+
+export function layoutNodes(graph: GraphResponse, positions: GraphPositions): LayoutNode[] {
+  return graph.nodes.map((node, rank) => {
+    const position = positions.get(node.slug) ?? stableInitialPosition(rank);
+    return { id: node.slug, degree: node.degree, x: position.x, y: position.y };
+  });
+}
+
+export function positionsFromResponse(response: LayoutSuccess): Map<string, GraphPosition> {
+  return new Map(
+    response.positions
+      .filter((position) => Number.isFinite(position.x) && Number.isFinite(position.y))
+      .map((position) => [position.id, { x: position.x, y: position.y }]),
+  );
+}
+
+export function visibleLinks(
+  links: ReadonlyArray<GraphEdge>,
+  visibleIds: ReadonlySet<string>,
+): GraphEdge[] {
+  return links
+    .filter((link) => visibleIds.has(link.source) && visibleIds.has(link.target))
+    .map((link) => ({ source: link.source, target: link.target }));
+}

--- a/frontend/tests/ForceGraphCanvas.test.tsx
+++ b/frontend/tests/ForceGraphCanvas.test.tsx
@@ -1,0 +1,329 @@
+import { act, createRef, StrictMode } from "react";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ForceGraphCanvas, { type ForceGraphCanvasHandle } from "@/components/ForceGraphCanvas";
+import type { GraphResponse } from "@/lib/api";
+import { clearLayoutCacheForTests, type LayoutResponse, type LayoutStart } from "@/lib/graphLayout";
+
+const graph: GraphResponse = {
+  nodes: [
+    { slug: "a", title: "A", section: "one", tier: "public", is_anchor: false, degree: 2 },
+    { slug: "b", title: "B", section: "one", tier: "friend", is_anchor: false, degree: 2 },
+    { slug: "c", title: "C", section: "two", tier: "private", is_anchor: false, degree: 2 },
+  ],
+  edges: [
+    { source: "a", target: "b" },
+    { source: "b", target: "c" },
+    { source: "c", target: "a" },
+  ],
+  anchors: [],
+};
+
+class MockPath2D {
+  static instances: MockPath2D[] = [];
+  lineCount = 0;
+
+  constructor() {
+    MockPath2D.instances.push(this);
+  }
+
+  moveTo(): void {}
+
+  lineTo(): void {
+    this.lineCount += 1;
+  }
+}
+
+class MockWorker {
+  static instances: MockWorker[] = [];
+  onmessage: ((event: MessageEvent<LayoutResponse>) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  readonly posted: unknown[] = [];
+  terminated = false;
+
+  constructor() {
+    MockWorker.instances.push(this);
+  }
+
+  postMessage(message: unknown): void {
+    this.posted.push(message);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  emit(response: LayoutResponse): void {
+    this.onmessage?.(new MessageEvent("message", { data: response }));
+  }
+}
+
+let rafCallbacks = new Map<number, FrameRequestCallback>();
+let nextRaf = 1;
+const context = {
+  arc: vi.fn(),
+  beginPath: vi.fn(),
+  clearRect: vi.fn(),
+  fill: vi.fn(),
+  fillRect: vi.fn(),
+  fillText: vi.fn(),
+  measureText: vi.fn((text: string) => ({ width: text.length * 7 })),
+  restore: vi.fn(),
+  save: vi.fn(),
+  scale: vi.fn(),
+  setTransform: vi.fn(),
+  stroke: vi.fn(),
+  translate: vi.fn(),
+};
+
+function flushFrames(time = performance.now() + 500): void {
+  for (let pass = 0; pass < 6 && rafCallbacks.size > 0; pass += 1) {
+    const callbacks = [...rafCallbacks.values()];
+    rafCallbacks = new Map();
+    for (const callback of callbacks) callback(time + pass * 250);
+  }
+}
+
+function isLayoutStart(message: unknown): message is LayoutStart {
+  return Boolean(
+    message &&
+    typeof message === "object" &&
+    "kind" in message &&
+    message.kind === "start" &&
+    "generation" in message &&
+    typeof message.generation === "number" &&
+    "nodes" in message &&
+    Array.isArray(message.nodes) &&
+    "links" in message &&
+    Array.isArray(message.links),
+  );
+}
+
+function startMessage(worker: MockWorker): LayoutStart {
+  const message = worker.posted[0];
+  if (!isLayoutStart(message)) {
+    throw new Error("worker did not receive a layout start message");
+  }
+  return message;
+}
+
+function finalPositions(generation: number, offset = 0): LayoutResponse {
+  return {
+    kind: "positions",
+    generation,
+    positions: graph.nodes.map((node, index) => ({
+      id: node.slug,
+      x: index * 100 + offset,
+      y: index * 50 + offset,
+    })),
+  };
+}
+
+beforeEach(() => {
+  clearLayoutCacheForTests();
+  MockPath2D.instances = [];
+  MockWorker.instances = [];
+  rafCallbacks = new Map();
+  nextRaf = 1;
+  vi.clearAllMocks();
+  vi.stubGlobal("Path2D", MockPath2D);
+  vi.stubGlobal("Worker", MockWorker);
+  vi.stubGlobal("PointerEvent", class extends MouseEvent {
+    readonly pointerId: number;
+    constructor(type: string, options: PointerEventInit) {
+      super(type, options);
+      this.pointerId = options.pointerId ?? 1;
+    }
+  });
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    const id = nextRaf;
+    nextRaf += 1;
+    rafCallbacks.set(id, callback);
+    return id;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => { rafCallbacks.delete(id); });
+  vi.stubGlobal("ResizeObserver", class {
+    constructor(private readonly callback: ResizeObserverCallback) {}
+    observe(target: Element): void {
+      this.callback([
+        {
+          target,
+          contentRect: new DOMRectReadOnly(0, 0, 800, 600),
+          borderBoxSize: [],
+          contentBoxSize: [],
+          devicePixelContentBoxSize: [],
+        },
+      ], this);
+    }
+    disconnect(): void {}
+    unobserve(): void {}
+  });
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: () => ({
+      matches: false,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+    configurable: true,
+    value: () => context,
+  });
+  Object.defineProperty(HTMLCanvasElement.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({ left: 0, top: 0, right: 800, bottom: 600, width: 800, height: 600, x: 0, y: 0, toJSON: () => ({}) }),
+  });
+  Object.defineProperty(HTMLCanvasElement.prototype, "setPointerCapture", { configurable: true, value: vi.fn() });
+  Object.defineProperty(HTMLCanvasElement.prototype, "hasPointerCapture", { configurable: true, value: () => false });
+});
+
+describe("ForceGraphCanvas", () => {
+  it("consumes wheel zoom instead of also scrolling the document", () => {
+    const view = render(<ForceGraphCanvas graph={graph} sectionFilter="" selectedSlug={null} labelMode="off" onSelect={vi.fn()} />);
+    const canvas = view.getByRole("application");
+    const wheel = new WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: 100 });
+    act(() => { canvas.dispatchEvent(wheel); });
+    expect(wheel.defaultPrevented).toBe(true);
+  });
+
+  it("repaints after the Strict Mode effect cleanup and remount", () => {
+    render(<StrictMode><ForceGraphCanvas graph={graph} sectionFilter="" selectedSlug={null} labelMode="off" onSelect={vi.fn()} /></StrictMode>);
+    const active = MockWorker.instances.at(-1);
+    if (!active) throw new Error("no active worker");
+    act(() => { active.emit(finalPositions(startMessage(active).generation)); flushFrames(); });
+    expect(context.stroke).toHaveBeenCalled();
+    expect(rafCallbacks.size).toBe(0);
+  });
+
+  it("gives a dragged node priority over pending layout and batches pointer updates into one frame", () => {
+    const ref = createRef<ForceGraphCanvasHandle>();
+    const view = render(<ForceGraphCanvas ref={ref} graph={graph} sectionFilter="" selectedSlug={null} labelMode="off" onSelect={vi.fn()} />);
+    act(() => { flushFrames(); });
+    const first = MockWorker.instances[0];
+    const start = startMessage(first);
+    const [cameraX, cameraY] = context.translate.mock.lastCall ?? [];
+    const [scale] = context.scale.mock.lastCall ?? [];
+    const node = start.nodes[0];
+    const x = cameraX + node.x * scale;
+    const y = cameraY + node.y * scale;
+    const canvas = view.getByRole("application");
+    act(() => { canvas.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, clientX: x, clientY: y })); });
+    const pathCount = MockPath2D.instances.length;
+    act(() => {
+      for (let offset = 10; offset <= 50; offset += 10) {
+        canvas.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerId: 1, clientX: x + offset, clientY: y }));
+      }
+    });
+    expect(first.terminated).toBe(true);
+    expect(MockPath2D.instances.length).toBe(pathCount);
+    act(() => {
+      canvas.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, clientX: x + 50, clientY: y }));
+      first.emit(finalPositions(start.generation, 999));
+      flushFrames();
+      ref.current?.relax();
+    });
+    const next = startMessage(MockWorker.instances[1]).nodes.find((candidate) => candidate.id === node.id);
+    expect(next?.x).toBeCloseTo(node.x + 50 / scale);
+  });
+
+  it("starts once, redraws final positions, keeps all edges, filters without a worker, and relaxes with a new generation", () => {
+    const ref = createRef<ForceGraphCanvasHandle>();
+    const onSelect = vi.fn();
+    const view = render(
+      <ForceGraphCanvas
+        ref={ref}
+        graph={graph}
+        tenant="tenant-a"
+        sectionFilter=""
+        selectedSlug={null}
+        labelMode="off"
+        onSelect={onSelect}
+      />,
+    );
+    expect(MockWorker.instances).toHaveLength(1);
+    const first = MockWorker.instances[0];
+    const firstStart = startMessage(first);
+    expect(firstStart.links).toEqual(graph.edges);
+    expect(firstStart.links[0]).not.toBe(graph.edges[0]);
+    expect(Math.max(...MockPath2D.instances.map((path) => path.lineCount))).toBe(3);
+
+    act(() => {
+      first.emit(finalPositions(firstStart.generation));
+      flushFrames();
+    });
+    expect(first.terminated).toBe(true);
+    expect(context.stroke).toHaveBeenCalled();
+
+    const pathsBeforeFilter = MockPath2D.instances.length;
+    view.rerender(
+      <ForceGraphCanvas
+        ref={ref}
+        graph={graph}
+        tenant="tenant-a"
+        sectionFilter="one"
+        selectedSlug={null}
+        labelMode="off"
+        onSelect={onSelect}
+      />,
+    );
+    expect(MockWorker.instances).toHaveLength(1);
+    expect(MockPath2D.instances.slice(pathsBeforeFilter).some((path) => path.lineCount === 1)).toBe(true);
+
+    act(() => { ref.current?.relax(); });
+    expect(MockWorker.instances).toHaveLength(2);
+    const second = MockWorker.instances[1];
+    const secondStart = startMessage(second);
+    expect(secondStart.generation).toBeGreaterThan(firstStart.generation);
+    act(() => { first.emit(finalPositions(firstStart.generation, 999)); });
+    expect(second.terminated).toBe(false);
+    act(() => {
+      second.emit(finalPositions(secondStart.generation, 10));
+      flushFrames();
+    });
+    expect(second.terminated).toBe(true);
+    expect(rafCallbacks.size).toBe(0);
+
+    view.unmount();
+    render(
+      <ForceGraphCanvas
+        graph={graph}
+        tenant="tenant-a"
+        sectionFilter=""
+        selectedSlug={null}
+        labelMode="off"
+        onSelect={onSelect}
+      />,
+    );
+    expect(MockWorker.instances).toHaveLength(2);
+  });
+
+  it("stays usable after worker failure and terminates an active worker on unmount", () => {
+    const ref = createRef<ForceGraphCanvasHandle>();
+    const view = render(
+      <ForceGraphCanvas
+        ref={ref}
+        graph={graph}
+        sectionFilter=""
+        selectedSlug={null}
+        labelMode="hubs"
+        onSelect={vi.fn()}
+      />,
+    );
+    const failed = MockWorker.instances[0];
+    act(() => { failed.onerror?.(new ErrorEvent("error")); flushFrames(); });
+    expect(failed.terminated).toBe(true);
+    expect(context.arc).toHaveBeenCalled();
+
+    act(() => { ref.current?.relax(); });
+    const active = MockWorker.instances[1];
+    view.unmount();
+    expect(active.terminated).toBe(true);
+    expect(rafCallbacks.size).toBe(0);
+  });
+});

--- a/frontend/tests/graphGeometry.test.ts
+++ b/frontend/tests/graphGeometry.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSpatialGrid,
+  fitCamera,
+  hitTestSpatialGrid,
+  screenToWorld,
+  zoomAroundPoint,
+} from "@/lib/graphGeometry";
+
+describe("graph geometry", () => {
+  it("fits the connected graph without letting a distant isolate shrink it", () => {
+    const nodes = [{ slug: "a", degree: 1 }, { slug: "b", degree: 1 }, { slug: "isolate", degree: 0 }];
+    const positions = new Map([["a", { x: -100, y: 0 }], ["b", { x: 100, y: 0 }], ["isolate", { x: 20000, y: 20000 }]]);
+    expect(fitCamera(nodes, positions, { width: 800, height: 600 })).toEqual(
+      fitCamera(nodes.slice(0, 2), positions, { width: 800, height: 600 }),
+    );
+  });
+
+  it("fits a singleton with finite padding-aware camera values", () => {
+    const camera = fitCamera(
+      [{ slug: "only", degree: 0 }],
+      new Map([["only", { x: 25, y: -10 }]]),
+      { width: 800, height: 600 },
+    );
+    expect(camera).toEqual({ x: 300, y: 340, scale: 4 });
+  });
+
+  it("zooms around the pointer without changing its world coordinate", () => {
+    const pointer = { x: 300, y: 220 };
+    const before = { x: 20, y: 10, scale: 0.5 };
+    const after = zoomAroundPoint(before, pointer, 1.5);
+    expect(screenToWorld(pointer, after)).toEqual(screenToWorld(pointer, before));
+  });
+
+  it("hit-tests nearby nodes through the spatial index", () => {
+    const positions = new Map([
+      ["a", { x: 10, y: 10 }],
+      ["b", { x: 500, y: 500 }],
+    ]);
+    const grid = buildSpatialGrid(["a", "b"], positions);
+    const nodes = new Map([["a", { degree: 2 }], ["b", { degree: 2 }]]);
+    expect(hitTestSpatialGrid(grid, positions, nodes, { x: 13, y: 12 }, 8)).toBe("a");
+    expect(hitTestSpatialGrid(grid, positions, nodes, { x: 200, y: 200 }, 8)).toBeNull();
+  });
+});

--- a/frontend/tests/graphLayout.test.ts
+++ b/frontend/tests/graphLayout.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { GraphResponse } from "@/lib/api";
+import { forceSimulation, type SimulationNodeDatum } from "d3-force";
+import {
+  activateLayoutCacheTenant,
+  clearLayoutCacheForTests,
+  initialGraphPositions,
+  readCachedLayout,
+  stableInitialPosition,
+  topologyFingerprint,
+  visibleLinks,
+  writeCachedLayout,
+} from "@/lib/graphLayout";
+
+function graph(edges: GraphResponse["edges"]): GraphResponse {
+  return {
+    nodes: ["a", "b", "c"].map((slug, index) => ({
+      slug,
+      title: slug,
+      section: index < 2 ? "one" : "two",
+      tier: "public",
+      is_anchor: false,
+      degree: 1,
+    })),
+    edges,
+    anchors: [],
+  };
+}
+
+describe("graph layout invariants", () => {
+  it("retains the original renderer's deterministic D3 seed positions", () => {
+    const first = graph([]);
+    const reference: SimulationNodeDatum[] = first.nodes.map(() => ({}));
+    forceSimulation(reference).stop();
+    const positions = initialGraphPositions(first);
+    first.nodes.forEach((node, index) => {
+      expect(positions.get(node.slug)?.x).toBeCloseTo(reference[index].x ?? 0);
+      expect(positions.get(node.slug)?.y).toBeCloseTo(reference[index].y ?? 0);
+    });
+    expect(stableInitialPosition(0)).toEqual(stableInitialPosition(0));
+  });
+
+  it("fingerprints the full topology independent of API order", () => {
+    const first = graph([{ source: "a", target: "b" }, { source: "b", target: "c" }]);
+    const reordered = {
+      ...first,
+      nodes: [...first.nodes].reverse(),
+      edges: [...first.edges].reverse(),
+    };
+    expect(topologyFingerprint(first)).toBe(topologyFingerprint(reordered));
+    expect(topologyFingerprint(graph([{ source: "a", target: "b" }]))).not.toBe(
+      topologyFingerprint(first),
+    );
+  });
+
+  it("returns fresh edge objects and every edge whose endpoints are visible", () => {
+    const links = [
+      { source: "a", target: "b" },
+      { source: "b", target: "c" },
+      { source: "c", target: "a" },
+    ];
+    const visible = visibleLinks(links, new Set(["a", "b", "c"]));
+    expect(visible).toEqual(links);
+    expect(visible[0]).not.toBe(links[0]);
+    expect(visibleLinks(links, new Set(["a", "b"]))).toEqual([
+      { source: "a", target: "b" },
+    ]);
+  });
+
+  it("reuses cache across same-tenant remounts and clears it on tenant change", () => {
+    clearLayoutCacheForTests();
+    const positions = new Map([["a", { x: 12, y: -4 }]]);
+    writeCachedLayout("tenant-a", "topology", positions);
+    expect(readCachedLayout("tenant-a", "topology")).toEqual(positions);
+    activateLayoutCacheTenant("tenant-b");
+    expect(readCachedLayout("tenant-a", "topology")).toBeNull();
+  });
+});

--- a/frontend/workers/graphLayout.worker.ts
+++ b/frontend/workers/graphLayout.worker.ts
@@ -1,0 +1,56 @@
+import {
+  forceCenter,
+  forceLink,
+  forceManyBody,
+  forceSimulation,
+  type SimulationLinkDatum,
+  type SimulationNodeDatum,
+} from "d3-force";
+import type { LayoutResponse, LayoutStart } from "@/lib/graphLayout";
+
+type WorkerNode = SimulationNodeDatum & { id: string; degree: number };
+type WorkerLink = SimulationLinkDatum<WorkerNode>;
+const MAX_ITERATIONS = 380;
+const MAX_RUNTIME_MS = 3_500;
+
+self.onmessage = (event: MessageEvent<LayoutStart>) => {
+  const message = event.data;
+  if (message.kind !== "start") return;
+  try {
+    const nodes: WorkerNode[] = message.nodes.map((node) => ({ ...node }));
+    const links: WorkerLink[] = message.links.map((link) => ({ source: link.source, target: link.target }));
+    const simulation = forceSimulation(nodes)
+      // Match the original renderer's initial layout: degree-weighted links
+      // keep global index pages from flattening the community structure.
+      .force("link", forceLink<WorkerNode, WorkerLink>(links).id((node) => node.id))
+      .force("charge", forceManyBody())
+      .force("center", forceCenter())
+      .alpha(1)
+      .alphaDecay(0.018)
+      .velocityDecay(0.35)
+      .stop();
+    const startedAt = performance.now();
+    for (let iteration = 0; iteration < MAX_ITERATIONS; iteration += 1) {
+      simulation.tick();
+      if (performance.now() - startedAt >= MAX_RUNTIME_MS) break;
+    }
+    simulation.stop();
+    const response: LayoutResponse = {
+      kind: "positions",
+      generation: message.generation,
+      positions: nodes.map((node) => ({
+        id: node.id,
+        x: Number.isFinite(node.x) ? node.x ?? 0 : 0,
+        y: Number.isFinite(node.y) ? node.y ?? 0 : 0,
+      })),
+    };
+    self.postMessage(response);
+  } catch (error) {
+    const response: LayoutResponse = {
+      kind: "error",
+      generation: message.generation,
+      message: error instanceof Error ? error.message : "layout failed",
+    };
+    self.postMessage(response);
+  }
+};


### PR DESCRIPTION
The full knowledge graph previously ran force simulation and rebuilt thousands of edge segments on the main thread. This change computes a bounded layout in a worker and caches the complete edge path. Pan, zoom, selection, and node dragging keep every edge in the active filter visible. Layout positions persist across in-app navigation, and recenter fits the connected mass so distant isolates do not shrink the useful graph.

The renderer retains the original degree-weighted community layout, section colors, tier rings, filters, labels, and node details. Pointer input takes priority over pending animations. Wheel zoom prevents page scrolling, and narrow containers no longer overflow.

Validation:
- 221 frontend tests pass, including edge retention, worker cleanup, Strict Mode, drag races, and wheel handling.
- TypeScript check and production build pass.
- Browser checks used anonymized real topology: 2,297 nodes and 32,512 edges at 1280 x 900, DPR 2. During a four-second relax sample, p95 frame interval improved from 41.7 ms to 9.2 ms; frames over 50 ms went from six to zero. This measures main-thread responsiveness, not total worker CPU usage.
- Filters, selection, label modes, wheel zoom, recenter, and 390 px container sizing checked in the browser.

Rollback: revert this change, or redeploy the prior production revision 7469fe560d7b297936f9b4ec01b8fa58ccf185a1. No backend API or data migration changes.
