### PR TITLE
fix: restore organic graph motion

### DIFF
--- a/frontend/components/ForceGraphCanvas.tsx
+++ b/frontend/components/ForceGraphCanvas.tsx
@@ -32,6 +32,7 @@ import {
   visibleLinks,
   writeCachedLayout,
   type GraphPosition,
+  type LayoutMode,
   type LayoutResponse,
   type LayoutStart,
 } from "@/lib/graphLayout";
@@ -78,8 +79,8 @@ const TIER_RING: Readonly<Record<string, string>> = {
   private: "#ef4444",
 };
 
-const LAYOUT_MOTION_MS = 220;
-const CAMERA_MOTION_MS = 220;
+const LAYOUT_MOTION_MS = 80;
+const CAMERA_MOTION_MS = 700;
 const TEXT_CACHE_LIMIT = 512;
 
 function edgePath(edges: ReadonlyArray<GraphEdge>, positions: ReadonlyMap<string, GraphPosition>): Path2D {
@@ -137,6 +138,7 @@ const ForceGraphCanvas = forwardRef<ForceGraphCanvasHandle, ForceGraphCanvasProp
     const hoverRef = useRef<string | null>(null);
     const workerRef = useRef<Worker | null>(null);
     const generationRef = useRef(0);
+    const layoutSequenceRef = useRef(-1);
     const drawFrameRef = useRef<number | null>(null);
     const positionIndexesDirtyRef = useRef(false);
     const motionFrameRef = useRef<number | null>(null);
@@ -149,7 +151,7 @@ const ForceGraphCanvas = forwardRef<ForceGraphCanvasHandle, ForceGraphCanvasProp
     const topologyRef = useRef("");
     const tenantRef = useRef(tenant);
     const drawRef = useRef<() => void>(() => undefined);
-    const startLayoutRef = useRef<() => void>(() => undefined);
+    const startLayoutRef = useRef<(mode: LayoutMode) => void>(() => undefined);
 
     const fingerprint = useMemo(() => topologyFingerprint(graph), [graph]);
     const nodesById = useMemo(
@@ -367,58 +369,74 @@ const ForceGraphCanvas = forwardRef<ForceGraphCanvasHandle, ForceGraphCanvasProp
       }
     }, [animateCamera, requestDraw]);
 
