### PR TITLE
Complete hosted ingest without Puppetmaster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ ordered newest-first.
 
 ## Unreleased
 
+## 0.2.4. Hosted ingest completes without Puppetmaster
+
+Hosted owner ingest could save a raw source but fail to produce wiki pages
+because the Render backend does not include the `puppetmaster` executable.
+The capture-paste path already fell back to the configured direct LLM; the
+MCP ingest and capture-history re-ingest paths did not.
+
+- **Direct hosted fallback.** Fresh owner ingest and single raw-file re-ingest
+  now draft private pages through the existing direct drafter when
+  Puppetmaster cannot start.
+- **Honest response contracts.** Backend responses retain the orchestrator
+  error and separately report direct drafting results and durable sync state.
+- **Visible outcomes.** Capture history reports drafted-page counts instead
+  of rendering an undefined job ID. The MCP connector distinguishes raw-only,
+  queued orchestrator, successful direct drafting, and drafting failure.
+- **Connector patch.** The MCP package advances to **0.1.5**.
+- Backend, frontend, and MCP regression suites cover the hosted fallback.
+
 ## 0.2.3. Named titles survive query retrieval
 
 `query_wiki` could answer a question that named *State, Not Tokens* from

--- a/README.md
+++ b/README.md
@@ -434,9 +434,9 @@ title matches.
 > on the same on-disk page format, so the user-facing wiki is
 > identical either way.
 
