### PR TITLE
fix: reveal the graph after its initial layout settles

### DIFF
--- a/frontend/components/ForceGraphCanvas.tsx
+++ b/frontend/components/ForceGraphCanvas.tsx
@@ -241,6 +241,14 @@ const ForceGraphCanvas = forwardRef<ForceGraphCanvasHandle, ForceGraphCanvasProp
       context.clearRect(0, 0, viewport.width, viewport.height);
       context.fillStyle = "#fafaf7";
       context.fillRect(0, 0, viewport.width, viewport.height);
+      if (!layoutReadyRef.current) {
+        context.font = "14px sans-serif";
+        context.fillStyle = "#525258";
+        context.textAlign = "center";
+        context.textBaseline = "middle";
+        context.fillText("Preparing graph…", viewport.width / 2, viewport.height / 2);
+        return;
+      }
       context.save();
       context.translate(camera.x, camera.y);
       context.scale(camera.scale, camera.scale);
@@ -364,6 +372,7 @@ const ForceGraphCanvas = forwardRef<ForceGraphCanvasHandle, ForceGraphCanvasProp
       generationRef.current += 1;
       workerRef.current?.terminate();
       workerRef.current = null;
+      const firstLayout = !layoutReadyRef.current;
       layoutReadyRef.current = true;
       if (response.kind === "error") {
         if (!userNavigatedRef.current) recenter(false);
@@ -381,9 +390,9 @@ const ForceGraphCanvas = forwardRef<ForceGraphCanvasHandle, ForceGraphCanvasProp
         positionsRef.current = target;
         rebuildPositionIndexes();
         requestDraw();
-        if (!userNavigatedRef.current) recenter(false);
+        if (firstLayout || !userNavigatedRef.current) recenter(false);
       };
-      if (reducedMotionRef.current) {
+      if (firstLayout || reducedMotionRef.current) {
         applyFinal();
         return;
       }
@@ -542,6 +551,7 @@ const ForceGraphCanvas = forwardRef<ForceGraphCanvasHandle, ForceGraphCanvasProp
     }, []);
 
     const hitTest = useCallback((point: GraphPosition) => {
+      if (!layoutReadyRef.current) return null;
       const world = screenToWorld(point, cameraRef.current);
       return hitTestSpatialGrid(
         spatialGridRef.current,

--- a/frontend/tests/ForceGraphCanvas.test.tsx
+++ b/frontend/tests/ForceGraphCanvas.test.tsx
@@ -184,6 +184,19 @@ beforeEach(() => {
 });
 
 describe("ForceGraphCanvas", () => {
+  it("reveals the first graph only after final positions and camera fit are ready", () => {
+    render(<ForceGraphCanvas graph={graph} sectionFilter="" selectedSlug={null} labelMode="off" onSelect={vi.fn()} />);
+    act(() => { flushFrames(); });
+    expect(context.arc).not.toHaveBeenCalled();
+    expect(context.fillText).toHaveBeenCalledWith("Preparing graph…", 400, 300);
+    const worker = MockWorker.instances[0];
+    act(() => { worker.emit(finalPositions(startMessage(worker).generation)); });
+    expect(rafCallbacks.size).toBe(1);
+    act(() => { flushFrames(); });
+    expect(context.arc).toHaveBeenCalled();
+    expect(rafCallbacks.size).toBe(0);
+  });
+
   it("consumes wheel zoom instead of also scrolling the document", () => {
     const view = render(<ForceGraphCanvas graph={graph} sectionFilter="" selectedSlug={null} labelMode="off" onSelect={vi.fn()} />);
     const canvas = view.getByRole("application");
@@ -204,8 +217,13 @@ describe("ForceGraphCanvas", () => {
   it("gives a dragged node priority over pending layout and batches pointer updates into one frame", () => {
     const ref = createRef<ForceGraphCanvasHandle>();
     const view = render(<ForceGraphCanvas ref={ref} graph={graph} sectionFilter="" selectedSlug={null} labelMode="off" onSelect={vi.fn()} />);
-    act(() => { flushFrames(); });
-    const first = MockWorker.instances[0];
+    const initial = MockWorker.instances[0];
+    act(() => {
+      initial.emit(finalPositions(startMessage(initial).generation));
+      flushFrames();
+      ref.current?.relax();
+    });
+    const first = MockWorker.instances[1];
     const start = startMessage(first);
     const [cameraX, cameraY] = context.translate.mock.lastCall ?? [];
     const [scale] = context.scale.mock.lastCall ?? [];
@@ -228,7 +246,7 @@ describe("ForceGraphCanvas", () => {
       flushFrames();
       ref.current?.relax();
     });
-    const next = startMessage(MockWorker.instances[1]).nodes.find((candidate) => candidate.id === node.id);
+    const next = startMessage(MockWorker.instances[2]).nodes.find((candidate) => candidate.id === node.id);
     expect(next?.x).toBeCloseTo(node.x + 50 / scale);
   });
 


### PR DESCRIPTION
A fresh graph load exposed the circular simulation seed before jumping to the finished layout and camera. Show Preparing graph while the first worker runs, then reveal final positions and framing together. Cached layouts still appear immediately, and later relax actions still animate with all edges visible.

Validation: 222 frontend tests, TypeScript check, and production build passed. A new regression test verifies that no seed nodes are painted and the first completed layout needs no intermediate animation frames. The drag regression now starts from a completed layout before testing a pending relax.