-    const finishLayout = useCallback((response: LayoutResponse) => {
+    const acceptLayoutResponse = useCallback((response: LayoutResponse) => {
       if (response.generation !== generationRef.current) return;
-      generationRef.current += 1;
-      workerRef.current?.terminate();
-      workerRef.current = null;
-      const firstLayout = !layoutReadyRef.current;
-      layoutReadyRef.current = true;
       if (response.kind === "error") {
+        generationRef.current += 1;
+        workerRef.current?.terminate();
+        workerRef.current = null;
+        layoutReadyRef.current = true;
         if (!userNavigatedRef.current) recenter(false);
         requestDraw();
         return;
       }
+      if (response.sequence <= layoutSequenceRef.current) return;
       const target = positionsFromResponse(response);
-      if (target.size !== graph.nodes.length || graph.nodes.some((node) => !target.has(node.slug))) {
-        if (!userNavigatedRef.current) recenter(false);
-        return;
-      }
-      writeCachedLayout(tenantRef.current, topologyRef.current, target);
+      if (target.size !== graph.nodes.length || graph.nodes.some((node) => !target.has(node.slug))) return;
+      layoutSequenceRef.current = response.sequence;
+      const firstReveal = !layoutReadyRef.current;
+      layoutReadyRef.current = true;
       const start = new Map(positionsRef.current);
-      const applyFinal = () => {
+      const applyTarget = () => {
         positionsRef.current = target;
         rebuildPositionIndexes();
         requestDraw();
-        if (firstLayout || !userNavigatedRef.current) recenter(false);
       };
-      if (firstLayout || reducedMotionRef.current) {
-        applyFinal();
-        return;
+      if (firstReveal || reducedMotionRef.current) applyTarget();
+      else {
+        if (motionFrameRef.current !== null) window.cancelAnimationFrame(motionFrameRef.current);
+        const startedAt = performance.now();
+        const step = (now: number) => {
+          const progress = Math.min(1, (now - startedAt) / LAYOUT_MOTION_MS);
+          positionsRef.current = interpolatePositions(start, target, progress);
+          rebuildPositionIndexes();
+          requestDraw();
+          if (progress < 1) motionFrameRef.current = window.requestAnimationFrame(step);
+          else {
+            motionFrameRef.current = null;
+            applyTarget();
+          }
+        };
+        motionFrameRef.current = window.requestAnimationFrame(step);
       }
-      if (motionFrameRef.current !== null) window.cancelAnimationFrame(motionFrameRef.current);
-      const startedAt = performance.now();
-      const step = (now: number) => {
-        const progress = Math.min(1, (now - startedAt) / LAYOUT_MOTION_MS);
-        positionsRef.current = interpolatePositions(start, target, progress);
-        rebuildPositionIndexes();
-        requestDraw();
-        if (progress < 1) motionFrameRef.current = window.requestAnimationFrame(step);
-        else {
-          motionFrameRef.current = null;
-          applyFinal();
+      if (!userNavigatedRef.current) {
+        const targetCamera = fitCamera(visibleNodesRef.current, target, viewportRef.current);
+        if (firstReveal) {
+          cameraRef.current = targetCamera;
+          requestDraw();
+        } else {
+          const camera = cameraRef.current;
+          const scaleChange = Math.abs(targetCamera.scale / camera.scale - 1);
+          const centerChange = Math.hypot(targetCamera.x - camera.x, targetCamera.y - camera.y);
+          if (scaleChange > 0.08 || centerChange > 24) animateCamera(targetCamera);
         }
-      };
-      motionFrameRef.current = window.requestAnimationFrame(step);
-    }, [graph.nodes, rebuildPositionIndexes, recenter, requestDraw]);
+      }
+      if (response.kind === "final") {
+        writeCachedLayout(tenantRef.current, topologyRef.current, target);
+        generationRef.current += 1;
+        workerRef.current?.terminate();
+        workerRef.current = null;
+      }
+    }, [animateCamera, graph.nodes, rebuildPositionIndexes, recenter, requestDraw]);
 
-    const startLayout = useCallback(() => {
+    const startLayout = useCallback((mode: LayoutMode) => {
       if (motionFrameRef.current !== null) window.cancelAnimationFrame(motionFrameRef.current);
       motionFrameRef.current = null;
       workerRef.current?.terminate();
       workerRef.current = null;
       generationRef.current += 1;
       const generation = generationRef.current;
+      layoutSequenceRef.current = -1;
       if (typeof Worker === "undefined") {
         layoutReadyRef.current = true;
         if (!userNavigatedRef.current) recenter(false);
@@ -428,19 +446,21 @@ const ForceGraphCanvas = forwardRef<ForceGraphCanvasHandle, ForceGraphCanvasProp
       try {
         const worker = new Worker(new URL("../workers/graphLayout.worker.ts", import.meta.url), { type: "module" });
         workerRef.current = worker;
-        worker.onmessage = (event: MessageEvent<LayoutResponse>) => finishLayout(event.data);
-        worker.onerror = () => finishLayout({ kind: "error", generation, message: "layout worker failed" });
+        worker.onmessage = (event: MessageEvent<LayoutResponse>) => acceptLayoutResponse(event.data);
+        worker.onerror = () => acceptLayoutResponse({ kind: "error", generation, message: "layout worker failed" });
         const message: LayoutStart = {
           kind: "start",
           generation,
+          mode,
+          delivery: reducedMotionRef.current ? "final-only" : "stream",
           nodes: layoutNodes(graph, positionsRef.current),
           links: graph.edges.map((edge) => ({ source: edge.source, target: edge.target })),
         };
         worker.postMessage(message);
       } catch {
-        finishLayout({ kind: "error", generation, message: "layout worker unavailable" });
+        acceptLayoutResponse({ kind: "error", generation, message: "layout worker unavailable" });
       }
-    }, [finishLayout, graph, recenter, requestDraw]);
+    }, [acceptLayoutResponse, graph, recenter, requestDraw]);
     startLayoutRef.current = startLayout;
 
     useImperativeHandle(ref, () => ({
@@ -448,7 +468,7 @@ const ForceGraphCanvas = forwardRef<ForceGraphCanvasHandle, ForceGraphCanvasProp
         userNavigatedRef.current = true;
         recenter(true);
       },
-      relax: () => startLayoutRef.current(),
+      relax: () => startLayoutRef.current("relax"),
     }), [recenter]);
 
     useEffect(() => {
@@ -487,7 +507,7 @@ const ForceGraphCanvas = forwardRef<ForceGraphCanvasHandle, ForceGraphCanvasProp
       rankedNodesRef.current = rankedNodes;
       visibleEdgesRef.current = visibleEdges;
       rebuildPositionIndexes();
-      if (layoutReadyRef.current) recenter(true);
+      if (layoutReadyRef.current && !userNavigatedRef.current) recenter(true);
       else requestDraw();
     }, [rankedNodes, rebuildPositionIndexes, recenter, requestDraw, visibleEdges, visibleNodes]);
 
@@ -500,7 +520,7 @@ const ForceGraphCanvas = forwardRef<ForceGraphCanvasHandle, ForceGraphCanvasProp
       layoutReadyRef.current = cached !== null;
       rebuildPositionIndexes();
       if (cached) recenter(false);
-      else startLayout();
+      else startLayout("initial");
       return () => {
         generationRef.current += 1;
         workerRef.current?.terminate();

--- a/frontend/lib/graphLayout.ts
+++ b/frontend/lib/graphLayout.ts
@@ -3,23 +3,29 @@ import type { GraphEdge, GraphResponse } from "@/lib/api";
 export type GraphPosition = Readonly<{ x: number; y: number }>;
 export type GraphPositions = ReadonlyMap<string, GraphPosition>;
 export type LayoutNode = Readonly<{ id: string; degree: number; x: number; y: number }>;
+export type LayoutMode = "initial" | "relax";
+export type LayoutDelivery = "stream" | "final-only";
 export type LayoutStart = Readonly<{
   kind: "start";
   generation: number;
+  mode: LayoutMode;
+  delivery: LayoutDelivery;
   nodes: LayoutNode[];
   links: GraphEdge[];
 }>;
-export type LayoutSuccess = Readonly<{
-  kind: "positions";
+type LayoutPositions = Readonly<{
   generation: number;
+  sequence: number;
   positions: Array<Readonly<{ id: string; x: number; y: number }>>;
 }>;
+export type LayoutProgress = LayoutPositions & Readonly<{ kind: "progress" }>;
+export type LayoutFinal = LayoutPositions & Readonly<{ kind: "final" }>;
 export type LayoutFailure = Readonly<{
   kind: "error";
   generation: number;
   message: string;
 }>;
-export type LayoutResponse = LayoutSuccess | LayoutFailure;
+export type LayoutResponse = LayoutProgress | LayoutFinal | LayoutFailure;
 
 const CACHE_LIMIT = 4;
 const SINGLE_TENANT_SCOPE = "single-tenant";
@@ -111,7 +117,7 @@ export function layoutNodes(graph: GraphResponse, positions: GraphPositions): La
   });
 }
 
-export function positionsFromResponse(response: LayoutSuccess): Map<string, GraphPosition> {
+export function positionsFromResponse(response: LayoutProgress | LayoutFinal): Map<string, GraphPosition> {
   return new Map(
     response.positions
       .filter((position) => Number.isFinite(position.x) && Number.isFinite(position.y))

--- a/frontend/tests/ForceGraphCanvas.test.tsx
+++ b/frontend/tests/ForceGraphCanvas.test.tsx
@@ -3,7 +3,14 @@ import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ForceGraphCanvas, { type ForceGraphCanvasHandle } from "@/components/ForceGraphCanvas";
 import type { GraphResponse } from "@/lib/api";
-import { clearLayoutCacheForTests, type LayoutResponse, type LayoutStart } from "@/lib/graphLayout";
+import { fitCamera } from "@/lib/graphGeometry";
+import {
+  clearLayoutCacheForTests,
+  type LayoutFinal,
+  type LayoutProgress,
+  type LayoutResponse,
+  type LayoutStart,
+} from "@/lib/graphLayout";
 
 const graph: GraphResponse = {
   nodes: [
@@ -84,6 +91,12 @@ function flushFrames(time = performance.now() + 500): void {
   }
 }
 
+function flushOneFrame(time: number): void {
+  const callbacks = [...rafCallbacks.values()];
+  rafCallbacks = new Map();
+  for (const callback of callbacks) callback(time);
+}
+
 function isLayoutStart(message: unknown): message is LayoutStart {
   return Boolean(
     message &&
@@ -107,16 +120,21 @@ function startMessage(worker: MockWorker): LayoutStart {
   return message;
 }
 
-function finalPositions(generation: number, offset = 0): LayoutResponse {
+function progressPositions(generation: number, sequence = 0, offset = 0): LayoutProgress {
   return {
-    kind: "positions",
+    kind: "progress",
     generation,
+    sequence,
     positions: graph.nodes.map((node, index) => ({
       id: node.slug,
       x: index * 100 + offset,
       y: index * 50 + offset,
     })),
   };
+}
+
+function finalPositions(generation: number, sequence = 1, offset = 0): LayoutFinal {
+  return { ...progressPositions(generation, sequence, offset), kind: "final" };
 }
 
 beforeEach(() => {
@@ -184,16 +202,39 @@ beforeEach(() => {
 });
 
 describe("ForceGraphCanvas", () => {
-  it("reveals the first graph only after final positions and camera fit are ready", () => {
+  it("requests final-only worker delivery when reduced motion is enabled", () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: () => ({
+        matches: true,
+        media: "(prefers-reduced-motion: reduce)",
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+    });
+    render(<ForceGraphCanvas graph={graph} sectionFilter="" selectedSlug={null} labelMode="off" onSelect={vi.fn()} />);
+    expect(startMessage(MockWorker.instances[0]).delivery).toBe("final-only");
+  });
+
+  it("reveals the fitted warmup layout on first progress and streams through final", () => {
     render(<ForceGraphCanvas graph={graph} sectionFilter="" selectedSlug={null} labelMode="off" onSelect={vi.fn()} />);
     act(() => { flushFrames(); });
     expect(context.arc).not.toHaveBeenCalled();
     expect(context.fillText).toHaveBeenCalledWith("Preparing graph…", 400, 300);
     const worker = MockWorker.instances[0];
-    act(() => { worker.emit(finalPositions(startMessage(worker).generation)); });
+    const generation = startMessage(worker).generation;
+    act(() => { worker.emit(progressPositions(generation)); });
     expect(rafCallbacks.size).toBe(1);
     act(() => { flushFrames(); });
     expect(context.arc).toHaveBeenCalled();
+    expect(worker.terminated).toBe(false);
+    act(() => { worker.emit(finalPositions(generation)); });
+    expect(worker.terminated).toBe(true);
+    act(() => { flushFrames(); });
     expect(rafCallbacks.size).toBe(0);
   });
 
@@ -209,7 +250,12 @@ describe("ForceGraphCanvas", () => {
     render(<StrictMode><ForceGraphCanvas graph={graph} sectionFilter="" selectedSlug={null} labelMode="off" onSelect={vi.fn()} /></StrictMode>);
     const active = MockWorker.instances.at(-1);
     if (!active) throw new Error("no active worker");
-    act(() => { active.emit(finalPositions(startMessage(active).generation)); flushFrames(); });
+    act(() => {
+      const generation = startMessage(active).generation;
+      active.emit(progressPositions(generation));
+      active.emit(finalPositions(generation));
+      flushFrames();
+    });
     expect(context.stroke).toHaveBeenCalled();
     expect(rafCallbacks.size).toBe(0);
   });
@@ -219,7 +265,9 @@ describe("ForceGraphCanvas", () => {
     const view = render(<ForceGraphCanvas ref={ref} graph={graph} sectionFilter="" selectedSlug={null} labelMode="off" onSelect={vi.fn()} />);
     const initial = MockWorker.instances[0];
     act(() => {
-      initial.emit(finalPositions(startMessage(initial).generation));
+      const generation = startMessage(initial).generation;
+      initial.emit(progressPositions(generation));
+      initial.emit(finalPositions(generation));
       flushFrames();
       ref.current?.relax();
     });
@@ -242,7 +290,7 @@ describe("ForceGraphCanvas", () => {
     expect(MockPath2D.instances.length).toBe(pathCount);
     act(() => {
       canvas.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, clientX: x + 50, clientY: y }));
-      first.emit(finalPositions(start.generation, 999));
+      first.emit(finalPositions(start.generation, 1, 999));
       flushFrames();
       ref.current?.relax();
     });
@@ -272,6 +320,7 @@ describe("ForceGraphCanvas", () => {
     expect(Math.max(...MockPath2D.instances.map((path) => path.lineCount))).toBe(3);
 
     act(() => {
+      first.emit(progressPositions(firstStart.generation));
       first.emit(finalPositions(firstStart.generation));
       flushFrames();
     });
@@ -298,10 +347,17 @@ describe("ForceGraphCanvas", () => {
     const second = MockWorker.instances[1];
     const secondStart = startMessage(second);
     expect(secondStart.generation).toBeGreaterThan(firstStart.generation);
-    act(() => { first.emit(finalPositions(firstStart.generation, 999)); });
+    expect(secondStart.mode).toBe("relax");
+    expect(secondStart.nodes.map(({ x, y }) => ({ x, y }))).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 50 },
+      { x: 200, y: 100 },
+    ]);
+    act(() => { first.emit(finalPositions(firstStart.generation, 1, 999)); });
     expect(second.terminated).toBe(false);
     act(() => {
-      second.emit(finalPositions(secondStart.generation, 10));
+      second.emit(progressPositions(secondStart.generation, 0, 10));
+      second.emit(finalPositions(secondStart.generation, 1, 10));
       flushFrames();
     });
     expect(second.terminated).toBe(true);
@@ -319,6 +375,37 @@ describe("ForceGraphCanvas", () => {
       />,
     );
     expect(MockWorker.instances).toHaveLength(2);
+  });
+
+  it("keeps every edge during streamed interpolation and never snaps the camera on final", () => {
+    render(<ForceGraphCanvas graph={graph} sectionFilter="" selectedSlug={null} labelMode="off" onSelect={vi.fn()} />);
+    const worker = MockWorker.instances[0];
+    const generation = startMessage(worker).generation;
+    act(() => {
+      worker.emit(progressPositions(generation));
+      flushFrames();
+    });
+    const cameraBeforeFinal = context.translate.mock.lastCall;
+    const pathIndex = MockPath2D.instances.length;
+    act(() => { worker.emit(finalPositions(generation, 1, 200)); });
+    expect(context.translate.mock.lastCall).toEqual(cameraBeforeFinal);
+    expect(worker.terminated).toBe(true);
+    const midpoint = performance.now() + 350;
+    act(() => {
+      flushOneFrame(midpoint);
+      flushOneFrame(midpoint);
+    });
+    const streamedPaths = MockPath2D.instances.slice(pathIndex);
+    expect(streamedPaths.length).toBeGreaterThan(0);
+    expect(streamedPaths.every((path) => path.lineCount === graph.edges.length)).toBe(true);
+    expect(context.translate.mock.lastCall).not.toEqual(cameraBeforeFinal);
+    const finalMap = new Map(
+      finalPositions(generation, 1, 200).positions.map(({ id, x, y }) => [id, { x, y }]),
+    );
+    const targetCamera = fitCamera(graph.nodes, finalMap, { width: 800, height: 600 });
+    const [midX, midY] = context.translate.mock.lastCall ?? [];
+    expect(midX).not.toBeCloseTo(targetCamera.x);
+    expect(midY).not.toBeCloseTo(targetCamera.y);
   });
 
   it("stays usable after worker failure and terminates an active worker on unmount", () => {

--- a/frontend/tests/graphLayoutWorker.test.ts
+++ b/frontend/tests/graphLayoutWorker.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LayoutFinal, LayoutProgress, LayoutResponse, LayoutStart } from "@/lib/graphLayout";
+
+type WorkerScope = {
+  onmessage: ((event: MessageEvent<LayoutStart>) => void) | null;
+  postMessage: ReturnType<typeof vi.fn<(response: LayoutResponse) => void>>;
+};
+
+function start(delivery: LayoutStart["delivery"]): LayoutStart {
+  return {
+    kind: "start",
+    generation: 7,
+    mode: "initial",
+    delivery,
+    nodes: [
+      { id: "a", degree: 1, x: -20, y: 0 },
+      { id: "b", degree: 1, x: 20, y: 0 },
+    ],
+    links: [{ source: "a", target: "b" }],
+  };
+}
+
+function isProgress(response: LayoutResponse): response is LayoutProgress {
+  return response.kind === "progress";
+}
+
+function isFinal(response: LayoutResponse): response is LayoutFinal {
+  return response.kind === "final";
+}
+
+describe("graph layout worker", () => {
+  let scope: WorkerScope;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    scope = { onmessage: null, postMessage: vi.fn() };
+    vi.stubGlobal("self", scope);
+    await import("@/workers/graphLayout.worker");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("posts a warmup snapshot first, then progressive positions and one bounded final", () => {
+    scope.onmessage?.(new MessageEvent("message", { data: start("stream") }));
+    const first = scope.postMessage.mock.calls[0]?.[0];
+    expect(first && isProgress(first)).toBe(true);
+    expect(first?.generation).toBe(7);
+    vi.advanceTimersByTime(100);
+    const progress = scope.postMessage.mock.calls.map(([response]) => response).filter(isProgress);
+    expect(progress.length).toBeGreaterThan(1);
+    vi.runAllTimers();
+    const responses = scope.postMessage.mock.calls.map(([response]) => response);
+    expect(responses.filter(isFinal)).toHaveLength(1);
+    expect(responses.at(-1)?.kind).toBe("final");
+  });
+
+  it("starts relax at the displayed positions instead of skipping its first motion", () => {
+    const message = { ...start("stream"), mode: "relax" as const };
+    scope.onmessage?.(new MessageEvent("message", { data: message }));
+    const first = scope.postMessage.mock.calls[0]?.[0];
+    expect(first && isProgress(first) && first.positions).toEqual(
+      message.nodes.map(({ id, x, y }) => ({ id, x, y })),
+    );
+    vi.advanceTimersByTime(100);
+    const next = scope.postMessage.mock.calls.at(-1)?.[0];
+    expect(next && isProgress(next) && next.positions).not.toEqual(
+      message.nodes.map(({ id, x, y }) => ({ id, x, y })),
+    );
+    vi.runAllTimers();
+  });
+
+  it("emits only the final layout for reduced-motion delivery", () => {
+    scope.onmessage?.(new MessageEvent("message", { data: start("final-only") }));
+    expect(scope.postMessage).toHaveBeenCalledTimes(1);
+    expect(scope.postMessage.mock.calls[0]?.[0].kind).toBe("final");
+  });
+});

--- a/frontend/workers/graphLayout.worker.ts
+++ b/frontend/workers/graphLayout.worker.ts
@@ -6,12 +6,45 @@ import {
   type SimulationLinkDatum,
   type SimulationNodeDatum,
 } from "d3-force";
-import type { LayoutResponse, LayoutStart } from "@/lib/graphLayout";
+import type { LayoutFinal, LayoutProgress, LayoutResponse, LayoutStart } from "@/lib/graphLayout";
 
 type WorkerNode = SimulationNodeDatum & { id: string; degree: number };
 type WorkerLink = SimulationLinkDatum<WorkerNode>;
-const MAX_ITERATIONS = 380;
-const MAX_RUNTIME_MS = 3_500;
+const WARMUP_TICKS = 72;
+const BATCH_TICKS = 3;
+const BATCH_INTERVAL_MS = 50;
+const MAX_ITERATIONS = 372;
+const MAX_RUNTIME_MS = 5_000;
+
+function snapshot(
+  kind: LayoutProgress["kind"] | LayoutFinal["kind"],
+  generation: number,
+  sequence: number,
+  nodes: WorkerNode[],
+): LayoutProgress | LayoutFinal {
+  return {
+    kind,
+    generation,
+    sequence,
+    positions: nodes.map((node) => ({
+      id: node.id,
+      x: Number.isFinite(node.x) ? node.x ?? 0 : 0,
+      y: Number.isFinite(node.y) ? node.y ?? 0 : 0,
+    })),
+  };
+}
+
+function addRelaxImpulse(nodes: WorkerNode[]): void {
+  for (const node of nodes) {
+    let hash = 2166136261;
+    for (let index = 0; index < node.id.length; index += 1) {
+      hash = Math.imul(hash ^ node.id.charCodeAt(index), 16777619);
+    }
+    const angle = ((hash >>> 0) / 0xffffffff) * Math.PI * 2;
+    node.vx = Math.cos(angle) * 0.18;
+    node.vy = Math.sin(angle) * 0.18;
+  }
+}
 
 self.onmessage = (event: MessageEvent<LayoutStart>) => {
   const message = event.data;
@@ -19,32 +52,60 @@ self.onmessage = (event: MessageEvent<LayoutStart>) => {
   try {
     const nodes: WorkerNode[] = message.nodes.map((node) => ({ ...node }));
     const links: WorkerLink[] = message.links.map((link) => ({ source: link.source, target: link.target }));
+    if (message.mode === "relax") addRelaxImpulse(nodes);
     const simulation = forceSimulation(nodes)
       // Match the original renderer's initial layout: degree-weighted links
       // keep global index pages from flattening the community structure.
       .force("link", forceLink<WorkerNode, WorkerLink>(links).id((node) => node.id))
       .force("charge", forceManyBody())
       .force("center", forceCenter())
-      .alpha(1)
+      .alpha(message.mode === "relax" ? 0.8 : 1)
       .alphaDecay(0.018)
       .velocityDecay(0.35)
       .stop();
     const startedAt = performance.now();
-    for (let iteration = 0; iteration < MAX_ITERATIONS; iteration += 1) {
+    let iterations = 0;
+    let sequence = 0;
+    const warmupTicks = message.mode === "initial" ? WARMUP_TICKS : 0;
+    while (iterations < warmupTicks) {
       simulation.tick();
-      if (performance.now() - startedAt >= MAX_RUNTIME_MS) break;
+      iterations += 1;
     }
-    simulation.stop();
-    const response: LayoutResponse = {
-      kind: "positions",
-      generation: message.generation,
-      positions: nodes.map((node) => ({
-        id: node.id,
-        x: Number.isFinite(node.x) ? node.x ?? 0 : 0,
-        y: Number.isFinite(node.y) ? node.y ?? 0 : 0,
-      })),
+    if (message.delivery === "final-only") {
+      while (iterations < MAX_ITERATIONS && performance.now() - startedAt < MAX_RUNTIME_MS) {
+        simulation.tick();
+        iterations += 1;
+      }
+      simulation.stop();
+      self.postMessage(snapshot("final", message.generation, sequence, nodes));
+      return;
+    }
+    self.postMessage(snapshot("progress", message.generation, sequence, nodes));
+    const runBatch = () => {
+      try {
+        for (let tick = 0; tick < BATCH_TICKS && iterations < MAX_ITERATIONS; tick += 1) {
+          simulation.tick();
+          iterations += 1;
+        }
+        sequence += 1;
+        if (iterations >= MAX_ITERATIONS || performance.now() - startedAt >= MAX_RUNTIME_MS) {
+          simulation.stop();
+          self.postMessage(snapshot("final", message.generation, sequence, nodes));
+          return;
+        }
+        self.postMessage(snapshot("progress", message.generation, sequence, nodes));
+        setTimeout(runBatch, BATCH_INTERVAL_MS);
+      } catch (error) {
+        simulation.stop();
+        const response: LayoutResponse = {
+          kind: "error",
+          generation: message.generation,
+          message: error instanceof Error ? error.message : "layout failed",
+        };
+        self.postMessage(response);
+      }
     };
-    self.postMessage(response);
+    setTimeout(runBatch, BATCH_INTERVAL_MS);
   } catch (error) {
     const response: LayoutResponse = {
       kind: "error",


### PR DESCRIPTION
The graph had become stiff: layout finished offscreen, then appeared as one snapshot, while relax hid its strongest motion and the camera snapped to the result.

Stream actual force-layout positions after a short initial warmup, interpolate between updates, and settle over roughly five seconds. Relax starts immediately from displayed positions and reheats physics. Recenter eases over 700 ms; terminal layout updates no longer snap the camera. All active edges stay visible throughout. Reduced-motion delivery remains final-only.

Validation: 227 frontend tests, TypeScript checking, production build, and whitespace checks pass. Browser checks used the real anonymized topology of 2,297 nodes and 32,512 edges: visible changes across the settling interval, zoom followed by a camera glide, and no console errors. A clean six-second cold-load frame sample at 1280 x 900 and DPR 2 measured p95 9 ms and no frames over 50 ms.

Rollback: revert this PR. No backend or data changes.