-`/owner/ingest` (and the capture endpoints with
-`run_orchestrator: true`) run the full Karpathy ingest pipeline
-server-side. Under the hood this shells out to:
+`/owner/ingest` and the capture endpoints process sources when
+`run_orchestrator: true`. Self-hosted deployments with Puppetmaster shell out
+to:
 
 ```bash
 puppetmaster cursor "<ingest goal>" --cwd $WIKI_ROOT --timeout-seconds 600
@@ -456,7 +456,8 @@ Endpoints:
 
 | Method | Path | Description |
 |---|---|---|
-| POST | `/owner/ingest` with `run_orchestrator: true` | save raw + kick off Puppetmaster Cursor agent |
+| POST | `/owner/ingest` with `run_orchestrator: true` | save raw + start Puppetmaster, or draft directly on hosted deployments |
+| POST | `/owner/raw/{path}/reingest` | reprocess an existing raw source through the same two execution paths |
 | GET | `/owner/jobs` | list all tracked Puppetmaster jobs |
 | GET | `/owner/jobs/{tracking_id}` | live status + log tail + Puppetmaster `status`/`show` output |
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -199,7 +199,7 @@ def _maybe_start_tenant_pull_poller(_persistence):
 
 app = FastAPI(
     title="Portable LLM Wiki",
-    version="0.2.3",
+    version="0.2.4",
     description=(
         "Vendor-neutral HTTP transport for a Karpathy-style personal LLM wiki. "
         "Any LLM client that can fetch URLs can read the wiki via this API."
@@ -1402,8 +1402,37 @@ def owner_persistence_flush(_: Viewer = Depends(require_owner)) -> dict:
     return _persistence.flush_now("manual sync from owner console")
 
 
+async def _draft_capture_without_orchestrator(
+    *, source_label: str, source_content: str
+) -> dict:
+    """Draft captured material when the Puppetmaster process cannot start."""
+    from . import direct_drafter
+    from .tenants import current_tenant
+
+    try:
+        draft = await direct_drafter.draft_capture_pages(
+            source_label=source_label,
+            source_content=source_content,
+            tenant=current_tenant(),
+        )
+        return {
+            "pages_created": len(draft.pages),
+            "pages": [
+                {"slug": p.slug, "title": p.title, "section": p.section}
+                for p in draft.pages
+            ],
+            "backend": draft.backend,
+            "model": draft.model,
+            "warnings": draft.warnings,
+        }
+    except direct_drafter.NoLLMConfigured as exc:
+        return {"error": str(exc), "kind": "no_llm_configured"}
+    except Exception as exc:  # noqa: BLE001
+        return {"error": str(exc)[:300], "kind": "draft_failed"}
+
+
 @app.post("/owner/ingest", status_code=status.HTTP_201_CREATED)
-def owner_ingest(req: IngestRequest, _: Viewer = Depends(require_owner)) -> dict:
+async def owner_ingest(req: IngestRequest, _: Viewer = Depends(require_owner)) -> dict:
     slug = _safe_slug(req.slug)
     today = date.today().isoformat()
     raw_dir = settings.raw_dir / req.subdir
@@ -1422,6 +1451,7 @@ def owner_ingest(req: IngestRequest, _: Viewer = Depends(require_owner)) -> dict
         "rel_path": rel_path,
         "size": file_path.stat().st_size,
         "orchestrator": None,
+        "drafted": None,
     }
 
     if req.run_orchestrator:
@@ -1432,6 +1462,12 @@ def owner_ingest(req: IngestRequest, _: Viewer = Depends(require_owner)) -> dict
                 "status": job.status,
                 "started_at": job.started_at,
             }
+        except OrchestratorUnavailable as exc:
+            response["orchestrator"] = {"error": str(exc)}
+            response["drafted"] = await _draft_capture_without_orchestrator(
+                source_label=req.note or slug,
+                source_content=req.content,
+            )
         except Exception as exc:  # noqa: BLE001
             response["orchestrator"] = {"error": str(exc)}
 
@@ -2857,27 +2893,40 @@ def owner_raw_bulk(
 
 
 @app.post("/owner/raw/{rel_path:path}/reingest")
-def owner_reingest_raw(
+async def owner_reingest_raw(
     rel_path: str, _: Viewer = Depends(require_owner)
 ) -> dict:
-    """Re-run the Puppetmaster ingest on an existing raw file.
+    """Reprocess an existing raw file.
 
     Useful when:
       - The original ingest was interrupted or errored
       - You've improved your prompt templates and want fresher drafts
       - The raw file is a long-form import that produced incomplete pages
 
-    Returns the tracking_id so the UI can poll /owner/jobs/{id} for status.
+    Returns a tracking ID when Puppetmaster starts, or a synchronous direct
+    drafting result on hosted deployments where the binary is unavailable.
     """
     full_rel = f"raw/{rel_path}" if not rel_path.startswith("raw/") else rel_path
-    if read_raw_file(full_rel) is None:
+    source_content = read_raw_file(full_rel)
+    if source_content is None:
         raise HTTPException(
             status_code=404, detail="Not found or path outside raw/"
         )
     try:
         job = start_ingest_job(full_rel, note="reingest from capture history")
     except OrchestratorUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        drafted = await _draft_capture_without_orchestrator(
+            source_label=Path(full_rel).stem,
+            source_content=source_content,
+        )
+        from . import persistence as _persistence
+
+        _persistence.flush_async(f"direct reingest {full_rel}")
+        return _with_sync({
+            "rel_path": full_rel,
+            "orchestrator": {"error": str(exc)},
+            "drafted": drafted,
+        })
     return {
         "tracking_id": job.tracking_id,
         "kind": job.kind,

--- a/backend/tests/test_capture_history.py
+++ b/backend/tests/test_capture_history.py
@@ -5,8 +5,8 @@ Covers:
   frontmatter, and excerpt_chars is clamped to [0, 1000]
 - `/owner/raw/{path}` and `DELETE /owner/raw/{path}` honor path-traversal
   guards (the most security-sensitive bit)
-- `/owner/raw/{path}/reingest` 404s on missing files and 503s when the
-  orchestrator isn't installed (which is the case in CI)
+- `/owner/raw/{path}/reingest` 404s on missing files and reports the hosted
+  direct-drafter fallback when the orchestrator is unavailable
 - `/owner/import/extract-pdf` rejects garbage, validates size, and
   returns text + page_count when given a real PDF
 
@@ -123,11 +123,11 @@ def test_reingest_raw_404_when_missing(client, owner_headers):
     assert r.status_code == 404
 
 
-def test_reingest_raw_responds_with_either_503_or_job_id(
+def test_reingest_raw_reports_hosted_fallback_when_worker_is_missing(
     client, owner_headers, wiki_root, monkeypatch
 ):
-    """The reingest endpoint returns a clean 503 (not a 500/NameError) when
-    the orchestrator can't be spawned.
+    """The reingest endpoint exposes the direct fallback result when the
+    orchestrator can't be spawned.
 
     We force PUPPETMASTER_BIN to a path that can't exist so the test is
     deterministic AND never spawns a real billable Cursor agent. Without
@@ -145,9 +145,10 @@ def test_reingest_raw_responds_with_either_503_or_job_id(
 
     rel = _write_raw(wiki_root, "conversations", "queue-me.md", "body")
     r = client.post(f"/owner/{rel}/reingest", headers=owner_headers)
-    assert r.status_code == 503
-    detail = r.json()["detail"].lower()
-    assert "orchestrator" in detail or "puppetmaster" in detail
+    assert r.status_code == 200
+    body = r.json()
+    assert "puppetmaster" in body["orchestrator"]["error"].lower()
+    assert body["drafted"]["kind"] == "no_llm_configured"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_capture_ingest.py
+++ b/backend/tests/test_capture_ingest.py
@@ -40,7 +40,7 @@ def _orchestrator_always_fails(monkeypatch):
     OrchestratorUnavailable from start_ingest_job. We also stub the
     main module's import binding because it caches the function."""
 
-    def boom(_rel_path, _note=""):
+    def boom(_rel_path, _note="", **_kwargs):
         raise _orchestrator.OrchestratorUnavailable(
             "puppetmaster binary not found"
         )
@@ -197,6 +197,127 @@ def test_paste_with_ingest_falls_back_to_direct_drafter(
     decisions = list((wiki / "decisions").glob("*use-postgres-for-events.md"))
     assert decisions, list((wiki / "decisions").iterdir())
     assert (wiki / "projects" / "events-table.md").exists()
+
+
+def test_owner_ingest_falls_back_to_direct_drafter(
+    client, owner_headers, wiki_root, monkeypatch
+):
+    """The MCP-facing ingest endpoint must work on hosted Render too.
+
+    ``/owner/ingest`` predates the capture endpoint and used to report the
+    missing Puppetmaster binary without attempting the direct drafter.
+    """
+    _orchestrator_always_fails(monkeypatch)
+    _stub_drafter_returns(
+        monkeypatch,
+        pages=[
+            {
+                "slug": "hosted-ingest-decision",
+                "title": "Hosted Ingest Decision",
+                "section": "decisions",
+                "tier": "private",
+                "tags": ["ingest"],
+                "body": "## Decision\n\nUse the hosted direct drafter fallback.",
+            }
+        ],
+    )
+
+    r = client.post(
+        "/owner/ingest",
+        headers=owner_headers,
+        json={
+            "slug": "hosted-ingest-fallback",
+            "content": _MIN_BODY,
+            "subdir": "conversations",
+            "note": "MCP capture",
+            "run_orchestrator": True,
+        },
+    )
+
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert "error" in body["orchestrator"]
+    assert body["drafted"]["pages_created"] == 1
+    assert list(
+        (wiki_root / "wiki" / "decisions").glob("*hosted-ingest-decision.md")
+    )
+
+
+def test_owner_ingest_does_not_mask_an_unexpected_start_failure(
+    client, owner_headers, wiki_root, monkeypatch
+):
+    def fail_unexpectedly(_rel_path, _note=""):
+        raise RuntimeError("unexpected startup failure")
+
+    async def fail_if_called(**_kwargs):
+        raise AssertionError("direct drafter must only replace an unavailable worker")
+
+    monkeypatch.setattr("app.main.start_ingest_job", fail_unexpectedly)
+    monkeypatch.setattr(
+        "app.main._draft_capture_without_orchestrator", fail_if_called
+    )
+
+    r = client.post(
+        "/owner/ingest",
+        headers=owner_headers,
+        json={
+            "slug": "unexpected-start-failure",
+            "content": _MIN_BODY,
+            "subdir": "conversations",
+            "run_orchestrator": True,
+        },
+    )
+
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["orchestrator"] == {"error": "unexpected startup failure"}
+    assert body["drafted"] is None
+
+
+def test_existing_raw_reingest_falls_back_to_direct_drafter(
+    client, owner_headers, wiki_root, monkeypatch
+):
+    """A saved raw source remains processable after a hosted PM failure."""
+    saved = client.post(
+        "/owner/ingest",
+        headers=owner_headers,
+        json={
+            "slug": "reingest-fallback",
+            "content": _MIN_BODY,
+            "subdir": "conversations",
+            "run_orchestrator": False,
+        },
+    )
+    assert saved.status_code == 201, saved.text
+    rel_path = saved.json()["rel_path"]
+
+    _orchestrator_always_fails(monkeypatch)
+    _stub_drafter_returns(
+        monkeypatch,
+        pages=[
+            {
+                "slug": "reingested-source",
+                "title": "Reingested Source",
+                "section": "projects",
+                "tier": "private",
+                "tags": ["ingest"],
+                "body": "## Source\n\nRecovered through the direct drafter.",
+            }
+        ],
+    )
+
+    stripped = rel_path.removeprefix("raw/")
+    r = client.post(
+        f"/owner/raw/{stripped}/reingest",
+        headers=owner_headers,
+    )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["rel_path"] == rel_path
+    assert "error" in body["orchestrator"]
+    assert body["drafted"]["pages_created"] == 1
+    assert (wiki_root / "wiki" / "projects" / "reingested-source.md").exists()
 
 
 def test_paste_drafted_pages_default_to_private_tier(

--- a/backend/tests/test_v1_polish.py
+++ b/backend/tests/test_v1_polish.py
@@ -162,11 +162,10 @@ def test_orchestrator_unavailable_raised_when_binary_missing(monkeypatch):
         orchestrator.start_ingest_job("raw/test.md", note="testing")
 
 
-def test_reingest_endpoint_returns_503_when_orchestrator_missing(
+def test_reingest_endpoint_reports_direct_fallback_when_orchestrator_missing(
     client, owner_headers, wiki_root
 ):
-    """End-to-end: hit /owner/raw/<path>/reingest with the orchestrator
-    binary missing. Expected: 503, not 500 (or NameError)."""
+    """Missing Puppetmaster is reported while the hosted fallback runs."""
     # Create a raw file so the endpoint gets past the existence check.
     raw_dir = wiki_root / "raw" / "conversations"
     raw_dir.mkdir(parents=True, exist_ok=True)
@@ -187,7 +186,7 @@ def test_reingest_endpoint_returns_503_when_orchestrator_missing(
             headers=owner_headers,
         )
 
-    # 503 = orchestrator unavailable. The detail message tells the
-    # caller exactly what's wrong (no NameError, no opaque 500).
-    assert r.status_code == 503
-    assert "puppetmaster" in r.json()["detail"].lower()
+    assert r.status_code == 200
+    body = r.json()
+    assert "puppetmaster" in body["orchestrator"]["error"].lower()
+    assert body["drafted"]["kind"] == "no_llm_configured"

--- a/frontend/app/owner/captures/page.tsx
+++ b/frontend/app/owner/captures/page.tsx
@@ -108,9 +108,21 @@ export default function CapturesPage() {
     setActionMsg(null);
     try {
       const result = await ownerReingestRaw(rel);
-      setActionMsg(
-        `re-ingest queued (job ${result.tracking_id}). watch /owner for status`,
-      );
+      setSync(result.sync ?? null);
+      if (result.drafted?.error) {
+        setActionMsg(`failed: ${result.drafted.error}`);
+      } else if (result.drafted) {
+        const count = result.drafted.pages_created ?? 0;
+        setActionMsg(
+          `re-ingest drafted ${count} page${count === 1 ? "" : "s"}`,
+        );
+      } else if (result.tracking_id) {
+        setActionMsg(
+          `re-ingest queued (job ${result.tracking_id}). watch /owner for status`,
+        );
+      } else {
+        setActionMsg("failed: re-ingest returned no job or drafted pages");
+      }
     } catch (e) {
       setActionMsg(`failed: ${(e as Error).message}`);
     }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -353,8 +353,19 @@ export type IngestResult = {
     started_at?: string;
     error?: string;
   } | null;
+  drafted?: DirectDraftResult | null;
   /** Durability verdict — present on all content-create responses. */
   sync?: SyncVerdict;
+};
+
+export type DirectDraftResult = {
+  pages_created?: number;
+  pages?: Array<{ slug: string; title: string; section: string }>;
+  backend?: string;
+  model?: string;
+  warnings?: string[];
+  error?: string;
+  kind?: "no_llm_configured" | "draft_failed";
 };
 
 export async function ownerIngest(input: {
@@ -1059,17 +1070,26 @@ export async function ownerDeleteRaw(
   return r.json() as Promise<{ ok: boolean; rel_path: string; sync?: SyncVerdict }>;
 }
 
-export async function ownerReingestRaw(relPath: string, tenant?: string): Promise<{
-  tracking_id: string;
-  kind: string;
-  started_at: string;
-}> {
+export type ReingestRawResult = {
+  tracking_id?: string;
+  kind?: string;
+  started_at?: string;
+  rel_path?: string;
+  orchestrator?: { error?: string };
+  drafted?: DirectDraftResult | null;
+  sync?: SyncVerdict;
+};
+
+export async function ownerReingestRaw(
+  relPath: string,
+  tenant?: string,
+): Promise<ReingestRawResult> {
   const stripped = relPath.startsWith("raw/") ? relPath.slice(4) : relPath;
   const r = await apiFetch(
     `${wikiBase(tenant)}/owner/raw/${encodeRawPath(stripped)}/reingest`,
     { method: "POST", headers: ownerHeaders() }
   );
-  return asJson(r);
+  return asJson<ReingestRawResult>(r);
 }
 
 // Encode path segments of a raw rel_path but preserve the slashes so the

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portable-llm-wiki-frontend",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portable-llm-wiki-frontend",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@types/d3-force": "^3.0.10",
         "@vercel/analytics": "^2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-llm-wiki-frontend",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "scripts": {
     "dev": "next dev -H 0.0.0.0 -p 3000",

--- a/frontend/tests/CapturesPage.test.tsx
+++ b/frontend/tests/CapturesPage.test.tsx
@@ -21,11 +21,12 @@ vi.mock("@/lib/api", () => ({
   ownerReingestRaw: vi.fn(),
 }));
 
-import { ownerListRaw, ownerReadRaw } from "@/lib/api";
+import { ownerListRaw, ownerReadRaw, ownerReingestRaw } from "@/lib/api";
 import CapturesPage from "@/app/owner/captures/page";
 
 const mockedList = vi.mocked(ownerListRaw);
 const mockedRead = vi.mocked(ownerReadRaw);
+const mockedReingest = vi.mocked(ownerReingestRaw);
 
 const SAMPLE_ROWS = [
   {
@@ -55,6 +56,7 @@ describe("CapturesPage", () => {
   beforeEach(() => {
     mockedList.mockReset();
     mockedRead.mockReset();
+    mockedReingest.mockReset();
     window.localStorage.setItem("llmwiki:ownerToken", "fake-test-token");
   });
 
@@ -140,5 +142,31 @@ describe("CapturesPage", () => {
     expect(
       screen.getByText("raw/conversations/2024-01-01-paste.md"),
     ).toBeInTheDocument();
+  });
+
+  it("reports pages drafted by the hosted re-ingest fallback", async () => {
+    mockedList.mockResolvedValue([SAMPLE_ROWS[0]]);
+    mockedReingest.mockResolvedValue({
+      rel_path: SAMPLE_ROWS[0].rel_path,
+      orchestrator: { error: "puppetmaster binary not found" },
+      drafted: {
+        pages_created: 2,
+        pages: [
+          { slug: "one", title: "One", section: "concepts" },
+          { slug: "two", title: "Two", section: "decisions" },
+        ],
+        backend: "openai",
+        model: "test-model",
+        warnings: [],
+      },
+    });
+    const user = userEvent.setup();
+
+    render(<CapturesPage />);
+    await user.click(await screen.findByRole("button", { name: "re-ingest" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/re-ingest drafted 2 pages/i)).toBeInTheDocument();
+    });
   });
 });

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -126,7 +126,7 @@ API (`/wiki/manifest.json` returns 404).
 | `search_wiki` | Fast keyword search across visible pages. | no |
 | `query_wiki` | The primary tool. Natural-language question → graph-aware retrieval → sourced answer with citations. | no |
 | `get_neighbors` | All pages within N hops of a slug along the wikilink graph. | no |
-| `ingest_source` | Save a new raw source + optionally kick off the ingest orchestrator. Fails closed if not owner-capable. | **yes** |
+| `ingest_source` | Save a new raw source, then optionally start the orchestrator or hosted direct drafter. Fails closed if not owner-capable. | **yes** |
 | `ingest_job_status` | Bounded polling of `GET /owner/jobs/{tracking_id}` (+ optional persistence). Verifies orchestrator outcome honestly. | **yes** |
 | `lint_wiki` | Structural lint report (orphans, stale, broken provenance, etc.). | **yes** |
 
@@ -144,12 +144,14 @@ API (`/wiki/manifest.json` returns 404).
 1. Call `connection_status` — confirm `capabilities.write` is true.
 2. Call `ingest_source` — response separates:
    - `raw_file: saved` (disk write only)
-   - `wiki_graph_pages: not_updated_by_raw_save`
+   - `wiki_graph_pages: not_updated_by_raw_save | updated_by_direct_drafter`
    - `orchestrator: not_requested | pending | running | failed | completed | skipped`
+   - `direct_drafter: completed | failed` when the hosted fallback runs
    - `durable_sync: will_sync | local_only` (from the backend sync verdict)
-3. If you passed `run_orchestrator=true`, call `ingest_job_status` with the
-   `tracking_id` and optional bounded `poll_attempts` / `poll_interval_ms`
-   (caps: 20 attempts, 5000 ms). Do not treat a raw save as a graph update.
+3. When the response includes a `tracking_id`, call `ingest_job_status` with
+   optional bounded `poll_attempts` / `poll_interval_ms` (caps: 20 attempts,
+   5000 ms). A successful synchronous direct-drafter result needs no polling.
+   Do not treat a raw save by itself as a graph update.
 
 Without an owner-capable token, owner-only tools return an actionable error
 explaining that browser OAuth cookies are unavailable to stdio and that a

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portable-llm-wiki-mcp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portable-llm-wiki-mcp",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.18.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-llm-wiki-mcp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MCP server that exposes a Portable LLM Wiki to Cursor, Claude Desktop, or any MCP-aware LLM client.",
   "type": "module",
   "main": "dist/server.js",

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -53,7 +53,7 @@ function asError(err: unknown): {
 const server = new McpServer(
   {
     name: "portable-llm-wiki",
-    version: "0.1.4",
+    version: "0.1.5",
   },
   {
     instructions: `You are connected to a Portable LLM Wiki via stdio MCP at ${wiki.baseUrl}.
@@ -70,8 +70,8 @@ Typical flow:
 2. For specific questions, call \`query_wiki\` — graph-aware retrieval with sources.
 3. For exploration, use \`search_wiki\` (keyword) or \`get_neighbors\` (graph walk).
 4. \`read_page\` returns the full body of a single page when you need quotes.
-5. Owner-only: \`ingest_source\` saves a raw file and may start an orchestrator job;
-   it does NOT mean wiki graph pages are updated. Use \`ingest_job_status\` to verify.
+5. Owner-only: \`ingest_source\` saves a raw file and may start an orchestrator job
+   or draft pages synchronously. Trust the returned status; poll a tracking ID when present.
 
 Every page has a tier (\`public\`/\`recruiter\`/\`friend\`/\`private\`). Pages above
 your tier are invisible — don't synthesize claims about them.`,
@@ -337,7 +337,7 @@ server.registerTool(
   {
     title: "Ingest a new source into the wiki (owner-only)",
     description:
-      "Owner-only. Probes owner capability BEFORE sending content (stdio has no browser cookies). Saves raw content under raw/<subdir>/YYYY-MM-DD-<slug>.md and optionally starts the ingest orchestrator. Reports raw_file vs orchestrator vs durable_sync separately — never claims graph pages are updated merely because a raw file was saved. Use ingest_job_status with the returned tracking_id to verify orchestrator progress.",
+      "Owner-only. Probes owner capability BEFORE sending content (stdio has no browser cookies). Saves raw content under raw/<subdir>/YYYY-MM-DD-<slug>.md and optionally starts the ingest orchestrator. Hosted backends may draft pages synchronously when Puppetmaster is unavailable. Reports raw_file, graph pages, orchestrator, direct drafter, and durable sync separately. Use ingest_job_status when a tracking_id is returned.",
     inputSchema: {
       slug: z
         .string()
@@ -354,7 +354,7 @@ server.registerTool(
         .boolean()
         .optional()
         .describe(
-          "If true, kick off the ingest orchestrator (costs LLM tokens). Default false. Graph updates only happen if/when that job completes."
+          "If true, process the source with the ingest orchestrator or the hosted direct drafter fallback (costs LLM tokens). Default false."
         ),
     },
   },

--- a/mcp/src/wikiClient.ts
+++ b/mcp/src/wikiClient.ts
@@ -54,6 +54,15 @@ export interface IngestApiResult {
     started_at?: string;
     error?: string;
   } | null;
+  drafted?: {
+    pages_created?: number;
+    pages?: Array<{ slug: string; title: string; section: string }>;
+    backend?: string;
+    model?: string;
+    warnings?: string[];
+    error?: string;
+    kind?: string;
+  } | null;
   sync?: SyncVerdict;
 }
 
@@ -248,12 +257,24 @@ export function formatIngestReport(
   runOrchestrator: boolean
 ): string {
   const orch = normalizeOrchestratorState(result.orchestrator, runOrchestrator);
+  const draftedPages = result.drafted?.pages_created;
+  const draftedSuccessfully =
+    !result.drafted?.error && typeof draftedPages === "number";
   const lines = [
     "Ingest result (honest status):",
     `- raw_file: saved (${result.rel_path}, ${result.size} bytes)`,
-    `- wiki_graph_pages: not_updated_by_raw_save`,
+    draftedSuccessfully && draftedPages > 0
+      ? `- wiki_graph_pages: updated_by_direct_drafter (${draftedPages} pages)`
+      : `- wiki_graph_pages: not_updated_by_raw_save`,
     `- orchestrator: ${orch.state} — ${orch.detail}`,
   ];
+  if (result.drafted) {
+    lines.push(
+      result.drafted.error
+        ? `- direct_drafter: failed (${result.drafted.kind ?? "draft_failed"}) — ${result.drafted.error}`
+        : `- direct_drafter: completed (${draftedPages ?? 0} pages)`
+    );
+  }
   if (orch.tracking_id) {
     lines.push(
       `- tracking_id: ${orch.tracking_id} (use ingest_job_status to verify progress)`

--- a/mcp/test/reliability.test.mjs
+++ b/mcp/test/reliability.test.mjs
@@ -338,6 +338,32 @@ test("formatIngestReport distinguishes orchestrator running from raw save", () =
   assert.match(report, /will_sync/);
 });
 
+test("formatIngestReport reports completed direct drafting after orchestrator fallback", () => {
+  const report = formatIngestReport(
+    {
+      ok: true,
+      rel_path: "raw/conversations/x.md",
+      size: 10,
+      orchestrator: { error: "puppetmaster binary not found" },
+      drafted: {
+        pages_created: 2,
+        pages: [
+          { slug: "one", title: "One", section: "concepts" },
+          { slug: "two", title: "Two", section: "decisions" },
+        ],
+        backend: "openai",
+        model: "test-model",
+        warnings: [],
+      },
+    },
+    true
+  );
+  assert.match(report, /orchestrator: failed/);
+  assert.match(report, /wiki_graph_pages: updated_by_direct_drafter \(2 pages\)/);
+  assert.match(report, /direct_drafter: completed/);
+  assert.doesNotMatch(report, /wiki_graph_pages: not_updated_by_raw_save/);
+});
+
 test("normalizeOrchestratorState covers pending/failed/completed", () => {
   assert.equal(
     normalizeOrchestratorState({ tracking_id: "t1", status: "pending" }, true)


### PR DESCRIPTION
The hosted owner ingest saved raw sources but could not produce wiki pages when Render lacked the Puppetmaster executable. A fresh ingest or a single saved-capture reingest now uses the existing direct LLM drafter when Puppetmaster is unavailable, while preserving the orchestrator error, page count, and persistence verdict in the API, owner UI, and MCP response.

Live trigger before this change: reingesting `raw/conversations/2026-09-11-marionette-459-460-puppetmaster-12711-execution-truth.md` returned HTTP 503 with `puppetmaster binary not found`. After deployment, the same existing raw source can be processed without creating a duplicate capture.

Validation:
- backend: 492 passed
- frontend: 30 files / 209 tests passed, TypeScript and production build passed
- MCP: 16 tests passed, smoke test passed
- dev CI: https://github.com/professorpalmer/portable-llm-wiki/actions/runs/34570234884

Live after merge: the hosted API reports 0.2.4. Replaying the exact existing raw capture returned HTTP 200, drafted four private pages, raised the owner-visible manifest from 2,515 to 2,519 pages, and durably synced connected-repository commit `45ae2e2e7dca`.
