### PR TITLE
0.3.0: sealed tiers and session-LLM write tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ Backend **0.3.0**, MCP connector **0.3.0**.
   - Frontend: unlock control in the nav, decrypted page/browse/graph/search
     rendering, and an owner Sealing panel (enable, seal existing pages in
     place, disable).
+  - Hardening from review: a `sealed: v1` marker with a body that is not
+    a well-formed envelope is refused (no plaintext smuggling); sealed
+    verbatim writes return `409 sealed_slug_exists` instead of a
+    renamed file, since the envelope is bound to its slug; after
+    `DELETE /owner/sealing` the keyring stays readable (manifest
+    `sealing.enabled: false`) so leftover sealed pages still unlock and
+    can be unsealed; PATCH of a sealed page across the boundary is
+    refused regardless of enabled state; `/wiki/sealed/bundle` is 403
+    at the public tier; the lint swarm, lint drafts, image/audio
+    orchestrator kicks, reingest, and hosted onboarding imports all
+    return `409 sealing_enabled`. Documented that git history and
+    pre-existing file names are not rewritten.
   - With no keyring every response is byte-identical to before (verified
     against the baseline on a 2632-page corpus), so Marionette and other
     clients see no change until a wiki opts in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ ordered newest-first.
 
 ## Unreleased
 
+- **MCP write tools (server v0.2.0).** A session LLM can now write the wiki
+  graph through MCP without the server-side orchestrator: `write_pages`,
+  `write_page_verbatim`, `read_page_raw`, `replace_page`, `append_to_page`,
+  `set_page_tier`, `delete_page`, and `writeback_spec`. Owner tools fail
+  closed via `requireOwnerCapability()` before sending content. Preferred
+  ingest is draft locally from `writeback_spec`, then `write_pages`, then
+  append to `log` / `index`. `run_orchestrator=true` is the legacy path.
+- **`DELETE /owner/page/{slug}`.** Owner-only page delete with a wiki-dir
+  containment check, index reload, and durable sync verdict.
+
 ## 0.2.3. Named titles survive query retrieval
 
 `query_wiki` could answer a question that named *State, Not Tokens* from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ ordered newest-first.
 
 ## Unreleased
 
+- **Sealed tiers (MCP server v0.3.0).** Opt-in client-side encryption for
+  `private`, `friend`, and/or `recruiter`. The MCP process on the user's
+  machine (or the browser) derives a key from a passphrase (PBKDF2-SHA256,
+  600k iterations), encrypts each page as an AES-256-GCM envelope bound to
+  its slug, and the hosted server stores ciphertext only. Titles, tags,
+  sources, and bodies are encrypted; slugs are opaque (`s-<hmac>`) except
+  `index`, `log`, `overview`. The operator can see tier, section, dates,
+  count, and ciphertext. Lose the passphrase and nobody can recover the
+  pages.
+  - Backend: keyring at `wiki/.sealed/keyring.json`; `GET /wiki/sealing`,
+    `GET /wiki/sealed/bundle`, `PUT`/`DELETE /owner/sealing`; manifest
+    gains `sealing` only when enabled; `/wiki/query` reports
+    `sealed_excluded`. Sealed pages are excluded from search, query
+    context, and link graphs. Plaintext writes into a sealed tier, the
+    orchestrator, import, and lint return `409` with a `code`. `PATCH
+    /owner/page/{slug}/tier` refuses to cross the seal boundary.
+  - MCP: `seal_init`, `seal_disable`, `seal_status`, `seal_page`,
+    `unseal_page`; `write_pages` seals automatically when `private` is
+    sealed, `append_to_page` re-seals, `read_page` / `read_page_raw`
+    decrypt locally, `search_wiki` / `query_wiki` merge locally decrypted
+    hits. `WIKI_SEAL_PASSPHRASE` unlocks the process; missing or wrong
+    means locked, and locked never sends plaintext.
+  - Frontend: unlock control in the nav, decrypted page/browse/graph/search
+    rendering, and an owner Sealing panel (enable, seal existing pages in
+    place, disable).
+  - With no keyring every response is byte-identical to before (verified
+    against the baseline on a 2632-page corpus), so Marionette and other
+    clients see no change until a wiki opts in.
 - **MCP write tools (server v0.2.0).** A session LLM can now write the wiki
   graph through MCP without the server-side orchestrator: `write_pages`,
   `write_page_verbatim`, `read_page_raw`, `replace_page`, `append_to_page`,

--- a/README.md
+++ b/README.md
@@ -343,6 +343,33 @@ when you point the backend at an existing wiki.
 - `Authorization: Bearer <SHARE_TOKEN>` → tier configured in `SHARE_TOKENS`
   env var (format `tokenA:recruiter,tokenB:friend`).
 
+### Sealed tiers (operator cannot read them)
+
+Tier filtering keeps other viewers out. It does not keep the server
+operator out: a hosted backend reads plaintext markdown to build the
+graph. If that is not acceptable for your `private` material, seal it.
+
+Sealing is opt-in per wiki. Run the MCP tool `seal_init` (or use the
+Sealing panel in the owner console) with a passphrase. From then on:
+
+- Pages in sealed tiers are encrypted before they leave your machine
+  (AES-256-GCM per page, key derived from the passphrase with
+  PBKDF2-SHA256). The server stores `sealed: v1` envelopes and sees
+  tier, section, dates, count, and ciphertext. Titles, tags, sources,
+  bodies are encrypted; new slugs are opaque.
+- Your own LLM session writes the graph through the MCP write tools
+  (`write_pages`, `append_to_page`, ...), which seal automatically. The
+  server-side orchestrator, import, and lint are refused for sealed
+  wikis because they would need plaintext.
+- Reading happens where the key is: the MCP process (set
+  `WIKI_SEAL_PASSPHRASE`) or the browser (Unlock in the nav). Server
+  search and `/wiki/query` skip sealed pages; the clients search the
+  decrypted set locally.
+- Lose the passphrase and nobody can recover those pages, including the
+  operator.
+
+Public pages and unsealed wikis behave exactly as before.
+
 ## API
 
 The LLM-facing wire protocol. `/.well-known/llm-wiki.json`,

--- a/README.md
+++ b/README.md
@@ -368,6 +368,14 @@ Sealing panel in the owner console) with a passphrase. From then on:
 - Lose the passphrase and nobody can recover those pages, including the
   operator.
 
+What sealing does not do: it does not rewrite git history. Pages that
+existed as plaintext before you sealed them are still plaintext in
+earlier commits of the wiki repository until you rotate that history
+(for example, start a fresh repository). Sealing existing pages keeps
+their file names, so title-derived slugs remain visible; pages created
+after sealing get opaque slugs. Raw captures under `raw/` are not
+sealed.
+
 Public pages and unsealed wikis behave exactly as before.
 
 ## API

--- a/backend/app/hosted_routes.py
+++ b/backend/app/hosted_routes.py
@@ -51,7 +51,7 @@ from fastapi import APIRouter, Body, Cookie, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 from pydantic import BaseModel, Field
 
-from . import github_api, onboarding_seed, persistence, tenants, url_scrape
+from . import github_api, onboarding_seed, persistence, sealing, tenants, url_scrape
 from .config import settings
 
 
@@ -993,6 +993,16 @@ def _write_raw_import(tenant: tenants.Tenant, kind: str, label: str, body: str) 
     return str(rel).replace("\\", "/")
 
 
+def _refuse_if_sealed(tenant: tenants.Tenant) -> None:
+    if sealing.load_state(tenant.wiki_root).enabled:
+        raise sealing.sealing_conflict(
+            "sealing_enabled",
+            "Server-side drafting and imports are disabled while sealing is "
+            "enabled for this wiki. Use the MCP write tools from your own "
+            "LLM session.",
+        )
+
+
 async def _draft_from_raw_with_fallback(
     *,
     tenant: tenants.Tenant,
@@ -1013,6 +1023,7 @@ async def _draft_from_raw_with_fallback(
     can stop saying "Orchestrator was unavailable" when in fact we
     drafted N pages.
     """
+    _refuse_if_sealed(tenant)
     out: dict = {"raw_path": raw_rel}
 
     if run_orchestrator:
@@ -2147,6 +2158,7 @@ async def onboarding_import_wiki(
     _require_hosted_mode()
     user = _require_session_user(request)
     tenant = tenants.manager().require(user["tenant_id"])
+    _refuse_if_sealed(tenant)
     mode = (req.mode or "verbatim").strip().lower()
     if mode not in ("verbatim", "standardize"):
         raise HTTPException(

--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -290,7 +290,10 @@ def _select_context_pages(
     anchors = reserved[:max_anchors]
     anchor_slugs = [p.slug for p in anchors]
     reserved_slugs = [p.slug for p in reserved]
-    breakdowns = score_pages(index.visible_pages(viewer_tier), load_access())
+    breakdowns = score_pages(
+        (p for p in index.visible_pages(viewer_tier) if not p.sealed),
+        load_access(),
+    )
 
     neighbor_budget = min(TOP_NEIGHBOR_RESERVE, max(0, max_total - len(reserved_slugs)))
     if neighbor_budget and reserved:
@@ -340,6 +343,8 @@ def _select_context_pages(
 
     if len(ordered_slugs) < 3:
         for page in index.visible_pages(viewer_tier):
+            if page.sealed:
+                continue
             if page.slug in ordered_slugs or _is_catalog_slug(page.slug):
                 continue
             tags_lower = [t.lower() for t in page.tags]
@@ -355,7 +360,7 @@ def _select_context_pages(
     chosen: list[Page] = []
     for s in ordered_slugs[:max_total]:
         p = index.get(s)
-        if p is not None:
+        if p is not None and not p.sealed:
             chosen.append(p)
 
     record_access(p.slug for p in chosen)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2469,6 +2469,32 @@ def owner_replace_page(
     })
 
 
+@app.delete("/owner/page/{slug}")
+def owner_delete_page(slug: str, _: Viewer = Depends(require_owner)) -> dict:
+    """Delete an existing wiki page file. Refuses paths that resolve
+    outside the wiki directory."""
+    page = index.get(slug)
+    if not page:
+        raise HTTPException(status_code=404, detail=f"No page with slug {slug!r}")
+    rel_path = page.rel_path
+    target = settings.wiki_root / rel_path
+    try:
+        target.resolve().relative_to(settings.wiki_dir.resolve())
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail="resolved path is not inside the wiki directory",
+        ) from None
+    try:
+        target.unlink()
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"delete failed: {exc}") from exc
+    index.reload()
+    from . import persistence as _persistence
+    _persistence.flush_async(f"delete page {rel_path}")
+    return _with_sync({"ok": True, "slug": slug, "rel_path": rel_path})
+
+
 @app.patch("/owner/page/{slug}/tier")
 def owner_patch_tier(slug: str, req: TierPatchRequest, _: Viewer = Depends(require_owner)) -> dict:
     new_tier = _validate_tier(req.tier)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -77,6 +77,7 @@ from .share_tokens import (
     purge_tokens as purge_share_tokens,
     revoke_token as revoke_share_token,
 )
+from . import sealing
 from .wiki import (
     Page,
     delete_raw_file,
@@ -516,6 +517,11 @@ class PageReplaceRequest(BaseModel):
     markdown: str = Field(..., min_length=5)
 
 
+class SealingPutRequest(BaseModel):
+    keyring: dict
+    force: bool = False
+
+
 # ---------- public, LLM-facing endpoints ----------
 
 
@@ -601,15 +607,15 @@ def _api_base_url() -> str:
     return f"{base}/api/backend"
 
 
-@app.get("/wiki/manifest.json", response_model=ManifestResponse)
-def manifest(viewer: Viewer = Depends(current_viewer)) -> ManifestResponse:
+@app.get("/wiki/manifest.json")
+def manifest(viewer: Viewer = Depends(current_viewer)) -> dict:
     _refresh()
     visible = index.visible_pages(viewer.tier)
     sections: dict[str, int] = {}
     for p in visible:
         sections[p.section] = sections.get(p.section, 0) + 1
     base = _api_base_url()
-    return ManifestResponse(
+    payload = ManifestResponse(
         wiki_title=settings.wiki_root.name,
         generated_at=datetime.now(timezone.utc).isoformat(),
         viewer_tier=viewer.tier,
@@ -632,7 +638,15 @@ def manifest(viewer: Viewer = Depends(current_viewer)) -> ManifestResponse:
             "endpoint with ?q=<terms>. To get a synthesized answer with "
             "citations, POST {\"question\": \"...\"} to the query endpoint."
         ),
-    )
+    ).model_dump()
+    if index.sealing.enabled:
+        payload["sealing"] = {
+            "enabled": True,
+            "tiers": list(index.sealing.tiers),
+            "keyring_url": "/wiki/sealing",
+            "bundle_url": "/wiki/sealed/bundle",
+        }
+    return payload
 
 
 @app.get("/wiki/page/{slug}")
@@ -703,7 +717,7 @@ def search(
 async def query(req: QueryRequest, viewer: Viewer = Depends(current_viewer)) -> dict:
     _refresh()
     result = await run_query(req.question, viewer_tier=viewer.tier)
-    return {
+    payload = {
         "question": req.question,
         "viewer_tier": viewer.tier,
         "answer": result.answer,
@@ -713,6 +727,42 @@ async def query(req: QueryRequest, viewer: Viewer = Depends(current_viewer)) -> 
         "used_pages": result.used_pages,
         "retrieval": result.retrieval,
     }
+    if index.sealing.enabled:
+        n = len(index.sealed_pages(viewer.tier))
+        if n > 0:
+            payload["sealed_excluded"] = n
+    return payload
+
+
+@app.get("/wiki/sealing")
+def wiki_sealing(viewer: Viewer = Depends(current_viewer)) -> dict:
+    _refresh()
+    state = index.sealing
+    if not state.enabled or not state.keyring:
+        raise HTTPException(status_code=404, detail="sealing is not enabled")
+    if not viewer.is_owner and viewer.tier == "public":
+        raise HTTPException(
+            status_code=403,
+            detail="sealing keyring is not visible at the public tier",
+        )
+    return state.keyring
+
+
+@app.get("/wiki/sealed/bundle")
+def wiki_sealed_bundle(viewer: Viewer = Depends(current_viewer)) -> dict:
+    _refresh()
+    pages = []
+    for page in index.sealed_pages(viewer.tier):
+        pages.append(
+            {
+                "slug": page.slug,
+                "section": page.section,
+                "tier": page.tier,
+                "updated": page.updated,
+                "envelope": page.envelope or "",
+            }
+        )
+    return {"pages": pages, "count": len(pages)}
 
 
 class ChatTurnIn(BaseModel):
@@ -1402,8 +1452,57 @@ def owner_persistence_flush(_: Viewer = Depends(require_owner)) -> dict:
     return _persistence.flush_now("manual sync from owner console")
 
 
+_SEALING_LLM_DISABLED = (
+    "Server-side LLM is disabled while sealing is enabled. Use MCP write "
+    "tools (write_pages / write_page_verbatim) on your machine."
+)
+
+
+@app.put("/owner/sealing")
+def owner_put_sealing(
+    req: SealingPutRequest, _: Viewer = Depends(require_owner)
+) -> dict:
+    try:
+        keyring = sealing.validate_keyring(req.keyring)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    path = settings.wiki_root / sealing.KEYRING_REL
+    if path.is_file() and not req.force:
+        raise sealing.sealing_conflict(
+            "keyring_exists",
+            "A keyring already exists. Pass force=true to replace it.",
+        )
+    sealing.write_keyring(settings.wiki_root, keyring)
+    index.reload()
+    from . import persistence as _persistence
+
+    _persistence.flush_async("enable sealing")
+    return _with_sync(
+        {
+            "ok": True,
+            "enabled": index.sealing.enabled,
+            "tiers": list(index.sealing.tiers),
+        }
+    )
+
+
+@app.delete("/owner/sealing")
+def owner_delete_sealing(_: Viewer = Depends(require_owner)) -> dict:
+    try:
+        sealing.disable(settings.wiki_root)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="sealing is not enabled") from None
+    index.reload()
+    from . import persistence as _persistence
+
+    _persistence.flush_async("disable sealing")
+    return _with_sync({"ok": True, "enabled": False})
+
+
 @app.post("/owner/ingest", status_code=status.HTTP_201_CREATED)
 def owner_ingest(req: IngestRequest, _: Viewer = Depends(require_owner)) -> dict:
+    if req.run_orchestrator and index.sealing.enabled:
+        raise sealing.sealing_conflict("sealing_enabled", _SEALING_LLM_DISABLED)
     slug = _safe_slug(req.slug)
     today = date.today().isoformat()
     raw_dir = settings.raw_dir / req.subdir
@@ -1535,6 +1634,8 @@ async def owner_import(req: ImportRequest, _: Viewer = Depends(require_owner)) -
        the pages so the frontend can skip straight to the "done"
        state without polling.
     """
+    if index.sealing.enabled:
+        raise sealing.sealing_conflict("sealing_enabled", _SEALING_LLM_DISABLED)
     today = date.today().isoformat()
     pages_before = {p.slug for p in index.all_pages()}
 
@@ -1662,6 +1763,8 @@ async def owner_capture_paste(
     if subdir not in ("conversations", "articles", "meetings", "assets"):
         raise HTTPException(status_code=400, detail=f"invalid subdir {subdir!r}")
     run_orch = bool(payload.get("run_orchestrator"))
+    if run_orch and index.sealing.enabled:
+        raise sealing.sealing_conflict("sealing_enabled", _SEALING_LLM_DISABLED)
     result = capture_paste(content=content, label=label, subdir=subdir)
 
     orchestrator_info = _maybe_kick_orchestrator(
@@ -1889,6 +1992,14 @@ def owner_capture_structured(
     from . import persistence as _persistence
     from .tenants import current_tenant
 
+    if "private" in index.sealing.tiers:
+        raise sealing.sealing_conflict(
+            "plaintext_into_sealed_tier",
+            "Cannot write plaintext into a sealed tier. Encrypt client-side "
+            "(MCP write tools or the browser sealer) and include 'sealed: v1' "
+            "frontmatter.",
+        )
+
     if not isinstance(payload, dict):
         raise HTTPException(status_code=400, detail="body must be a JSON object")
 
@@ -2113,6 +2224,13 @@ def owner_capture_verbatim(
         )
 
     force_overwrite = bool(payload.get("force_overwrite", False))
+
+    resulting_tier = sealing.frontmatter_tier(content) or "private"
+    violation = sealing.plaintext_write_violation(
+        index.sealing, resulting_tier, content
+    )
+    if violation:
+        raise sealing.sealing_conflict("plaintext_into_sealed_tier", violation)
 
     tenant = current_tenant()
     try:
@@ -2364,6 +2482,13 @@ def owner_get_job(tracking_id: str, _: Viewer = Depends(require_owner)) -> dict:
 @app.post("/owner/page", status_code=status.HTTP_201_CREATED)
 def owner_write_page(req: PageWriteRequest, _: Viewer = Depends(require_owner)) -> dict:
     tier = _validate_tier(req.tier)
+    if tier in index.sealing.tiers:
+        raise sealing.sealing_conflict(
+            "plaintext_into_sealed_tier",
+            "Cannot write plaintext into a sealed tier. Encrypt client-side "
+            "(MCP write tools or the browser sealer) and include 'sealed: v1' "
+            "frontmatter.",
+        )
     slug = _safe_slug(_slug_from_title(req.title))
     section_dir = settings.wiki_dir / req.section
     section_dir.mkdir(parents=True, exist_ok=True)
@@ -2447,8 +2572,12 @@ def owner_replace_page(
     page = index.get(slug)
     if not page:
         raise HTTPException(status_code=404, detail=f"No page with slug {slug!r}")
-    target = settings.wiki_root / page.rel_path
     new_text = req.markdown
+    put_tier = sealing.frontmatter_tier(new_text) or settings.default_tier
+    violation = sealing.plaintext_write_violation(index.sealing, put_tier, new_text)
+    if violation:
+        raise sealing.sealing_conflict("plaintext_into_sealed_tier", violation)
+    target = settings.wiki_root / page.rel_path
     if not new_text.endswith("\n"):
         new_text = new_text + "\n"
     try:
@@ -2501,6 +2630,16 @@ def owner_patch_tier(slug: str, req: TierPatchRequest, _: Viewer = Depends(requi
     page = index.get(slug)
     if not page:
         raise HTTPException(status_code=404, detail=f"No page with slug {slug!r}")
+    if index.sealing.enabled:
+        sealed_tiers = set(index.sealing.tiers)
+        if (page.sealed and new_tier not in sealed_tiers) or (
+            not page.sealed and new_tier in sealed_tiers
+        ):
+            raise sealing.sealing_conflict(
+                "seal_boundary_crossing",
+                "Cannot cross the seal boundary with PATCH. Use a single PUT "
+                "that changes tier and content together.",
+            )
     target = settings.wiki_root / page.rel_path
     text = target.read_text(encoding="utf-8")
     new_text = _set_tier_in_frontmatter(text, new_tier)
@@ -2546,6 +2685,8 @@ def _set_tier_in_frontmatter(text: str, new_tier: str) -> str:
 @app.post("/owner/lint")
 def owner_lint(_: Viewer = Depends(require_owner)) -> dict:
     _refresh()
+    if index.sealing.enabled:
+        raise sealing.sealing_conflict("sealing_enabled", _SEALING_LLM_DISABLED)
     return lint_wiki()
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -639,9 +639,9 @@ def manifest(viewer: Viewer = Depends(current_viewer)) -> dict:
             "citations, POST {\"question\": \"...\"} to the query endpoint."
         ),
     ).model_dump()
-    if index.sealing.enabled:
+    if index.sealing.keyring is not None:
         payload["sealing"] = {
-            "enabled": True,
+            "enabled": index.sealing.enabled,
             "tiers": list(index.sealing.tiers),
             "keyring_url": "/wiki/sealing",
             "bundle_url": "/wiki/sealed/bundle",
@@ -738,7 +738,7 @@ async def query(req: QueryRequest, viewer: Viewer = Depends(current_viewer)) -> 
 def wiki_sealing(viewer: Viewer = Depends(current_viewer)) -> dict:
     _refresh()
     state = index.sealing
-    if not state.enabled or not state.keyring:
+    if not state.keyring:
         raise HTTPException(status_code=404, detail="sealing is not enabled")
     if not viewer.is_owner and viewer.tier == "public":
         raise HTTPException(
@@ -751,6 +751,11 @@ def wiki_sealing(viewer: Viewer = Depends(current_viewer)) -> dict:
 @app.get("/wiki/sealed/bundle")
 def wiki_sealed_bundle(viewer: Viewer = Depends(current_viewer)) -> dict:
     _refresh()
+    if not viewer.is_owner and viewer.tier == "public":
+        raise HTTPException(
+            status_code=403,
+            detail="sealed bundle is not visible at the public tier",
+        )
     pages = []
     for page in index.sealed_pages(viewer.tier):
         pages.append(
@@ -1756,9 +1761,15 @@ class CaptureIngestRequest(BaseModel):
     note: Optional[str] = None
 
 
+def _refuse_if_sealed() -> None:
+    if index.sealing.enabled:
+        raise sealing.sealing_conflict("sealing_enabled", _SEALING_LLM_DISABLED)
+
+
 def _maybe_kick_orchestrator(rel_path: str, note: str | None, *, run: bool) -> dict | None:
     if not run:
         return None
+    _refuse_if_sealed()
     try:
         job = start_ingest_job(rel_path, note or "")
         return {
@@ -2269,6 +2280,21 @@ def owner_capture_verbatim(
         raise sealing.sealing_conflict("plaintext_into_sealed_tier", violation)
 
     tenant = current_tenant()
+    if sealing.is_sealed_markdown(content) and not force_overwrite:
+        try:
+            _, _, _, section, _, slug = _verbatim.parse_and_validate(
+                content=content, slug_override=slug_override
+            )
+        except _verbatim.VerbatimValidationError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        existing = tenant.wiki_root / "wiki" / section / f"{slug}.md"
+        if existing.exists():
+            raise sealing.sealing_conflict(
+                "sealed_slug_exists",
+                f"A page already exists at {section}/{slug}. Sealed envelopes "
+                "are bound to their slug, so the file cannot be renamed on "
+                "conflict. Pass force_overwrite=true to replace it.",
+            )
     try:
         result = _verbatim.write_verbatim(
             content=content,
@@ -2666,16 +2692,15 @@ def owner_patch_tier(slug: str, req: TierPatchRequest, _: Viewer = Depends(requi
     page = index.get(slug)
     if not page:
         raise HTTPException(status_code=404, detail=f"No page with slug {slug!r}")
-    if index.sealing.enabled:
-        sealed_tiers = set(index.sealing.tiers)
-        if (page.sealed and new_tier not in sealed_tiers) or (
-            not page.sealed and new_tier in sealed_tiers
-        ):
-            raise sealing.sealing_conflict(
-                "seal_boundary_crossing",
-                "Cannot cross the seal boundary with PATCH. Use a single PUT "
-                "that changes tier and content together.",
-            )
+    sealed_tiers = set(index.sealing.tiers)
+    if (page.sealed and new_tier not in sealed_tiers) or (
+        not page.sealed and new_tier in sealed_tiers
+    ):
+        raise sealing.sealing_conflict(
+            "seal_boundary_crossing",
+            "Cannot cross the seal boundary with PATCH. Use a single PUT "
+            "that changes tier and content together.",
+        )
     target = settings.wiki_root / page.rel_path
     text = target.read_text(encoding="utf-8")
     new_text = _set_tier_in_frontmatter(text, new_tier)
@@ -2745,6 +2770,7 @@ def owner_start_lint_swarm(
     Returns a swarm_id immediately. The frontend polls
     /owner/lint/swarm/{swarm_id} for live worker progress + aggregated findings.
     """
+    _refuse_if_sealed()
     try:
         record = start_lint_swarm(workers=req.workers)
     except ValueError as exc:
@@ -2802,6 +2828,7 @@ async def owner_draft_missing_page(
     ``"direct-llm"`` so the UI knows there's nothing to poll — the
     page is already on disk by the time this returns.
     """
+    _refuse_if_sealed()
     try:
         job = start_draft_missing_page(
             proposed_title=req.proposed_title,
@@ -2863,6 +2890,7 @@ async def owner_draft_contradiction(
     """Draft a reconciliation page for a semantic-lint contradiction
     finding. Falls back to direct-LLM the same way
     ``/owner/lint/draft/missing-page`` does — see its docstring."""
+    _refuse_if_sealed()
     try:
         job = start_draft_contradiction(
             page_a=req.page_a,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -607,15 +607,15 @@ def _api_base_url() -> str:
     return f"{base}/api/backend"
 
 
-@app.get("/wiki/manifest.json")
-def manifest(viewer: Viewer = Depends(current_viewer)) -> dict:
+@app.get("/wiki/manifest.json", response_model=ManifestResponse)
+def manifest(viewer: Viewer = Depends(current_viewer)):
     _refresh()
     visible = index.visible_pages(viewer.tier)
     sections: dict[str, int] = {}
     for p in visible:
         sections[p.section] = sections.get(p.section, 0) + 1
     base = _api_base_url()
-    payload = ManifestResponse(
+    response = ManifestResponse(
         wiki_title=settings.wiki_root.name,
         generated_at=datetime.now(timezone.utc).isoformat(),
         viewer_tier=viewer.tier,
@@ -638,15 +638,17 @@ def manifest(viewer: Viewer = Depends(current_viewer)) -> dict:
             "endpoint with ?q=<terms>. To get a synthesized answer with "
             "citations, POST {\"question\": \"...\"} to the query endpoint."
         ),
-    ).model_dump()
-    if index.sealing.keyring is not None:
-        payload["sealing"] = {
-            "enabled": index.sealing.enabled,
-            "tiers": list(index.sealing.tiers),
-            "keyring_url": "/wiki/sealing",
-            "bundle_url": "/wiki/sealed/bundle",
-        }
-    return payload
+    )
+    if index.sealing.keyring is None:
+        return response
+    payload = response.model_dump(mode="json")
+    payload["sealing"] = {
+        "enabled": index.sealing.enabled,
+        "tiers": list(index.sealing.tiers),
+        "keyring_url": "/wiki/sealing",
+        "bundle_url": "/wiki/sealed/bundle",
+    }
+    return JSONResponse(payload)
 
 
 @app.get("/wiki/page/{slug}")

--- a/backend/app/sealing.py
+++ b/backend/app/sealing.py
@@ -1,0 +1,211 @@
+"""Sealed-tier keyring helpers.
+
+Pure functions: load/validate/write the committed keyring, cheap
+frontmatter scans, and the 409 conflict constructor. No index I/O
+beyond the keyring path the caller supplies. Guards live at the HTTP
+boundary; this module does not touch routes.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+KEYRING_REL = Path("wiki/.sealed/keyring.json")
+SEALABLE_TIERS = ("recruiter", "friend", "private")
+
+_SEALED_LINE_RE = re.compile(r"^sealed:\s*v1\s*$", re.IGNORECASE | re.MULTILINE)
+_TIER_LINE_RE = re.compile(r"^tier:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+
+_PLAINTEXT_INTO_SEALED = (
+    "Cannot write plaintext into a sealed tier. Encrypt client-side "
+    "(MCP write tools or the browser sealer) and include 'sealed: v1' "
+    "frontmatter."
+)
+
+
+@dataclass(frozen=True)
+class SealingState:
+    enabled: bool
+    tiers: tuple[str, ...]
+    keyring: dict | None
+
+
+def _disabled(keyring: dict | None = None) -> SealingState:
+    return SealingState(enabled=False, tiers=(), keyring=keyring)
+
+
+def _require_b64(name: str, value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty base64-decodable string")
+    try:
+        decoded = base64.b64decode(value, validate=False)
+    except Exception as exc:
+        raise ValueError(f"{name} must be a non-empty base64-decodable string") from exc
+    if not decoded:
+        raise ValueError(f"{name} must be a non-empty base64-decodable string")
+    return value
+
+
+def validate_keyring(obj: object) -> dict:
+    """Return a normalized keyring dict or raise ValueError with a specific message."""
+    if not isinstance(obj, dict):
+        raise ValueError("keyring must be a JSON object")
+
+    if obj.get("v") != 1:
+        raise ValueError("v must be 1")
+
+    tiers_raw = obj.get("tiers")
+    if not isinstance(tiers_raw, list) or not tiers_raw:
+        raise ValueError(
+            "tiers must be a non-empty subset of recruiter, friend, private"
+        )
+    tiers: list[str] = []
+    allowed = set(SEALABLE_TIERS)
+    for item in tiers_raw:
+        if not isinstance(item, str) or item not in allowed:
+            raise ValueError(
+                "tiers must be a non-empty subset of recruiter, friend, private"
+            )
+        if item not in tiers:
+            tiers.append(item)
+
+    if obj.get("kdf") != "pbkdf2-sha256":
+        raise ValueError("kdf must be 'pbkdf2-sha256'")
+
+    iterations = obj.get("iterations")
+    if type(iterations) is not int or iterations < 100000:
+        raise ValueError("iterations must be an integer >= 100000")
+
+    salt = _require_b64("salt", obj.get("salt"))
+    wrapped_dek = _require_b64("wrapped_dek", obj.get("wrapped_dek"))
+    check = _require_b64("check", obj.get("check"))
+
+    created = obj.get("created")
+    if not isinstance(created, str) or not created:
+        raise ValueError("created must be a string")
+
+    return {
+        "v": 1,
+        "tiers": tiers,
+        "kdf": "pbkdf2-sha256",
+        "iterations": iterations,
+        "salt": salt,
+        "wrapped_dek": wrapped_dek,
+        "check": check,
+        "created": created,
+    }
+
+
+def load_state(wiki_root: Path) -> SealingState:
+    path = wiki_root / KEYRING_REL
+    if not path.is_file():
+        return _disabled()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.warning("malformed sealing keyring at %s; treating as disabled", path)
+        return _disabled()
+    if not isinstance(raw, dict):
+        logger.warning("malformed sealing keyring at %s; treating as disabled", path)
+        return _disabled()
+    tiers_raw = raw.get("tiers")
+    if isinstance(tiers_raw, list) and len(tiers_raw) == 0:
+        return _disabled(keyring=raw)
+    try:
+        keyring = validate_keyring(raw)
+    except ValueError:
+        logger.warning("malformed sealing keyring at %s; treating as disabled", path)
+        return _disabled()
+    return SealingState(
+        enabled=True,
+        tiers=tuple(keyring["tiers"]),
+        keyring=keyring,
+    )
+
+
+def write_keyring(wiki_root: Path, keyring: dict) -> dict:
+    validated = validate_keyring(keyring)
+    path = wiki_root / KEYRING_REL
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(validated, indent=2) + "\n", encoding="utf-8")
+    return validated
+
+
+def disable(wiki_root: Path) -> dict:
+    path = wiki_root / KEYRING_REL
+    if not path.is_file():
+        raise FileNotFoundError(str(path))
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise FileNotFoundError(str(path)) from exc
+    if not isinstance(raw, dict):
+        raise FileNotFoundError(str(path))
+    raw["tiers"] = []
+    path.write_text(json.dumps(raw, indent=2) + "\n", encoding="utf-8")
+    return raw
+
+
+def _frontmatter_block(text: str) -> str | None:
+    """Return the interior of the leading ``---`` block, or None.
+
+    Mirrors ``_set_tier_in_frontmatter``: scan lines, do not YAML-parse.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].rstrip("\r") != "---":
+        return None
+    end_idx: int | None = None
+    for i in range(1, len(lines)):
+        if lines[i].rstrip("\r") == "---":
+            end_idx = i
+            break
+    if end_idx is None:
+        return None
+    return "\n".join(lines[1:end_idx])
+
+
+def is_sealed_markdown(text: str) -> bool:
+    block = _frontmatter_block(text)
+    if block is None:
+        return False
+    return _SEALED_LINE_RE.search(block) is not None
+
+
+def frontmatter_tier(text: str) -> str | None:
+    block = _frontmatter_block(text)
+    if block is None:
+        return None
+    for line in block.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        if stripped.lower().startswith("tier:") and not stripped.startswith("#"):
+            match = _TIER_LINE_RE.match(stripped)
+            if not match:
+                return None
+            value = match.group(1).strip().strip("'\"")
+            return value.lower() or None
+    return None
+
+
+def plaintext_write_violation(
+    state: SealingState, tier: str, markdown: str
+) -> str | None:
+    if tier in state.tiers and not is_sealed_markdown(markdown):
+        return _PLAINTEXT_INTO_SEALED
+    return None
+
+
+def sealing_conflict(code: str, message: str) -> HTTPException:
+    return HTTPException(
+        status_code=409,
+        detail={"code": code, "message": message},
+    )

--- a/backend/app/sealing.py
+++ b/backend/app/sealing.py
@@ -118,7 +118,12 @@ def load_state(wiki_root: Path) -> SealingState:
         return _disabled()
     tiers_raw = raw.get("tiers")
     if isinstance(tiers_raw, list) and len(tiers_raw) == 0:
-        return _disabled(keyring=raw)
+        try:
+            keyring = validate_keyring({**raw, "tiers": ["private"]})
+        except ValueError:
+            logger.warning("malformed sealing keyring at %s; treating as disabled", path)
+            return _disabled()
+        return _disabled(keyring={**keyring, "tiers": []})
     try:
         keyring = validate_keyring(raw)
     except ValueError:
@@ -196,10 +201,43 @@ def frontmatter_tier(text: str) -> str | None:
     return None
 
 
+_MIN_ENVELOPE_BYTES = 12 + 16  # nonce || tag; ciphertext may be empty
+_B64_RE = re.compile(r"^[A-Za-z0-9+/]+={0,2}$")
+
+_MALFORMED_ENVELOPE = (
+    "Sealed document body is not a well-formed envelope "
+    "(base64 of nonce||ciphertext||tag). Plaintext under a 'sealed: v1' "
+    "marker is refused."
+)
+
+
+def _sealed_body(text: str) -> str | None:
+    lines = text.splitlines()
+    if not lines or lines[0].rstrip("\r") != "---":
+        return None
+    for i in range(1, len(lines)):
+        if lines[i].rstrip("\r") == "---":
+            return "".join("\n".join(lines[i + 1 :]).split())
+    return None
+
+
+def is_well_formed_envelope(compact: str) -> bool:
+    if not compact or len(compact) % 4 != 0 or not _B64_RE.match(compact):
+        return False
+    try:
+        raw = base64.b64decode(compact, validate=True)
+    except Exception:
+        return False
+    return len(raw) >= _MIN_ENVELOPE_BYTES
+
+
 def plaintext_write_violation(
     state: SealingState, tier: str, markdown: str
 ) -> str | None:
-    if tier in state.tiers and not is_sealed_markdown(markdown):
+    sealed = is_sealed_markdown(markdown)
+    if sealed and not is_well_formed_envelope(_sealed_body(markdown) or ""):
+        return _MALFORMED_ENVELOPE
+    if tier in state.tiers and not sealed:
         return _PLAINTEXT_INTO_SEALED
     return None
 

--- a/backend/app/verbatim_capture.py
+++ b/backend/app/verbatim_capture.py
@@ -57,6 +57,7 @@ from typing import Optional
 
 import frontmatter
 
+from .sealing import is_sealed_markdown
 from .tenants import Tenant
 
 logger = logging.getLogger(__name__)
@@ -226,25 +227,50 @@ def parse_and_validate(
         )
     section = TYPE_TO_SECTION[page_type]
 
+    sealed = is_sealed_markdown(content)
+
     # --- title ---
     raw_title = metadata.get("title")
-    if not raw_title or not isinstance(raw_title, str):
-        raise VerbatimValidationError(
-            "frontmatter is missing required field 'title' (or it's empty/"
-            "non-string)"
-        )
-    title = raw_title.strip()
-    if not title:
-        raise VerbatimValidationError("'title' is blank after trimming")
-    if len(title) > MAX_TITLE_LEN:
-        raise VerbatimValidationError(
-            f"'title' is {len(title)} chars; cap is {MAX_TITLE_LEN}. Shorten "
-            "the title; long context belongs in the body."
-        )
+    if sealed:
+        if raw_title is not None and not isinstance(raw_title, str):
+            raise VerbatimValidationError(
+                "'title' must be a string when provided"
+            )
+        title = (raw_title or "").strip()
+        if title and len(title) > MAX_TITLE_LEN:
+            raise VerbatimValidationError(
+                f"'title' is {len(title)} chars; cap is {MAX_TITLE_LEN}. Shorten "
+                "the title; long context belongs in the body."
+            )
+    else:
+        if not raw_title or not isinstance(raw_title, str):
+            raise VerbatimValidationError(
+                "frontmatter is missing required field 'title' (or it's empty/"
+                "non-string)"
+            )
+        title = raw_title.strip()
+        if not title:
+            raise VerbatimValidationError("'title' is blank after trimming")
+        if len(title) > MAX_TITLE_LEN:
+            raise VerbatimValidationError(
+                f"'title' is {len(title)} chars; cap is {MAX_TITLE_LEN}. Shorten "
+                "the title; long context belongs in the body."
+            )
 
-    # --- tier (optional, defaults to private) ---
+    # --- tier ---
     raw_tier = metadata.get("tier")
-    if raw_tier is None:
+    if sealed:
+        if not raw_tier or not isinstance(raw_tier, str):
+            raise VerbatimValidationError(
+                "frontmatter is missing required field 'tier'"
+            )
+        tier = raw_tier.strip().lower()
+        if not tier or tier not in VALID_TIERS:
+            raise VerbatimValidationError(
+                f"invalid tier {raw_tier!r}. Must be one of: "
+                + ", ".join(sorted(VALID_TIERS))
+            )
+    elif raw_tier is None:
         tier = "private"
     elif not isinstance(raw_tier, str):
         raise VerbatimValidationError(
@@ -264,14 +290,22 @@ def parse_and_validate(
     #   1. explicit slug_override (from request payload, e.g. user typed
     #      a slug in the UI form)
     #   2. ``slug`` field in the frontmatter
-    #   3. derived from title
+    #   3. derived from title (unsealed only — sealed docs must supply a slug)
     # Then we normalize: lowercase, ascii, hyphens, leading-trailing
     # hyphens stripped, capped length.
-    slug_source = (
-        slug_override
-        or metadata.get("slug")
-        or title
-    )
+    if sealed:
+        slug_source = slug_override or metadata.get("slug")
+        if not slug_source:
+            raise VerbatimValidationError(
+                "sealed documents require a slug (request 'slug' or "
+                "frontmatter 'slug:')"
+            )
+    else:
+        slug_source = (
+            slug_override
+            or metadata.get("slug")
+            or title
+        )
     if not isinstance(slug_source, str):
         raise VerbatimValidationError(
             "'slug' in frontmatter must be a string when provided"
@@ -291,8 +325,11 @@ def parse_and_validate(
         slug = f"{date.today().isoformat()}-{slug}"
         slug = slug[:MAX_SLUG_LEN]
 
+    if sealed and not title:
+        title = slug
+
     body = (post.content or "").strip()
-    if len(body) < MIN_BODY_CHARS:
+    if not sealed and len(body) < MIN_BODY_CHARS:
         raise VerbatimValidationError(
             "page body is empty (everything after the closing '---' is "
             "blank). Add at least a one-line summary."

--- a/backend/app/wiki.py
+++ b/backend/app/wiki.py
@@ -21,6 +21,7 @@ import frontmatter
 
 from .config import TIER_ORDER, VALID_TIERS, settings
 from .importance import load_access, score_pages
+from .sealing import SealingState, load_state
 
 # How long a freshness verdict is trusted before we re-walk the corpus.
 # Under load, ``reload_if_stale`` would otherwise rglob+stat every markdown
@@ -171,9 +172,11 @@ class Page:
     links_in: list[str] = field(default_factory=list)  # other page titles linking TO this page
     word_count: int = 0
     mtime: float = 0.0
+    sealed: bool = False
+    envelope: str | None = None
 
     def to_summary(self, base_url: str = "") -> dict:
-        return {
+        out = {
             "slug": self.slug,
             "title": self.title,
             "section": self.section,
@@ -187,15 +190,22 @@ class Page:
             "rel_path": self.rel_path,
             "url": f"{base_url}/wiki/page/{self.slug}" if base_url else f"/wiki/page/{self.slug}",
         }
+        if self.sealed:
+            out["sealed"] = True
+        return out
 
     def to_full(self, base_url: str = "") -> dict:
-        return {
+        out = {
             **self.to_summary(base_url=base_url),
             "body": self.body,
             "sources": self.sources,
-            "links_out": self.links_out,
-            "links_in": self.links_in,
+            "links_out": [] if self.sealed else self.links_out,
+            "links_in": [] if self.sealed else self.links_in,
         }
+        if self.sealed:
+            out["sources"] = []
+            out["envelope"] = self.envelope or ""
+        return out
 
 
 def _section_from_relpath(rel: Path) -> str:
@@ -286,6 +296,7 @@ class WikiIndex:
         self._last_scan: float = 0.0
         self._last_wiki_mtime: float = 0.0
         self._last_stale_check: float = 0.0
+        self.sealing: SealingState = SealingState(enabled=False, tiers=(), keyring=None)
 
     # ---------- public API ----------
 
@@ -335,13 +346,14 @@ class WikiIndex:
             for slug, page in pages.items():
                 for target_slug in page.links_out:
                     target = pages.get(target_slug)
-                    if target and slug not in target.links_in:
+                    if target and not target.sealed and slug not in target.links_in:
                         target.links_in.append(slug)
 
             self._pages_by_slug = pages
             self._slug_by_title = titles
             self._last_scan = datetime.now(timezone.utc).timestamp()
             self._last_wiki_mtime = self._latest_mtime(settings.wiki_dir)
+            self.sealing = load_state(settings.wiki_root)
 
     def all_pages(self) -> list[Page]:
         return list(self._pages_by_slug.values())
@@ -349,6 +361,14 @@ class WikiIndex:
     def visible_pages(self, viewer_tier: str) -> list[Page]:
         viewer_rank = TIER_ORDER.get(viewer_tier, 0)
         return [p for p in self._pages_by_slug.values() if TIER_ORDER[p.tier] <= viewer_rank]
+
+    def sealed_pages(self, viewer_tier: str) -> list[Page]:
+        viewer_rank = TIER_ORDER.get(viewer_tier, 0)
+        return [
+            p
+            for p in self._pages_by_slug.values()
+            if p.sealed and TIER_ORDER[p.tier] <= viewer_rank
+        ]
 
     def get(self, slug: str) -> Page | None:
         return self._pages_by_slug.get(slug)
@@ -474,6 +494,8 @@ class WikiIndex:
             return []
         results: list[tuple[Page, float]] = []
         for page in self.visible_pages(viewer_tier):
+            if page.sealed:
+                continue
             score = _phrase_bonus(query_folded, page.title, page.slug)
             title_tokens = set(_tokens(page.title))
             tag_tokens = set(_tokens(" ".join(page.tags)))
@@ -526,6 +548,33 @@ class WikiIndex:
                     body = raw[_end + 4:]
             meta = {}
         section = _section_from_relpath(rel)
+
+        sealed_raw = meta.get("sealed")
+        if sealed_raw is not None and str(sealed_raw).strip().lower() == "v1":
+            page_type = _infer_type(section, str(meta.get("type")) if meta.get("type") else None)
+            tier = _normalize_tier(meta.get("tier")) or settings.default_tier
+            created = str(meta.get("created")) if meta.get("created") else None
+            updated = str(meta.get("updated")) if meta.get("updated") else None
+            return Page(
+                slug=md_path.stem,
+                title="Sealed page",
+                rel_path=str(rel).replace("\\", "/"),
+                section=section,
+                page_type=page_type,
+                tier=tier,
+                created=created,
+                updated=updated,
+                sources=[],
+                tags=[],
+                body="",
+                excerpt="",
+                links_out=[],
+                links_in=[],
+                word_count=0,
+                mtime=md_path.stat().st_mtime,
+                sealed=True,
+                envelope="".join((body or "").split()),
+            )
 
         title = str(meta.get("title") or md_path.stem.replace("-", " ").title()).strip()
         slug = md_path.stem

--- a/backend/app/wiki.py
+++ b/backend/app/wiki.py
@@ -21,7 +21,7 @@ import frontmatter
 
 from .config import TIER_ORDER, VALID_TIERS, settings
 from .importance import load_access, score_pages
-from .sealing import SealingState, load_state
+from .sealing import SealingState, is_well_formed_envelope, load_state
 
 # How long a freshness verdict is trusted before we re-walk the corpus.
 # Under load, ``reload_if_stale`` would otherwise rglob+stat every markdown
@@ -551,6 +551,7 @@ class WikiIndex:
 
         sealed_raw = meta.get("sealed")
         if sealed_raw is not None and str(sealed_raw).strip().lower() == "v1":
+            compact = "".join((body or "").split())
             page_type = _infer_type(section, str(meta.get("type")) if meta.get("type") else None)
             tier = _normalize_tier(meta.get("tier")) or settings.default_tier
             created = str(meta.get("created")) if meta.get("created") else None
@@ -573,7 +574,7 @@ class WikiIndex:
                 word_count=0,
                 mtime=md_path.stat().st_mtime,
                 sealed=True,
-                envelope="".join((body or "").split()),
+                envelope=compact if is_well_formed_envelope(compact) else "",
             )
 
         title = str(meta.get("title") or md_path.stem.replace("-", " ").title()).strip()

--- a/backend/tests/test_hosted_multitenant.py
+++ b/backend/tests/test_hosted_multitenant.py
@@ -3928,3 +3928,32 @@ def test_logout_post_clears_session(multi_tenant_app):
     multi_tenant_app.cookies.delete("plw_session")
     r = multi_tenant_app.get("/auth/me")
     assert r.json().get("authenticated") is False
+
+
+def test_hosted_manifest_omits_sealing_without_keyring(multi_tenant_app):
+    r = multi_tenant_app.get("/t/alice/wiki/manifest.json")
+    assert r.status_code == 200
+    assert "sealing" not in r.json()
+
+
+def test_hosted_sealing_is_tenant_scoped(multi_tenant_app):
+    from tests.test_sealing import valid_keyring
+
+    _set_session_user(multi_tenant_app, "alice", login="alice")
+    r = multi_tenant_app.put(
+        "/t/alice/owner/sealing",
+        json={"keyring": valid_keyring()},
+    )
+    assert r.status_code == 200, r.text
+    alice = multi_tenant_app.get("/t/alice/wiki/manifest.json")
+    assert alice.status_code == 200
+    assert alice.json()["sealing"]["enabled"] is True
+    assert alice.json()["sealing"]["tiers"] == ["private"]
+    bob = multi_tenant_app.get("/t/bob/wiki/manifest.json")
+    assert bob.status_code == 200
+    assert "sealing" not in bob.json()
+    blocked = multi_tenant_app.post(
+        "/t/alice/owner/lint",
+    )
+    assert blocked.status_code == 409
+    assert blocked.json()["detail"]["code"] == "sealing_enabled"

--- a/backend/tests/test_owner_page_delete.py
+++ b/backend/tests/test_owner_page_delete.py
@@ -1,0 +1,80 @@
+"""DELETE /owner/page/{slug} — owner-only page removal."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _seed_deletable_page(wiki_root: Path, slug: str, title: str) -> Path:
+    path = wiki_root / "wiki" / "concepts" / f"{slug}.md"
+    path.write_text(
+        f"""---
+type: concept
+title: {title}
+tier: private
+created: 2026-09-12
+updated: 2026-09-12
+---
+
+Temporary page used only by the delete-route tests.
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_delete_page_removes_file_and_index(client, owner_headers, wiki_root):
+    from app.main import index
+
+    slug = "delete-target-happy"
+    path = _seed_deletable_page(wiki_root, slug, "Delete Target Happy")
+    try:
+        index.reload()
+        assert index.get(slug) is not None
+        assert path.is_file()
+
+        r = client.delete(f"/owner/page/{slug}", headers=owner_headers)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ok"] is True
+        assert data["slug"] == slug
+        assert data["rel_path"] == f"wiki/concepts/{slug}.md"
+        assert not path.exists()
+        assert index.get(slug) is None
+
+        missing = client.get(f"/wiki/page/{slug}", headers=owner_headers)
+        assert missing.status_code == 404
+    finally:
+        if path.exists():
+            path.unlink()
+            index.reload()
+
+
+def test_delete_unknown_slug_is_404(client, owner_headers):
+    r = client.delete("/owner/page/definitely-not-a-page", headers=owner_headers)
+    assert r.status_code == 404
+
+
+def test_delete_then_manifest_reflects_change(client, owner_headers, wiki_root):
+    from app.main import index
+
+    slug = "delete-target-manifest"
+    path = _seed_deletable_page(wiki_root, slug, "Delete Target Manifest")
+    try:
+        index.reload()
+
+        before = client.get("/wiki/manifest.json", headers=owner_headers)
+        assert before.status_code == 200
+        assert slug in {p["slug"] for p in before.json()["pages"]}
+
+        deleted = client.delete(f"/owner/page/{slug}", headers=owner_headers)
+        assert deleted.status_code == 200
+
+        after = client.get("/wiki/manifest.json", headers=owner_headers)
+        assert after.status_code == 200
+        assert slug not in {p["slug"] for p in after.json()["pages"]}
+        assert index.get(slug) is None
+        assert not path.exists()
+    finally:
+        if path.exists():
+            path.unlink()
+            index.reload()

--- a/backend/tests/test_sealing.py
+++ b/backend/tests/test_sealing.py
@@ -29,8 +29,11 @@ def valid_keyring(tiers: tuple[str, ...] = ("private",)) -> dict:
 
 
 SEALED_SLUG = "s-aaaabbbbccccdddd"
-SEALED_ENVELOPE_WRAPPED = "YWJjZGVm\n  Z2hpams=\n"
-SEALED_ENVELOPE_STRIPPED = "YWJjZGVmZ2hpams="
+# 12-byte nonce || 4-byte ciphertext || 16-byte tag, base64, wrapped like a client would.
+SEALED_ENVELOPE_STRIPPED = base64.b64encode(b"n" * 12 + b"ct!!" + b"t" * 16).decode()
+SEALED_ENVELOPE_WRAPPED = (
+    SEALED_ENVELOPE_STRIPPED[:20] + "\n  " + SEALED_ENVELOPE_STRIPPED[20:] + "\n"
+)
 
 SEALED_DOC = (
     "---\n"
@@ -384,8 +387,98 @@ def test_delete_sealing_disables_and_drops_manifest_key(client, owner_headers):
     assert r.status_code == 200
     assert r.json()["ok"] is True
     assert r.json()["enabled"] is False
-    assert "sealing" not in client.get("/wiki/manifest.json").json()
-    assert client.get("/wiki/sealing", headers=owner_headers).status_code == 404
+    after = client.get("/wiki/manifest.json").json()["sealing"]
+    assert after["enabled"] is False
+    assert after["tiers"] == []
+    keyring = client.get("/wiki/sealing", headers=owner_headers)
+    assert keyring.status_code == 200
+    assert keyring.json()["tiers"] == []
+    assert client.get("/wiki/sealing").status_code == 403
+    plain = client.post(
+        "/owner/capture/verbatim",
+        headers=owner_headers,
+        json={"content": "---\ntype: concept\ntitle: After Disable\ntier: private\n---\n\nplain again"},
+    )
+    assert plain.status_code == 201, plain.text
+
+
+def test_sealed_marker_with_plaintext_body_409(client, owner_headers):
+    _enable(client, owner_headers)
+    r = client.post(
+        "/owner/capture/verbatim",
+        headers=owner_headers,
+        json={
+            "content": (
+                "---\nsealed: v1\ntype: concept\ntier: private\nslug: s-1111222233334444\n---\n"
+                "This is plaintext hiding under a sealed marker."
+            ),
+            "force_overwrite": True,
+        },
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "plaintext_into_sealed_tier"
+
+
+def test_sealed_verbatim_conflict_is_409_not_suffix(client, owner_headers, wiki_root: Path):
+    _enable(client, owner_headers)
+    first = client.post(
+        "/owner/capture/verbatim", headers=owner_headers, json={"content": SEALED_DOC}
+    )
+    assert first.status_code == 201, first.text
+    second = client.post(
+        "/owner/capture/verbatim", headers=owner_headers, json={"content": SEALED_DOC}
+    )
+    assert second.status_code == 409
+    assert second.json()["detail"]["code"] == "sealed_slug_exists"
+    assert len(list((wiki_root / "wiki" / "concepts").glob(f"{SEALED_SLUG}*.md"))) == 1
+    forced = client.post(
+        "/owner/capture/verbatim",
+        headers=owner_headers,
+        json={"content": SEALED_DOC, "force_overwrite": True},
+    )
+    assert forced.status_code == 201
+    assert forced.json()["overwrote_existing"] is True
+
+
+def test_lint_swarm_and_drafts_409(client, owner_headers):
+    _enable(client, owner_headers)
+    for path, body in (
+        ("/owner/lint/swarm", {}),
+        (
+            "/owner/lint/draft/missing-page",
+            {"proposed_title": "Gap", "proposed_section": "concepts", "bootstrap_summary": "x"},
+        ),
+        (
+            "/owner/lint/draft/contradiction",
+            {"page_a": "index", "page_b": "log", "claim_a": "a", "claim_b": "b", "conflict": "c"},
+        ),
+    ):
+        r = client.post(path, headers=owner_headers, json=body)
+        assert r.status_code == 409, (path, r.text)
+        assert r.json()["detail"]["code"] == "sealing_enabled"
+
+
+def test_patch_sealed_page_refused_after_disable(client, owner_headers):
+    _enable(client, owner_headers)
+    written = client.post(
+        "/owner/capture/verbatim",
+        headers=owner_headers,
+        json={"content": SEALED_DOC, "force_overwrite": True},
+    ).json()["written"]
+    assert client.delete("/owner/sealing", headers=owner_headers).status_code == 200
+    r = client.patch(
+        f"/owner/page/{written['slug']}/tier",
+        headers=owner_headers,
+        json={"tier": "public"},
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "seal_boundary_crossing"
+
+
+def test_bundle_public_403(client, owner_headers):
+    _enable(client, owner_headers)
+    assert client.get("/wiki/sealed/bundle").status_code == 403
+    assert client.get("/wiki/sealed/bundle", headers=owner_headers).status_code == 200
 
 
 def test_delete_sealing_404_when_absent(client, owner_headers):
@@ -617,7 +710,7 @@ def test_put_with_sealed_marker_succeeds(client, owner_headers):
         json={
             "markdown": (
                 "---\nsealed: v1\ntype: concept\ntier: private\n"
-                f"slug: {slug}\n---\nYWJj\n"
+                f"slug: {slug}\n---\n{SEALED_ENVELOPE_STRIPPED}\n"
             )
         },
     )

--- a/backend/tests/test_sealing.py
+++ b/backend/tests/test_sealing.py
@@ -1,0 +1,727 @@
+"""Sealed-tier backend: keyring, loader, HTTP guards, zero-regression."""
+from __future__ import annotations
+
+import base64
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from app.sealing import (
+    KEYRING_REL,
+    load_state,
+    validate_keyring,
+)
+
+
+def valid_keyring(tiers: tuple[str, ...] = ("private",)) -> dict:
+    return {
+        "v": 1,
+        "tiers": list(tiers),
+        "kdf": "pbkdf2-sha256",
+        "iterations": 100000,
+        "salt": base64.b64encode(b"s" * 16).decode(),
+        "wrapped_dek": base64.b64encode(b"d" * 48).decode(),
+        "check": base64.b64encode(b"c" * 48).decode(),
+        "created": "2026-09-12T00:00:00Z",
+    }
+
+
+SEALED_SLUG = "s-aaaabbbbccccdddd"
+SEALED_ENVELOPE_WRAPPED = "YWJjZGVm\n  Z2hpams=\n"
+SEALED_ENVELOPE_STRIPPED = "YWJjZGVmZ2hpams="
+
+SEALED_DOC = (
+    "---\n"
+    "sealed: v1\n"
+    "type: concept\n"
+    "tier: private\n"
+    f"slug: {SEALED_SLUG}\n"
+    "created: 2026-09-12\n"
+    "updated: 2026-09-12\n"
+    "---\n"
+    f"{SEALED_ENVELOPE_WRAPPED}"
+)
+
+MANIFEST_KEYS = {
+    "wiki_title",
+    "generated_at",
+    "viewer_tier",
+    "viewer_is_owner",
+    "page_count",
+    "sections",
+    "pages",
+    "base_url",
+    "endpoints",
+    "instructions_for_llm",
+}
+SUMMARY_KEYS = {
+    "slug",
+    "title",
+    "section",
+    "type",
+    "tier",
+    "created",
+    "updated",
+    "tags",
+    "excerpt",
+    "word_count",
+    "rel_path",
+    "url",
+}
+QUERY_KEYS = {
+    "question",
+    "viewer_tier",
+    "answer",
+    "citations",
+    "backend",
+    "model",
+    "used_pages",
+    "retrieval",
+}
+
+
+def _enable(client, owner_headers, tiers=("private",), force=False):
+    return client.put(
+        "/owner/sealing",
+        headers=owner_headers,
+        json={"keyring": valid_keyring(tiers), "force": force},
+    )
+
+
+def _mint_recruiter(client, owner_headers) -> str:
+    r = client.post(
+        "/owner/share-tokens",
+        json={"label": "sealing recruiter", "tier": "recruiter"},
+        headers=owner_headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["token"]
+
+
+def _write_sealed_page(wiki_root: Path) -> Path:
+    path = wiki_root / "wiki" / "concepts" / f"{SEALED_SLUG}.md"
+    path.write_text(SEALED_DOC, encoding="utf-8")
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _reset_sealing_state(wiki_root: Path):
+    yield
+    sealed_dir = wiki_root / "wiki" / ".sealed"
+    if sealed_dir.exists():
+        shutil.rmtree(sealed_dir)
+    extra = wiki_root / "wiki" / "concepts" / f"{SEALED_SLUG}.md"
+    if extra.exists():
+        extra.unlink()
+    for pattern in (
+        "wiki/concepts/seal-*.md",
+        "wiki/concepts/s-*.md",
+        "wiki/entities/seal-*.md",
+    ):
+        for path in wiki_root.glob(pattern):
+            path.unlink()
+    from app.main import index
+
+    index.reload()
+
+
+# ---------------------------------------------------------------------------
+# Golden no-regression (no keyring)
+# ---------------------------------------------------------------------------
+
+
+def test_unsealed_to_summary_has_no_sealed_key():
+    from app.main import index
+
+    index.reload()
+    page = index.get("public-entity")
+    assert page is not None
+    summary = page.to_summary()
+    full = page.to_full()
+    assert "sealed" not in summary
+    assert "sealed" not in full
+    assert "envelope" not in full
+    assert set(summary) == SUMMARY_KEYS
+    dumped = json.dumps(summary, sort_keys=True)
+    from app import sealing as _sealing  # noqa: F401
+
+    assert json.dumps(page.to_summary(), sort_keys=True) == dumped
+
+
+def test_no_keyring_http_json_is_unchanged(client):
+    manifest = client.get("/wiki/manifest.json").json()
+    page = client.get("/wiki/page/public-entity").json()
+    search = client.get("/wiki/search", params={"q": "Public"}).json()
+    query = client.post(
+        "/wiki/query", json={"question": "Tell me about the Public Entity"}
+    ).json()
+
+    assert set(manifest) == MANIFEST_KEYS
+    assert "sealing" not in manifest
+    for item in manifest["pages"]:
+        assert "sealed" not in item
+        assert "envelope" not in item
+        assert set(item) == SUMMARY_KEYS
+
+    assert "sealed" not in page
+    assert "envelope" not in page
+    assert "sealed_excluded" not in query
+    assert set(query) == QUERY_KEYS
+    for item in search["results"]:
+        assert "sealed" not in item
+
+    assert json.dumps(manifest["pages"], sort_keys=True)
+    assert json.dumps(page, sort_keys=True)
+    assert json.dumps(search, sort_keys=True)
+    assert json.dumps(query, sort_keys=True)
+
+
+def test_wiki_sealing_404_when_disabled(client, owner_headers):
+    r = client.get("/wiki/sealing", headers=owner_headers)
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# validate_keyring / load_state
+# ---------------------------------------------------------------------------
+
+
+def test_validate_keyring_rejects_bad_tiers():
+    bad = valid_keyring()
+    bad["tiers"] = ["public"]
+    with pytest.raises(ValueError, match="tiers"):
+        validate_keyring(bad)
+
+
+def test_validate_keyring_rejects_low_iterations():
+    bad = valid_keyring()
+    bad["iterations"] = 99999
+    with pytest.raises(ValueError, match="iterations"):
+        validate_keyring(bad)
+
+
+def test_validate_keyring_rejects_missing_fields():
+    bad = valid_keyring()
+    del bad["salt"]
+    with pytest.raises(ValueError, match="salt"):
+        validate_keyring(bad)
+
+
+def test_load_state_missing_is_disabled(tmp_path: Path):
+    state = load_state(tmp_path)
+    assert state.enabled is False
+    assert state.tiers == ()
+    assert state.keyring is None
+
+
+def test_load_state_malformed_json_is_disabled(tmp_path: Path, caplog):
+    path = tmp_path / KEYRING_REL
+    path.parent.mkdir(parents=True)
+    path.write_text("{not-json", encoding="utf-8")
+    with caplog.at_level("WARNING"):
+        state = load_state(tmp_path)
+    assert state.enabled is False
+    assert "malformed" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def test_loader_sealed_page_is_opaque(wiki_root: Path):
+    _write_sealed_page(wiki_root)
+    from app.main import index
+
+    index.reload()
+    page = index.get(SEALED_SLUG)
+    assert page is not None
+    assert page.sealed is True
+    assert page.title == "Sealed page"
+    assert page.body == ""
+    assert page.excerpt == ""
+    assert page.tags == []
+    assert page.sources == []
+    assert page.links_out == []
+    assert page.word_count == 0
+    assert page.envelope == SEALED_ENVELOPE_STRIPPED
+    summary = page.to_summary()
+    assert summary["sealed"] is True
+    full = page.to_full()
+    assert full["envelope"] == SEALED_ENVELOPE_STRIPPED
+    assert full["body"] == ""
+    assert full["links_out"] == []
+    assert full["links_in"] == []
+
+
+def test_loader_ignores_wikilinks_in_sealed_body(wiki_root: Path):
+    path = wiki_root / "wiki" / "concepts" / "s-linkleaktest.md"
+    path.write_text(
+        "---\nsealed: v1\ntype: concept\ntier: private\n---\n"
+        "[[Public Entity]]\n",
+        encoding="utf-8",
+    )
+    from app.main import index
+
+    index.reload()
+    page = index.get("s-linkleaktest")
+    assert page is not None
+    assert page.sealed is True
+    assert page.links_out == []
+
+
+# ---------------------------------------------------------------------------
+# Manifest / keyring / bundle
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_gains_sealing_only_when_enabled(client, owner_headers):
+    before = client.get("/wiki/manifest.json").json()
+    assert "sealing" not in before
+    r = _enable(client, owner_headers)
+    assert r.status_code == 200, r.text
+    assert r.json()["ok"] is True
+    assert r.json()["enabled"] is True
+    assert r.json()["tiers"] == ["private"]
+    assert "sync" in r.json()
+    after = client.get("/wiki/manifest.json").json()
+    assert after["sealing"] == {
+        "enabled": True,
+        "tiers": ["private"],
+        "keyring_url": "/wiki/sealing",
+        "bundle_url": "/wiki/sealed/bundle",
+    }
+
+
+def test_wiki_sealing_owner_200_public_denied(client, owner_headers):
+    _enable(client, owner_headers)
+    owner = client.get("/wiki/sealing", headers=owner_headers)
+    assert owner.status_code == 200
+    body = owner.json()
+    assert body["v"] == 1
+    assert body["tiers"] == ["private"]
+    public = client.get("/wiki/sealing")
+    assert public.status_code == 403
+
+
+def test_wiki_sealing_recruiter_token_allowed(client, owner_headers):
+    _enable(client, owner_headers)
+    token = _mint_recruiter(client, owner_headers)
+    r = client.get("/wiki/sealing", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+    assert r.json()["v"] == 1
+
+
+def test_bundle_tier_gating(client, owner_headers, wiki_root: Path):
+    _write_sealed_page(wiki_root)
+    _enable(client, owner_headers)
+    from app.main import index
+
+    index.reload()
+    owner = client.get("/wiki/sealed/bundle", headers=owner_headers)
+    assert owner.status_code == 200
+    slugs = {p["slug"] for p in owner.json()["pages"]}
+    assert SEALED_SLUG in slugs
+    token = _mint_recruiter(client, owner_headers)
+    rec = client.get(
+        "/wiki/sealed/bundle", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert rec.status_code == 200
+    rec_slugs = {p["slug"] for p in rec.json()["pages"]}
+    assert SEALED_SLUG not in rec_slugs
+
+
+# ---------------------------------------------------------------------------
+# PUT / DELETE /owner/sealing
+# ---------------------------------------------------------------------------
+
+
+def test_put_sealing_validation_errors(client, owner_headers):
+    bad_tiers = valid_keyring()
+    bad_tiers["tiers"] = ["public"]
+    r = client.put(
+        "/owner/sealing",
+        headers=owner_headers,
+        json={"keyring": bad_tiers},
+    )
+    assert r.status_code == 400
+    assert "tiers" in r.json()["detail"]
+
+    low = valid_keyring()
+    low["iterations"] = 10
+    r = client.put(
+        "/owner/sealing", headers=owner_headers, json={"keyring": low}
+    )
+    assert r.status_code == 400
+    assert "iterations" in r.json()["detail"]
+
+    missing = valid_keyring()
+    del missing["wrapped_dek"]
+    r = client.put(
+        "/owner/sealing", headers=owner_headers, json={"keyring": missing}
+    )
+    assert r.status_code == 400
+    assert "wrapped_dek" in r.json()["detail"]
+
+
+def test_put_sealing_keyring_exists_and_force(client, owner_headers):
+    first = _enable(client, owner_headers)
+    assert first.status_code == 200
+    second = _enable(client, owner_headers, force=False)
+    assert second.status_code == 409
+    assert second.json()["detail"]["code"] == "keyring_exists"
+    forced = _enable(client, owner_headers, tiers=("private", "friend"), force=True)
+    assert forced.status_code == 200, forced.text
+    assert set(forced.json()["tiers"]) == {"private", "friend"}
+
+
+def test_delete_sealing_disables_and_drops_manifest_key(client, owner_headers):
+    _enable(client, owner_headers)
+    assert "sealing" in client.get("/wiki/manifest.json").json()
+    r = client.delete("/owner/sealing", headers=owner_headers)
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    assert r.json()["enabled"] is False
+    assert "sealing" not in client.get("/wiki/manifest.json").json()
+    assert client.get("/wiki/sealing", headers=owner_headers).status_code == 404
+
+
+def test_delete_sealing_404_when_absent(client, owner_headers):
+    r = client.delete("/owner/sealing", headers=owner_headers)
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# 409 guards + allowed paths
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_orchestrator_409(client, owner_headers):
+    _enable(client, owner_headers)
+    r = client.post(
+        "/owner/ingest",
+        headers=owner_headers,
+        json={
+            "slug": "seal-orch-ingest",
+            "content": "hello",
+            "run_orchestrator": True,
+        },
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "sealing_enabled"
+
+
+def test_ingest_without_orchestrator_allowed(client, owner_headers):
+    _enable(client, owner_headers)
+    r = client.post(
+        "/owner/ingest",
+        headers=owner_headers,
+        json={
+            "slug": "seal-raw-ingest",
+            "content": "hello",
+            "run_orchestrator": False,
+        },
+    )
+    assert r.status_code == 201, r.text
+
+
+def test_import_409(client, owner_headers):
+    _enable(client, owner_headers)
+    r = client.post(
+        "/owner/import",
+        headers=owner_headers,
+        json={"kind": "bio", "content": "A" * 40},
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "sealing_enabled"
+
+
+def test_paste_orchestrator_409(client, owner_headers):
+    _enable(client, owner_headers)
+    r = client.post(
+        "/owner/capture/paste",
+        headers=owner_headers,
+        json={"content": "pasted notes", "run_orchestrator": True},
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "sealing_enabled"
+
+
+def test_lint_409(client, owner_headers):
+    _enable(client, owner_headers)
+    r = client.post("/owner/lint", headers=owner_headers)
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "sealing_enabled"
+
+
+def test_structured_409_when_private_sealed(client, owner_headers):
+    _enable(client, owner_headers, tiers=("private",))
+    r = client.post(
+        "/owner/capture/structured",
+        headers=owner_headers,
+        json={
+            "session_label": "chatgpt-seal-test",
+            "pages": [
+                {
+                    "slug": "seal-structured",
+                    "title": "Seal Structured",
+                    "section": "concepts",
+                    "body": "A paragraph long enough to look like a real page.",
+                }
+            ],
+        },
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "plaintext_into_sealed_tier"
+
+
+def test_verbatim_plaintext_into_sealed_tier_409(client, owner_headers):
+    _enable(client, owner_headers)
+    r = client.post(
+        "/owner/capture/verbatim",
+        headers=owner_headers,
+        json={
+            "content": (
+                "---\ntype: concept\ntitle: Plain Into Seal\n"
+                "tier: private\n---\n\nplaintext body\n"
+            )
+        },
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "plaintext_into_sealed_tier"
+
+
+def test_verbatim_sealed_write_succeeds(client, owner_headers, wiki_root: Path):
+    _enable(client, owner_headers)
+    r = client.post(
+        "/owner/capture/verbatim",
+        headers=owner_headers,
+        json={"content": SEALED_DOC, "force_overwrite": True},
+    )
+    assert r.status_code == 201, r.text
+    written = r.json()["written"]
+    assert written["slug"] == SEALED_SLUG
+    assert written["tier"] == "private"
+    on_disk = (wiki_root / written["rel_path"]).read_text(encoding="utf-8")
+    expected = SEALED_DOC if SEALED_DOC.endswith("\n") else SEALED_DOC + "\n"
+    assert on_disk == expected
+
+
+def test_post_owner_page_plaintext_into_sealed_409(client, owner_headers):
+    _enable(client, owner_headers)
+    r = client.post(
+        "/owner/page",
+        headers=owner_headers,
+        json={
+            "title": "Seal Plain Post",
+            "section": "concepts",
+            "tier": "private",
+            "body": "plaintext",
+        },
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "plaintext_into_sealed_tier"
+
+
+def test_post_owner_page_public_still_allowed(client, owner_headers):
+    _enable(client, owner_headers)
+    r = client.post(
+        "/owner/page",
+        headers=owner_headers,
+        json={
+            "title": "Seal Public Allowed",
+            "section": "concepts",
+            "tier": "public",
+            "body": "public plaintext is fine",
+        },
+    )
+    assert r.status_code == 201, r.text
+
+
+def test_put_plaintext_into_sealed_tier_409(client, owner_headers):
+    created = client.post(
+        "/owner/page",
+        headers=owner_headers,
+        json={
+            "title": "Seal Put Target",
+            "section": "concepts",
+            "tier": "public",
+            "body": "start public",
+        },
+    )
+    assert created.status_code == 201, created.text
+    slug = created.json()["slug"]
+    _enable(client, owner_headers)
+    r = client.put(
+        f"/owner/page/{slug}",
+        headers=owner_headers,
+        json={
+            "markdown": (
+                "---\ntype: concept\ntitle: Seal Put Target\n"
+                "tier: private\n---\n\nnow private plaintext\n"
+            )
+        },
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "plaintext_into_sealed_tier"
+
+
+def test_put_with_sealed_marker_succeeds(client, owner_headers):
+    created = client.post(
+        "/owner/page",
+        headers=owner_headers,
+        json={
+            "title": "Seal Put Marker",
+            "section": "concepts",
+            "tier": "public",
+            "body": "start",
+        },
+    )
+    slug = created.json()["slug"]
+    _enable(client, owner_headers)
+    r = client.put(
+        f"/owner/page/{slug}",
+        headers=owner_headers,
+        json={
+            "markdown": (
+                "---\nsealed: v1\ntype: concept\ntier: private\n"
+                f"slug: {slug}\n---\nYWJj\n"
+            )
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_put_to_public_plaintext_succeeds(client, owner_headers):
+    created = client.post(
+        "/owner/page",
+        headers=owner_headers,
+        json={
+            "title": "Seal Put Public",
+            "section": "concepts",
+            "tier": "recruiter",
+            "body": "start",
+        },
+    )
+    slug = created.json()["slug"]
+    _enable(client, owner_headers)
+    r = client.put(
+        f"/owner/page/{slug}",
+        headers=owner_headers,
+        json={
+            "markdown": (
+                "---\ntype: concept\ntitle: Seal Put Public\n"
+                "tier: public\n---\n\nnow public\n"
+            )
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_patch_boundary_crossing_both_directions(
+    client, owner_headers, wiki_root: Path
+):
+    created = client.post(
+        "/owner/page",
+        headers=owner_headers,
+        json={
+            "title": "Seal Patch Plain",
+            "section": "concepts",
+            "tier": "public",
+            "body": "plain",
+        },
+    )
+    plain_slug = created.json()["slug"]
+    _write_sealed_page(wiki_root)
+    _enable(client, owner_headers)
+    from app.main import index
+
+    index.reload()
+
+    into_sealed = client.patch(
+        f"/owner/page/{plain_slug}/tier",
+        headers=owner_headers,
+        json={"tier": "private"},
+    )
+    assert into_sealed.status_code == 409
+    assert into_sealed.json()["detail"]["code"] == "seal_boundary_crossing"
+
+    out_of_sealed = client.patch(
+        f"/owner/page/{SEALED_SLUG}/tier",
+        headers=owner_headers,
+        json={"tier": "public"},
+    )
+    assert out_of_sealed.status_code == 409
+    assert out_of_sealed.json()["detail"]["code"] == "seal_boundary_crossing"
+
+
+# ---------------------------------------------------------------------------
+# Search / query
+# ---------------------------------------------------------------------------
+
+
+def test_search_never_returns_sealed_pages(
+    client, owner_headers, wiki_root: Path
+):
+    _write_sealed_page(wiki_root)
+    _enable(client, owner_headers)
+    from app.main import index
+
+    index.reload()
+    r = client.get("/wiki/search", params={"q": "Sealed"}, headers=owner_headers)
+    slugs = {item["slug"] for item in r.json()["results"]}
+    assert SEALED_SLUG not in slugs
+
+
+def test_query_sealed_excluded_and_not_retrieved(
+    client, owner_headers, wiki_root: Path
+):
+    _write_sealed_page(wiki_root)
+    _enable(client, owner_headers)
+    from app.main import index
+
+    index.reload()
+    r = client.post(
+        "/wiki/query",
+        headers=owner_headers,
+        json={"question": "Tell me about the Public Entity"},
+    )
+    data = r.json()
+    assert data["sealed_excluded"] >= 1
+    used = set(data["used_pages"])
+    cited = {c["slug"] for c in data["citations"]}
+    assert SEALED_SLUG not in used
+    assert SEALED_SLUG not in cited
+    assert SEALED_ENVELOPE_STRIPPED not in data["answer"]
+
+
+def test_query_omits_sealed_excluded_when_zero_visible(
+    client, owner_headers, wiki_root: Path
+):
+    _write_sealed_page(wiki_root)
+    _enable(client, owner_headers)
+    from app.main import index
+
+    index.reload()
+    token = _mint_recruiter(client, owner_headers)
+    r = client.post(
+        "/wiki/query",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"question": "Tell me about the Public Entity"},
+    )
+    assert "sealed_excluded" not in r.json()
+
+
+def test_verbatim_parse_sealed_title_optional():
+    from app.verbatim_capture import parse_and_validate
+
+    metadata, body, page_type, section, title, slug = parse_and_validate(
+        content=SEALED_DOC
+    )
+    assert page_type == "concept"
+    assert section == "concepts"
+    assert slug == SEALED_SLUG
+    assert title == SEALED_SLUG
+    assert "sealed" in metadata

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "next/core-web-vitals",
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off",
+    "react/no-unescaped-entities": "off",
+    "react/jsx-no-comment-textnodes": "off"
+  }
+}

--- a/frontend/app/ask/page.tsx
+++ b/frontend/app/ask/page.tsx
@@ -13,7 +13,19 @@ import {
   type ChatTurn,
 } from "@/lib/api";
 import { Markdown } from "@/components/Markdown";
+import { useSealing, type SealingStatus } from "@/lib/useSealing";
 import { useTenant } from "@/lib/useTenant";
+
+function sealedAskNotice(status: SealingStatus, n: number): string | null {
+  if (status === "not_enabled" && n <= 0) return null;
+  if (n > 0) {
+    return `${n} sealed pages were not available to the server-side answer. Unlock and use search, or ask through the MCP.`;
+  }
+  if (status !== "not_enabled") {
+    return "Sealed pages were not available to the server-side answer. Unlock and use search, or ask through the MCP.";
+  }
+  return null;
+}
 
 type Turn =
   | {
@@ -52,6 +64,8 @@ export default function AskPage() {
   const [turns, setTurns] = useState<Turn[]>([]);
   const [draft, setDraft] = useState("");
   const [pending, setPending] = useState(false);
+  const [sealedExcluded, setSealedExcluded] = useState<number | null>(null);
+  const sealing = useSealing(tenant);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -110,6 +124,9 @@ export default function AskPage() {
         history,
         (evt) => {
           if (evt.type === "start") {
+            if (typeof evt.sealed_excluded === "number") {
+              setSealedExcluded(evt.sealed_excluded);
+            }
             setTurns((prev) =>
               prev.map((t) =>
                 t.id === assistantId && t.kind === "assistant"
@@ -171,6 +188,14 @@ export default function AskPage() {
     setDraft("");
   };
 
+  const sealedNotice = sealedAskNotice(
+    sealing.status,
+    sealedExcluded ??
+      (sealing.status === "unlocked"
+        ? (sealing.titles?.size ?? sealing.sealedCount)
+        : sealing.sealedCount),
+  );
+
   return (
     <div className="max-w-3xl mx-auto px-5 py-8">
       <div className="flex items-baseline justify-between gap-3 flex-wrap">
@@ -192,6 +217,12 @@ export default function AskPage() {
           </button>
         )}
       </div>
+
+      {sealedNotice && (
+        <div className="mt-4 p-3 rounded border border-paper-soft bg-paper-soft/50 text-sm text-ink">
+          {sealedNotice}
+        </div>
+      )}
 
       {turns.length === 0 && (
         <div className="mt-6 p-5 rounded border border-paper-soft bg-paper-soft/40">

--- a/frontend/app/browse/page.tsx
+++ b/frontend/app/browse/page.tsx
@@ -3,7 +3,21 @@
 import { useEffect, useMemo, useState } from "react";
 import { fetchManifest, searchWiki, type Manifest, type PageSummary } from "@/lib/api";
 import { PageCard } from "@/components/PageCard";
+import { displayPageTitle } from "@/lib/sealing";
+import { useSealing } from "@/lib/useSealing";
 import { useTenant } from "@/lib/useTenant";
+
+function parseHitTier(tier: string): PageSummary["tier"] {
+  switch (tier) {
+    case "public":
+    case "recruiter":
+    case "friend":
+    case "private":
+      return tier;
+    default:
+      return "private";
+  }
+}
 
 const SECTION_ORDER = [
   "projects",
@@ -24,6 +38,17 @@ export default function BrowsePage() {
   const [searchResults, setSearchResults] = useState<PageSummary[] | null>(null);
   const [tierFilter, setTierFilter] = useState<string>("");
   const [sectionFilter, setSectionFilter] = useState<string>("");
+  const sealing = useSealing(tenant);
+  const sealingStatus = sealing.status;
+  const searchLocal = sealing.searchLocal;
+  const sealingTitles = sealing.titles;
+
+  function titled(page: PageSummary): PageSummary {
+    return {
+      ...page,
+      title: displayPageTitle(page.slug, page.title, sealingTitles),
+    };
+  }
 
   useEffect(() => {
     fetchManifest(tenant)
@@ -46,6 +71,11 @@ export default function BrowsePage() {
     }, 220);
     return () => clearTimeout(handle);
   }, [q, tenant]);
+
+  const localHits = useMemo(() => {
+    if (!q.trim() || sealingStatus !== "unlocked") return [];
+    return searchLocal(q.trim());
+  }, [q, sealingStatus, searchLocal]);
 
   const grouped = useMemo(() => {
     if (!manifest) return {} as Record<string, PageSummary[]>;
@@ -121,16 +151,48 @@ export default function BrowsePage() {
 
       {searchResults ? (
         <section className="mt-6">
+          {localHits.length > 0 && (
+            <div className="mb-6">
+              <h2 className="text-sm uppercase tracking-wider text-ink-muted mb-3">
+                Decrypted locally · {localHits.length}
+              </h2>
+              <div className="grid md:grid-cols-2 gap-3">
+                {localHits.map((hit) => (
+                  <PageCard
+                    key={`local-${hit.slug}`}
+                    page={{
+                      slug: hit.slug,
+                      title: hit.title,
+                      section: hit.section,
+                      type: "",
+                      tier: parseHitTier(hit.tier),
+                      created: null,
+                      updated: hit.updated || null,
+                      tags: [],
+                      excerpt: hit.excerpt,
+                      word_count: 0,
+                      rel_path: "",
+                      sealed: true,
+                    }}
+                    tenant={tenant}
+                    badge="decrypted locally"
+                  />
+                ))}
+              </div>
+            </div>
+          )}
           <h2 className="text-sm uppercase tracking-wider text-ink-muted mb-3">
             Search · {searchResults.length} match{searchResults.length === 1 ? "" : "es"}
           </h2>
-          {searchResults.length === 0 && (
+          {searchResults.length === 0 && localHits.length === 0 && (
             <div className="text-sm text-ink-muted">No pages match.</div>
           )}
           <div className="grid md:grid-cols-2 gap-3">
-            {searchResults.map((p) => (
-              <PageCard key={p.slug} page={p} tenant={tenant} />
-            ))}
+            {searchResults
+              .filter((p) => !localHits.some((h) => h.slug === p.slug))
+              .map((p) => (
+                <PageCard key={p.slug} page={titled(p)} tenant={tenant} />
+              ))}
           </div>
         </section>
       ) : manifest ? (
@@ -141,7 +203,7 @@ export default function BrowsePage() {
             </h2>
             <div className="grid md:grid-cols-2 gap-3">
               {grouped[section].map((p) => (
-                <PageCard key={p.slug} page={p} tenant={tenant} />
+                <PageCard key={p.slug} page={titled(p)} tenant={tenant} />
               ))}
             </div>
           </section>

--- a/frontend/app/graph/page.tsx
+++ b/frontend/app/graph/page.tsx
@@ -15,6 +15,8 @@ import {
   undoLibraryAutoZoom,
   type CameraPose,
 } from "@/lib/graphCamera";
+import { displayPageTitle } from "@/lib/sealing";
+import { useSealing } from "@/lib/useSealing";
 import { useTenant } from "@/lib/useTenant";
 
 function settleGraphCamera(
@@ -119,6 +121,7 @@ export default function GraphPage() {
   const autoFitDoneRef = useRef(false);
   const fittedPoseRef = useRef<ReturnType<typeof captureCamera>>(null);
   const [size, setSize] = useState({ w: 800, h: 600 });
+  const sealing = useSealing(tenant);
 
   useEffect(() => {
     fetchGraph(tenant)
@@ -145,18 +148,30 @@ export default function GraphPage() {
     return () => ro.disconnect();
   }, []);
 
-  const filtered = useMemo(() => {
+  const labeledGraph = useMemo(() => {
     if (!graph) return null;
-    if (!sectionFilter) return graph;
+    if (!sealing.titles) return graph;
+    return {
+      ...graph,
+      nodes: graph.nodes.map((n) => ({
+        ...n,
+        title: displayPageTitle(n.slug, n.title, sealing.titles),
+      })),
+    };
+  }, [graph, sealing.titles]);
+
+  const filtered = useMemo(() => {
+    if (!labeledGraph) return null;
+    if (!sectionFilter) return labeledGraph;
     const allowed = new Set(
-      graph.nodes.filter((n) => n.section === sectionFilter).map((n) => n.slug)
+      labeledGraph.nodes.filter((n) => n.section === sectionFilter).map((n) => n.slug)
     );
     return {
-      nodes: graph.nodes.filter((n) => allowed.has(n.slug)),
-      edges: graph.edges.filter((e) => allowed.has(e.source) && allowed.has(e.target)),
-      anchors: graph.anchors,
+      nodes: labeledGraph.nodes.filter((n) => allowed.has(n.slug)),
+      edges: labeledGraph.edges.filter((e) => allowed.has(e.source) && allowed.has(e.target)),
+      anchors: labeledGraph.anchors,
     };
-  }, [graph, sectionFilter]);
+  }, [labeledGraph, sectionFilter]);
 
   const data = useMemo(() => {
     if (!filtered) return { nodes: [], links: [] };
@@ -589,9 +604,9 @@ export default function GraphPage() {
         <h2 className="text-sm uppercase tracking-wider text-ink-muted mb-3">
           Hubs (most-connected pages)
         </h2>
-        {graph ? (
+        {labeledGraph ? (
           <ol className="grid sm:grid-cols-2 gap-x-6 gap-y-1 text-sm">
-            {[...graph.nodes]
+            {[...labeledGraph.nodes]
               .sort((a, b) => b.degree - a.degree)
               .slice(0, 10)
               .map((n, i) => (

--- a/frontend/app/owner/page.tsx
+++ b/frontend/app/owner/page.tsx
@@ -6,6 +6,7 @@ import { DangerZonePanel } from "@/components/DangerZonePanel";
 import { ForceResetModal } from "@/components/ForceResetModal";
 import { PersistencePanel } from "@/components/PersistencePanel";
 import { PersonalLlmUrlPanel } from "@/components/PersonalLlmUrlPanel";
+import { SealingPanel } from "@/components/SealingPanel";
 import { ShareTokensPanel } from "@/components/ShareTokensPanel";
 import { SwitchRepoModal } from "@/components/SwitchRepoModal";
 import {
@@ -604,6 +605,7 @@ function OwnerPageInner({ tenant }: { tenant?: string }) {
           tenant={tenant}
         />
       )}
+      {authed && <SealingPanel tenant={tenant} />}
 
       {error && (
         <div className="mt-6 p-3 rounded border border-red-200 bg-red-50 text-red-700 text-sm">

--- a/frontend/app/page/[slug]/page.tsx
+++ b/frontend/app/page/[slug]/page.tsx
@@ -10,9 +10,12 @@ import {
   ownerReplacePage,
   type PageFull,
 } from "@/lib/api";
+import { invertTitles, type EnvelopePayload } from "@/lib/sealing";
+import { useSealing } from "@/lib/useSealing";
 import { useTenant } from "@/lib/useTenant";
 import { useIsOwnerOf } from "@/lib/useIsOwner";
 import { Markdown } from "@/components/Markdown";
+import { SealedUnlock } from "@/components/SealedUnlock";
 
 const tierStyles: Record<string, string> = {
   public: "bg-emerald-50 text-emerald-700 border-emerald-200",
@@ -34,9 +37,14 @@ export default function PageView() {
   const [editError, setEditError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [showPreview, setShowPreview] = useState(true);
+  const [plain, setPlain] = useState<EnvelopePayload | null>(null);
+  const [plainError, setPlainError] = useState<string | null>(null);
   const ownerAccess = useIsOwnerOf(tenant);
   const tokenReady = ownerAccess.ready;
   const hasOwnerToken = ownerAccess.ready && ownerAccess.isOwner;
+  const sealing = useSealing(tenant);
+  const decryptPage = sealing.decryptPage;
+  const titleToSlug = invertTitles(sealing.titles);
 
   // App-route prefix for internal Links and router pushes. In hosted mode
   // every wiki page lives under /<tenant>/...; in single-tenant mode this
@@ -51,6 +59,28 @@ export default function PageView() {
       .then(setPage)
       .catch((e) => setError((e as Error).message));
   }, [slug, tenant]);
+
+  useEffect(() => {
+    if (!page?.sealed || !page.envelope || sealing.status !== "unlocked") {
+      setPlain(null);
+      setPlainError(null);
+      return;
+    }
+    let cancelled = false;
+    decryptPage(page.slug, page.envelope)
+      .then((p) => {
+        if (!cancelled) {
+          setPlain(p);
+          setPlainError(null);
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) setPlainError((e as Error).message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [page, sealing.status, sealing.dek, decryptPage]);
 
   async function changeTier(newTier: PageFull["tier"]) {
     if (!page) return;
@@ -118,6 +148,37 @@ export default function PageView() {
     );
   }
 
+  if (page.sealed && sealing.status !== "unlocked") {
+    return (
+      <article className="max-w-3xl mx-auto px-5 py-8">
+        <div className="flex items-center gap-3 text-xs text-ink-muted">
+          <Link href={`${appPrefix}/browse`} className="hover:text-ink">browse</Link>
+          <span>/</span>
+          <span>{page.section}</span>
+        </div>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-ink">
+          Sealed page
+        </h1>
+        <p className="mt-2 text-sm text-ink-muted">
+          Sealed page. Unlock to read.
+        </p>
+        <div className="mt-4">
+          <SealedUnlock tenant={tenant} />
+        </div>
+      </article>
+    );
+  }
+
+  const viewTitle = page.sealed ? (plain?.title ?? page.title) : page.title;
+  const viewTags = page.sealed ? (plain?.tags ?? []) : page.tags;
+  const viewBody = page.sealed
+    ? (plain?.body ?? "")
+    : (page.rendered_body || page.body);
+  const viewSources = page.sealed ? (plain?.sources ?? []) : page.sources;
+  const viewWords = page.sealed
+    ? (plain?.body.trim() ? plain.body.trim().split(/\s+/).length : 0)
+    : page.word_count;
+
   return (
     <article className="max-w-3xl mx-auto px-5 py-8">
       <div className="flex items-center gap-3 text-xs text-ink-muted">
@@ -130,7 +191,7 @@ export default function PageView() {
 
       <header className="mt-3">
         <h1 className="text-3xl font-semibold tracking-tight text-ink">
-          {page.title}
+          {viewTitle}
         </h1>
         <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
           <span
@@ -145,7 +206,7 @@ export default function PageView() {
           {page.updated && (
             <span className="text-ink-muted">updated {page.updated}</span>
           )}
-          <span className="text-ink-muted">{page.word_count} words</span>
+          <span className="text-ink-muted">{viewWords} words</span>
           <span className="text-ink-muted font-mono">{page.rel_path}</span>
         </div>
         {tokenReady && hasOwnerToken && (
@@ -178,9 +239,9 @@ export default function PageView() {
             </button>
           </div>
         )}
-        {page.tags.length > 0 && (
+        {viewTags.length > 0 && (
           <div className="mt-3 flex flex-wrap gap-1">
-            {page.tags.map((t) => (
+            {viewTags.map((t) => (
               <span
                 key={t}
                 className="text-[11px] bg-paper-soft text-ink-muted px-1.5 py-0.5 rounded"
@@ -193,6 +254,12 @@ export default function PageView() {
       </header>
 
       <hr className="my-6 border-paper-soft" />
+
+      {plainError && (
+        <div className="mb-4 p-3 rounded border border-red-200 bg-red-50 text-red-700 text-sm">
+          {plainError}
+        </div>
+      )}
 
       {editing ? (
         <section className="bg-white border border-accent/30 rounded-xl p-4">
@@ -256,7 +323,9 @@ export default function PageView() {
           </div>
         </section>
       ) : (
-        <Markdown tenant={tenant}>{page.rendered_body || page.body}</Markdown>
+        <Markdown tenant={tenant} titleToSlug={titleToSlug}>
+          {viewBody}
+        </Markdown>
       )}
 
       {(page.links_out_resolved.length > 0 || page.links_in_resolved.length > 0) && (
@@ -304,13 +373,13 @@ export default function PageView() {
         </section>
       )}
 
-      {page.sources.length > 0 && (
+      {viewSources.length > 0 && (
         <section className="mt-8">
           <h3 className="text-xs uppercase tracking-wider text-ink-muted mb-2">
             Sources (provenance)
           </h3>
           <ul className="text-sm space-y-1 font-mono text-ink-muted">
-            {page.sources.map((s) => (
+            {viewSources.map((s) => (
               <li key={s}>· {s}</li>
             ))}
           </ul>

--- a/frontend/components/Markdown.tsx
+++ b/frontend/components/Markdown.tsx
@@ -26,10 +26,14 @@ function slugify(text: string): string {
  * tenant-aware route when a tenant is in scope). Kept symmetrical
  * with the backend so wikilinks render identically whether the
  * markdown was streamed from the LLM or hand-baked into a component. */
-export function preprocessWikilinks(text: string): string {
+export function preprocessWikilinks(
+  text: string,
+  titleToSlug?: Map<string, string>,
+): string {
   return text.replace(WIKILINK_RE, (_match, target, label) => {
     const display = (label ?? target).trim();
-    const slug = slugify(target);
+    const mapped = titleToSlug?.get(String(target).toLowerCase().trim());
+    const slug = mapped ?? slugify(target);
     if (!slug) return display;
     return `[${display}](/wiki/page/${slug})`;
   });
@@ -38,16 +42,19 @@ export function preprocessWikilinks(text: string): string {
 export function Markdown({
   children,
   tenant,
+  titleToSlug,
 }: {
   children: string;
   /** When set, ``/wiki/page/<slug>`` links resolve to
    * ``/<tenant>/page/<slug>``. Without it, they resolve to
    * ``/page/<slug>`` (single-tenant / OSS / preview). */
   tenant?: string;
+  /** Decrypted sealed-page titles -> opaque slugs. */
+  titleToSlug?: Map<string, string>;
 }) {
   // Inline-rewrite [[wikilinks]] before react-markdown sees the text,
   // since react-markdown doesn't natively understand wiki link syntax.
-  const processed = preprocessWikilinks(children);
+  const processed = preprocessWikilinks(children, titleToSlug);
   return (
     <div className="prose-wiki">
       <ReactMarkdown

--- a/frontend/components/NavBar.tsx
+++ b/frontend/components/NavBar.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { apiBase, authLogout, authMe, isHostedMode, type AuthUser } from "@/lib/api";
 import { loginReturnTo } from "@/lib/safeReturnTo";
 
+import { SealedUnlock } from "./SealedUnlock";
 import { ViewerBadge } from "./ViewerBadge";
 
 // Links anyone can see (viewer pages). In hosted mode they're scoped to
@@ -161,7 +162,8 @@ export function NavBar() {
         )}
 
         <div className="ml-auto flex items-center gap-3">
-          <div className="hidden sm:block">
+          <div className="hidden sm:flex items-center gap-3">
+            <SealedUnlock tenant={effectiveTenant} />
             {hosted ? (
               <HostedIdentityBadge viewer={viewer} loaded={viewerLoaded} />
             ) : (
@@ -194,7 +196,8 @@ export function NavBar() {
             className="max-w-5xl mx-auto px-5 py-4"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="mb-4 sm:hidden">
+            <div className="mb-4 sm:hidden space-y-3">
+              <SealedUnlock tenant={effectiveTenant} />
               {hosted ? (
                 <HostedIdentityBadge viewer={viewer} loaded={viewerLoaded} />
               ) : (

--- a/frontend/components/PageCard.tsx
+++ b/frontend/components/PageCard.tsx
@@ -8,7 +8,15 @@ const tierStyles: Record<PageSummary["tier"], string> = {
   private: "bg-red-50 text-red-700 border-red-200",
 };
 
-export function PageCard({ page, tenant }: { page: PageSummary; tenant?: string }) {
+export function PageCard({
+  page,
+  tenant,
+  badge,
+}: {
+  page: PageSummary;
+  tenant?: string;
+  badge?: string;
+}) {
   // Hosted mode: link to /<tenant>/page/<slug>. Single-tenant: /page/<slug>.
   const href = tenant
     ? `/${encodeURIComponent(tenant)}/page/${encodeURIComponent(page.slug)}`
@@ -20,6 +28,9 @@ export function PageCard({ page, tenant }: { page: PageSummary; tenant?: string 
     >
       <div className="flex items-baseline gap-3">
         <h3 className="font-semibold text-ink truncate flex-1">{page.title}</h3>
+        {badge && (
+          <span className="text-[10px] text-ink-muted shrink-0">{badge}</span>
+        )}
         <span
           className={`text-[10px] uppercase tracking-wide font-semibold border rounded px-1.5 py-0.5 ${tierStyles[page.tier]}`}
         >

--- a/frontend/components/SealedUnlock.tsx
+++ b/frontend/components/SealedUnlock.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+
+import { useSealing } from "@/lib/useSealing";
+import { WrongPassphraseError } from "@/lib/sealing";
+
+export function SealedUnlock({ tenant }: { tenant?: string } = {}) {
+  const sealing = useSealing(tenant);
+  const [passphrase, setPassphrase] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (sealing.status === "not_enabled") {
+    return null;
+  }
+
+  async function onUnlock(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      await sealing.unlock(passphrase);
+      setPassphrase("");
+    } catch (err) {
+      setError(
+        err instanceof WrongPassphraseError
+          ? "Wrong passphrase"
+          : (err as Error).message,
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (sealing.status === "unlocked") {
+    return (
+      <div className="flex items-center gap-2 text-xs">
+        <span className="text-ink-muted">unlocked</span>
+        <button
+          type="button"
+          onClick={() => {
+            sealing.lock();
+            setError(null);
+          }}
+          className="px-2 py-1 rounded border border-paper-soft text-ink-muted hover:border-ink hover:text-ink"
+        >
+          Lock
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={onUnlock}
+      className="flex flex-wrap items-center gap-1.5 text-xs"
+    >
+      <label className="sr-only" htmlFor="sealed-passphrase">
+        Passphrase
+      </label>
+      <input
+        id="sealed-passphrase"
+        type="password"
+        value={passphrase}
+        onChange={(e) => setPassphrase(e.target.value)}
+        placeholder="passphrase"
+        autoComplete="current-password"
+        className="w-28 border border-paper-soft rounded px-2 py-1 bg-white focus:border-accent focus:outline-none"
+      />
+      <button
+        type="submit"
+        disabled={busy || !passphrase}
+        className="px-2 py-1 rounded bg-ink text-paper font-medium hover:bg-ink-soft disabled:opacity-50"
+      >
+        {busy ? "unlocking" : "Unlock"}
+      </button>
+      {error && (
+        <span className="text-red-700 w-full" role="alert">
+          {error}
+        </span>
+      )}
+    </form>
+  );
+}

--- a/frontend/components/SealingPanel.tsx
+++ b/frontend/components/SealingPanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import {
   fetchManifest,
+  fetchSealingKeyring,
   ownerDeleteSealing,
   ownerGetPageRaw,
   ownerPutSealing,
@@ -11,7 +12,12 @@ import {
   type Manifest,
   type PageSummary,
 } from "@/lib/api";
-import { generateKeyring, parseWikiFrontmatter, sealMarkdown } from "@/lib/sealing";
+import {
+  generateKeyring,
+  parseWikiFrontmatter,
+  sealMarkdown,
+  unwrapDek,
+} from "@/lib/sealing";
 import { useSealing } from "@/lib/useSealing";
 
 const OFFERED_TIERS: { id: "private" | "friend" | "recruiter"; label: string }[] = [
@@ -107,8 +113,15 @@ export function SealingPanel({ tenant }: { tenant?: string } = {}) {
     }
     setEnabling(true);
     try {
-      const keyring = await generateKeyring(passphrase, tiers);
-      await ownerPutSealing({ keyring, force }, tenant);
+      const reuseKeyring = sealing.status !== "not_enabled" && !force;
+      if (reuseKeyring) {
+        const existing = await fetchSealingKeyring(tenant);
+        await unwrapDek(existing, passphrase);
+        await ownerPutSealing({ keyring: { ...existing, tiers }, force: true }, tenant);
+      } else {
+        const keyring = await generateKeyring(passphrase, tiers);
+        await ownerPutSealing({ keyring, force }, tenant);
+      }
       await sealing.unlock(passphrase);
       setPassphrase("");
       setConfirm("");
@@ -188,7 +201,9 @@ export function SealingPanel({ tenant }: { tenant?: string } = {}) {
 
       {sealing.status !== "not_enabled" && (
         <p className="mt-1 text-sm text-ink">
-          enabled ({sealing.tiers.join(", ") || "none"})
+          {sealing.tiers.length > 0
+            ? `enabled (${sealing.tiers.join(", ")})`
+            : "disabled, keyring kept for leftover sealed pages"}
           {sealing.status === "unlocked" ? " · unlocked" : " · locked"}
         </p>
       )}
@@ -199,7 +214,7 @@ export function SealingPanel({ tenant }: { tenant?: string } = {}) {
         </p>
       )}
 
-      {sealing.status === "not_enabled" && (
+      {(sealing.status === "not_enabled" || sealing.tiers.length === 0) && (
         <form onSubmit={onEnable} className="mt-4 space-y-3">
           <p className="text-sm text-ink-muted">
             Encrypt non-public pages in the browser. The hosted server stores
@@ -278,7 +293,7 @@ export function SealingPanel({ tenant }: { tenant?: string } = {}) {
         </form>
       )}
 
-      {sealing.status !== "not_enabled" && (
+      {sealing.status !== "not_enabled" && sealing.tiers.length > 0 && (
         <div className="mt-4 space-y-4">
           <p className="text-sm text-ink-muted leading-relaxed">
             While sealing is enabled the server-side ingest, import, and lint
@@ -291,6 +306,9 @@ export function SealingPanel({ tenant }: { tenant?: string } = {}) {
             </h3>
             <p className="mt-1 text-xs text-ink-muted">
               Existing file names are kept; only page contents are sealed.
+              Earlier plaintext versions remain in the wiki&apos;s git
+              history until you rotate it (for example, start a fresh
+              repository), so the operator can still read those commits.
             </p>
             {sealing.status === "locked" ? (
               <p className="mt-2 text-sm text-ink-muted">

--- a/frontend/components/SealingPanel.tsx
+++ b/frontend/components/SealingPanel.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  fetchManifest,
+  ownerDeleteSealing,
+  ownerGetPageRaw,
+  ownerPutSealing,
+  ownerReplacePage,
+  type Manifest,
+  type PageSummary,
+} from "@/lib/api";
+import { generateKeyring, parseWikiFrontmatter, sealMarkdown } from "@/lib/sealing";
+import { useSealing } from "@/lib/useSealing";
+
+const OFFERED_TIERS: { id: "private" | "friend" | "recruiter"; label: string }[] = [
+  { id: "private", label: "private" },
+  { id: "friend", label: "friend" },
+  { id: "recruiter", label: "recruiter" },
+];
+
+const ACK_TEXT =
+  "If I lose this passphrase, nobody, including the site operator, can recover these pages.";
+
+function todayStamp(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function SealingPanel({ tenant }: { tenant?: string } = {}) {
+  const sealing = useSealing(tenant);
+  const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [chosen, setChosen] = useState<Record<string, boolean>>({
+    private: true,
+    friend: false,
+    recruiter: false,
+  });
+  const [passphrase, setPassphrase] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [ack, setAck] = useState(false);
+  const [force, setForce] = useState(false);
+  const [enableError, setEnableError] = useState<string | null>(null);
+  const [enabling, setEnabling] = useState(false);
+
+  const [migrating, setMigrating] = useState(false);
+  const [progress, setProgress] = useState<string | null>(null);
+  const [failures, setFailures] = useState<string[]>([]);
+
+  const [disableError, setDisableError] = useState<string | null>(null);
+
+  async function reloadManifest() {
+    try {
+      const m = await fetchManifest(tenant, { asOwner: true });
+      setManifest(m);
+      setLoadError(null);
+    } catch (e) {
+      setLoadError((e as Error).message);
+    }
+  }
+
+  useEffect(() => {
+    void reloadManifest();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tenant, sealing.status]);
+
+  const sealedTiers = sealing.tiers;
+  const pending = useMemo(() => {
+    if (!manifest) return [] as PageSummary[];
+    const tiers = new Set(
+      (manifest.sealing?.tiers ?? sealedTiers).filter(Boolean),
+    );
+    return manifest.pages.filter((p) => tiers.has(p.tier) && !p.sealed);
+  }, [manifest, sealedTiers]);
+
+  const statusLabel =
+    sealing.status === "not_enabled"
+      ? "not enabled"
+      : sealing.status === "unlocked"
+        ? "unlocked"
+        : "locked";
+
+  async function onEnable(e: React.FormEvent) {
+    e.preventDefault();
+    setEnableError(null);
+    const tiers = OFFERED_TIERS.map((t) => t.id).filter((id) => chosen[id]);
+    if (tiers.length === 0) {
+      setEnableError("Choose at least one tier.");
+      return;
+    }
+    if (!passphrase) {
+      setEnableError("Passphrase is required.");
+      return;
+    }
+    if (passphrase !== confirm) {
+      setEnableError("Passphrase and confirm do not match.");
+      return;
+    }
+    if (!ack) {
+      setEnableError("Acknowledgement is required.");
+      return;
+    }
+    setEnabling(true);
+    try {
+      const keyring = await generateKeyring(passphrase, tiers);
+      await ownerPutSealing({ keyring, force }, tenant);
+      await sealing.unlock(passphrase);
+      setPassphrase("");
+      setConfirm("");
+      setAck(false);
+      await reloadManifest();
+      await sealing.refresh();
+    } catch (err) {
+      setEnableError((err as Error).message);
+    } finally {
+      setEnabling(false);
+    }
+  }
+
+  async function onMigrate() {
+    if (!sealing.dek) return;
+    setMigrating(true);
+    setFailures([]);
+    const dek = sealing.dek;
+    const failed: string[] = [];
+    const total = pending.length;
+    let done = 0;
+    for (const page of pending) {
+      setProgress(`sealing ${done + 1} of ${total}`);
+      try {
+        const raw = await ownerGetPageRaw(page.slug, tenant);
+        const parsed = parseWikiFrontmatter(raw.markdown);
+        const stamped = todayStamp();
+        const sealed = await sealMarkdown(dek, {
+          slug: raw.slug,
+          type: parsed.fields.type || page.type,
+          tier: parsed.fields.tier || page.tier,
+          created: parsed.fields.created || stamped,
+          updated: parsed.fields.updated || stamped,
+          title: parsed.fields.title || raw.title || page.title,
+          tags: parsed.fields.tags,
+          sources: parsed.fields.sources,
+          body: parsed.body,
+        });
+        await ownerReplacePage(raw.slug, sealed, tenant);
+      } catch (err) {
+        failed.push(`${page.slug}: ${(err as Error).message}`);
+      }
+      done += 1;
+      setProgress(`sealing ${done} of ${total}`);
+    }
+    setFailures(failed);
+    setProgress(total === 0 ? null : `sealed ${done} of ${total}`);
+    setMigrating(false);
+    await reloadManifest();
+    await sealing.refresh();
+  }
+
+  async function onDisable() {
+    setDisableError(null);
+    const ok = window.confirm(
+      "Disable sealing? Already-sealed pages stay sealed until they are re-saved as plaintext.",
+    );
+    if (!ok) return;
+    try {
+      await ownerDeleteSealing(tenant);
+      sealing.lock();
+      await reloadManifest();
+      await sealing.refresh();
+    } catch (err) {
+      setDisableError((err as Error).message);
+    }
+  }
+
+  return (
+    <section className="mt-6 bg-white border border-paper-soft rounded-xl p-5">
+      <div className="flex items-baseline justify-between flex-wrap gap-2">
+        <h2 className="text-sm uppercase tracking-wider text-ink-muted">
+          Sealed tiers
+        </h2>
+        <span className="text-xs text-ink-muted">{statusLabel}</span>
+      </div>
+
+      {sealing.status !== "not_enabled" && (
+        <p className="mt-1 text-sm text-ink">
+          enabled ({sealing.tiers.join(", ") || "none"})
+          {sealing.status === "unlocked" ? " · unlocked" : " · locked"}
+        </p>
+      )}
+
+      {loadError && (
+        <p className="mt-2 text-xs text-red-700" role="alert">
+          {loadError}
+        </p>
+      )}
+
+      {sealing.status === "not_enabled" && (
+        <form onSubmit={onEnable} className="mt-4 space-y-3">
+          <p className="text-sm text-ink-muted">
+            Encrypt non-public pages in the browser. The hosted server stores
+            only ciphertext.
+          </p>
+          <fieldset>
+            <legend className="text-xs uppercase tracking-wider text-ink-muted mb-1">
+              Tiers to seal
+            </legend>
+            <div className="flex flex-col gap-1.5">
+              {OFFERED_TIERS.map((t) => (
+                <label key={t.id} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={!!chosen[t.id]}
+                    onChange={(e) =>
+                      setChosen((prev) => ({ ...prev, [t.id]: e.target.checked }))
+                    }
+                  />
+                  {t.label}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+          <div className="grid sm:grid-cols-2 gap-2">
+            <input
+              type="password"
+              value={passphrase}
+              onChange={(e) => setPassphrase(e.target.value)}
+              placeholder="passphrase"
+              autoComplete="new-password"
+              className="border border-paper-soft rounded px-3 py-2 text-sm bg-paper focus:border-accent focus:outline-none"
+            />
+            <input
+              type="password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              placeholder="confirm passphrase"
+              autoComplete="new-password"
+              className="border border-paper-soft rounded px-3 py-2 text-sm bg-paper focus:border-accent focus:outline-none"
+            />
+          </div>
+          <label className="flex items-start gap-2 text-sm text-ink cursor-pointer">
+            <input
+              type="checkbox"
+              checked={ack}
+              onChange={(e) => setAck(e.target.checked)}
+              className="mt-1"
+            />
+            <span>{ACK_TEXT}</span>
+          </label>
+          <label className="flex items-start gap-2 text-xs text-ink-muted cursor-pointer">
+            <input
+              type="checkbox"
+              checked={force}
+              onChange={(e) => setForce(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              Replace existing keyring (pages sealed with the old key will not
+              open).
+            </span>
+          </label>
+          {enableError && (
+            <p className="text-xs text-red-700" role="alert">
+              {enableError}
+            </p>
+          )}
+          <button
+            type="submit"
+            disabled={enabling}
+            className="px-3 py-2 rounded bg-ink text-paper text-sm font-medium hover:bg-ink-soft disabled:opacity-50"
+          >
+            {enabling ? "enabling" : "Enable sealing"}
+          </button>
+        </form>
+      )}
+
+      {sealing.status !== "not_enabled" && (
+        <div className="mt-4 space-y-4">
+          <p className="text-sm text-ink-muted leading-relaxed">
+            While sealing is enabled the server-side ingest, import, and lint
+            are disabled for this wiki. Use the MCP write tools from your own
+            LLM session.
+          </p>
+          <div>
+            <h3 className="text-xs uppercase tracking-wider text-ink-muted">
+              Seal existing pages
+            </h3>
+            <p className="mt-1 text-xs text-ink-muted">
+              Existing file names are kept; only page contents are sealed.
+            </p>
+            {sealing.status === "locked" ? (
+              <p className="mt-2 text-sm text-ink-muted">
+                Unlock to seal existing pages.
+              </p>
+            ) : pending.length === 0 ? (
+              <p className="mt-2 text-sm text-ink-muted">
+                No plaintext pages in sealed tiers.
+              </p>
+            ) : (
+              <>
+                <ul className="mt-2 text-sm space-y-1 max-h-40 overflow-y-auto">
+                  {pending.map((p) => (
+                    <li key={p.slug} className="font-mono text-xs">
+                      {p.slug} · {p.tier}
+                    </li>
+                  ))}
+                </ul>
+                <button
+                  type="button"
+                  onClick={() => void onMigrate()}
+                  disabled={migrating}
+                  className="mt-2 px-3 py-1.5 rounded bg-ink text-paper text-xs font-medium hover:bg-ink-soft disabled:opacity-50"
+                >
+                  Seal existing pages
+                </button>
+              </>
+            )}
+            {progress && (
+              <p className="mt-2 text-xs text-ink-muted" role="status">
+                {progress}
+              </p>
+            )}
+            {failures.length > 0 && (
+              <ul className="mt-2 text-xs text-red-700 space-y-1">
+                {failures.map((f) => (
+                  <li key={f}>{f}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <div>
+            <button
+              type="button"
+              onClick={() => void onDisable()}
+              className="px-3 py-1.5 rounded border border-paper-soft text-xs text-ink-muted hover:border-ink hover:text-ink"
+            >
+              Disable sealing
+            </button>
+            <p className="mt-1 text-xs text-ink-muted">
+              Already-sealed pages stay sealed until they are re-saved as
+              plaintext.
+            </p>
+            {disableError && (
+              <p className="mt-1 text-xs text-red-700" role="alert">
+                {disableError}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/TenantPageList.tsx
+++ b/frontend/components/TenantPageList.tsx
@@ -27,6 +27,8 @@ import {
   type SyncVerdict,
 } from "@/lib/api";
 import { SyncWarning } from "@/components/SyncWarning";
+import { displayPageTitle } from "@/lib/sealing";
+import { useSealing } from "@/lib/useSealing";
 
 
 // Tailwind classes for tier-coloured pills. Mirrors the per-page detail
@@ -184,13 +186,15 @@ export function PageRow({
   isOwnerView: boolean;
   onTierChanged: () => void;
 }) {
+  const sealing = useSealing(tenantId);
+  const title = displayPageTitle(page.slug, page.title, sealing.titles);
   return (
     <li className="flex items-center gap-2 min-w-0">
       <Link
         href={`/${tenantId}/page/${encodeURIComponent(page.slug)}`}
         className="flex-1 text-sm text-ink hover:text-accent truncate min-w-0"
       >
-        {page.title}
+        {title}
       </Link>
       {isOwnerView ? (
         <TierToggle

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -48,7 +48,7 @@ export type PageFull = PageSummary & {
 };
 
 export type ManifestSealing = {
-  enabled: true;
+  enabled: boolean;
   tiers: string[];
   keyring_url: string;
   bundle_url: string;
@@ -315,13 +315,13 @@ function requireString(v: unknown, field: string): string {
 
 export function parseManifestSealing(raw: unknown): ManifestSealing {
   if (!isRecord(raw)) throw new Error("invalid sealing");
-  if (raw.enabled !== true) throw new Error("invalid sealing");
+  if (typeof raw.enabled !== "boolean") throw new Error("invalid sealing");
   if (!Array.isArray(raw.tiers) || !raw.tiers.every((t) => typeof t === "string")) {
     throw new Error("invalid sealing tiers");
   }
   return {
-    enabled: true,
-    tiers: raw.tiers,
+    enabled: raw.enabled && raw.tiers.length > 0,
+    tiers: raw.enabled ? raw.tiers : [],
     keyring_url: requireString(raw.keyring_url, "keyring_url"),
     bundle_url: requireString(raw.bundle_url, "bundle_url"),
   };

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,6 +2,9 @@
 // (configured in next.config.mjs) so we don't fight CORS during local dev.
 
 import { getShareToken } from "./shareToken";
+import { parseKeyring, type SealingKeyring } from "./sealing";
+
+export type { SealingKeyring };
 
 /**
  * Durability verdict the backend stamps on every content-create response so
@@ -29,6 +32,7 @@ export type PageSummary = {
   excerpt: string;
   word_count: number;
   rel_path: string;
+  sealed?: true;
 };
 
 export type PageFull = PageSummary & {
@@ -39,6 +43,15 @@ export type PageFull = PageSummary & {
   links_in: string[];
   links_out_resolved: { slug: string; title: string; section: string }[];
   links_in_resolved: { slug: string; title: string; section: string }[];
+  sealed?: true;
+  envelope?: string;
+};
+
+export type ManifestSealing = {
+  enabled: true;
+  tiers: string[];
+  keyring_url: string;
+  bundle_url: string;
 };
 
 export type Manifest = {
@@ -49,6 +62,7 @@ export type Manifest = {
   page_count: number;
   sections: Record<string, number>;
   pages: PageSummary[];
+  sealing?: ManifestSealing;
 };
 
 export type QueryRetrievalDebug = {
@@ -71,6 +85,7 @@ export type QueryResponse = {
   model: string | null;
   used_pages: string[];
   retrieval?: QueryRetrievalDebug;
+  sealed_excluded?: number;
 };
 
 export type SearchResponse = {
@@ -260,18 +275,98 @@ async function apiFetch(
   return fetch(input, { credentials: "include", ...init });
 }
 
-async function asJson<T>(res: Response): Promise<T> {
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function extractDetail(data: unknown): string | null {
+  if (!isRecord(data) || data.detail === undefined) return null;
+  if (typeof data.detail === "string") return data.detail;
+  if (isRecord(data.detail) && typeof data.detail.message === "string") {
+    return data.detail.message;
+  }
+  return null;
+}
+
+async function readOkJson(res: Response): Promise<unknown> {
   if (!res.ok) {
     let detail = res.statusText;
     try {
-      const data = (await res.json()) as { detail?: string };
-      if (data?.detail) detail = data.detail;
+      const data: unknown = await res.json();
+      detail = extractDetail(data) ?? detail;
     } catch {
       /* ignore */
     }
     throw new Error(`${res.status} ${detail}`);
   }
-  return (await res.json()) as T;
+  return res.json();
+}
+
+async function asJson<T>(res: Response): Promise<T> {
+  return (await readOkJson(res)) as T;
+}
+
+function requireString(v: unknown, field: string): string {
+  if (typeof v !== "string" || !v) {
+    throw new Error(`invalid ${field}`);
+  }
+  return v;
+}
+
+export function parseManifestSealing(raw: unknown): ManifestSealing {
+  if (!isRecord(raw)) throw new Error("invalid sealing");
+  if (raw.enabled !== true) throw new Error("invalid sealing");
+  if (!Array.isArray(raw.tiers) || !raw.tiers.every((t) => typeof t === "string")) {
+    throw new Error("invalid sealing tiers");
+  }
+  return {
+    enabled: true,
+    tiers: raw.tiers,
+    keyring_url: requireString(raw.keyring_url, "keyring_url"),
+    bundle_url: requireString(raw.bundle_url, "bundle_url"),
+  };
+}
+
+function attachManifestSealing(raw: unknown): Manifest {
+  if (!isRecord(raw)) throw new Error("invalid manifest");
+  const base = raw as unknown as Manifest;
+  if (raw.sealing === undefined) {
+    const { sealing: _drop, ...rest } = base;
+    void _drop;
+    return rest;
+  }
+  return { ...base, sealing: parseManifestSealing(raw.sealing) };
+}
+
+export type SealedBundlePage = {
+  slug: string;
+  section: string;
+  tier: string;
+  updated: string;
+  envelope: string;
+};
+
+export type SealedBundle = {
+  pages: SealedBundlePage[];
+  count: number;
+};
+
+export function parseSealedBundle(raw: unknown): SealedBundle {
+  if (!isRecord(raw)) throw new Error("invalid sealed bundle");
+  if (!Array.isArray(raw.pages)) throw new Error("invalid sealed bundle pages");
+  const pages: SealedBundlePage[] = [];
+  for (const item of raw.pages) {
+    if (!isRecord(item)) throw new Error("invalid sealed bundle page");
+    pages.push({
+      slug: requireString(item.slug, "slug"),
+      section: requireString(item.section, "section"),
+      tier: requireString(item.tier, "tier"),
+      updated: typeof item.updated === "string" ? item.updated : "",
+      envelope: requireString(item.envelope, "envelope"),
+    });
+  }
+  const count = typeof raw.count === "number" ? raw.count : pages.length;
+  return { pages, count };
 }
 
 /**
@@ -285,12 +380,59 @@ export async function fetchManifest(
   tenant?: string,
   opts?: { asOwner?: boolean },
 ): Promise<Manifest> {
-  return asJson<Manifest>(
+  const raw = await readOkJson(
     await apiFetch(`${wikiBase(tenant)}/wiki/manifest.json`, {
       headers: opts?.asOwner ? ownerHeaders() : browseHeaders(undefined, tenant),
       cache: "no-store",
-    })
+    }),
   );
+  return attachManifestSealing(raw);
+}
+
+export async function fetchSealingKeyring(tenant?: string): Promise<SealingKeyring> {
+  const raw = await readOkJson(
+    await apiFetch(`${wikiBase(tenant)}/wiki/sealing`, {
+      headers: browseHeaders(undefined, tenant),
+      cache: "no-store",
+    }),
+  );
+  return parseKeyring(raw);
+}
+
+export async function fetchSealedBundle(tenant?: string): Promise<SealedBundle> {
+  const raw = await readOkJson(
+    await apiFetch(`${wikiBase(tenant)}/wiki/sealed/bundle`, {
+      headers: browseHeaders(undefined, tenant),
+      cache: "no-store",
+    }),
+  );
+  return parseSealedBundle(raw);
+}
+
+export async function ownerPutSealing(
+  input: { keyring: SealingKeyring; force: boolean },
+  tenant?: string,
+): Promise<{ ok: boolean }> {
+  const raw = await readOkJson(
+    await apiFetch(`${wikiBase(tenant)}/owner/sealing`, {
+      method: "PUT",
+      headers: ownerHeaders(),
+      body: JSON.stringify({ keyring: input.keyring, force: input.force }),
+    }),
+  );
+  if (!isRecord(raw)) return { ok: true };
+  return { ok: raw.ok !== false };
+}
+
+export async function ownerDeleteSealing(tenant?: string): Promise<{ ok: boolean }> {
+  const raw = await readOkJson(
+    await apiFetch(`${wikiBase(tenant)}/owner/sealing`, {
+      method: "DELETE",
+      headers: ownerHeaders(),
+    }),
+  );
+  if (!isRecord(raw)) return { ok: true };
+  return { ok: raw.ok !== false };
 }
 
 export async function fetchPage(slug: string, tenant?: string): Promise<PageFull> {
@@ -894,6 +1036,7 @@ export type ChatStreamEvent =
       citations: { slug: string; title: string }[];
       used_pages: string[];
       retrieval: ChatResponse["retrieval"];
+      sealed_excluded?: number;
     }
   | { type: "token"; text: string }
   | { type: "error"; message: string }

--- a/frontend/lib/sealing.ts
+++ b/frontend/lib/sealing.ts
@@ -1,0 +1,623 @@
+// Client-side sealed-tier crypto. Pure module — no React.
+// Contract: /tmp/wiki-bench/SEALING_CONTRACT.md (v1).
+// The hosted server stores ciphertext only; passphrase never leaves this process.
+
+export const DEK_STORAGE_KEY = "plw.sealed.dek";
+export const KDF_ITERATIONS = 600_000;
+export const KDF_NAME = "pbkdf2-sha256";
+export const CHECK_PLAINTEXT = "portable-llm-wiki-seal-check";
+export const WRAP_AAD = "plw-dek-v1";
+export const CHECK_AAD = "plw-check-v1";
+
+const ROOT_SLUGS = new Set(["index", "log", "overview"]);
+const DATE_PREFIX_RE = /^(\d{4}-\d{2}-\d{2})-/;
+const SEALABLE_TIERS = new Set(["recruiter", "friend", "private"]);
+
+export class WrongPassphraseError extends Error {
+  readonly name = "WrongPassphraseError";
+  constructor(message = "Wrong passphrase") {
+    super(message);
+  }
+}
+
+export type SealingKeyring = {
+  v: 1;
+  tiers: string[];
+  kdf: "pbkdf2-sha256";
+  iterations: number;
+  salt: string;
+  wrapped_dek: string;
+  check: string;
+  created: string;
+};
+
+export type EnvelopePayload = {
+  v: 1;
+  title: string;
+  tags: string[];
+  sources: string[];
+  body: string;
+};
+
+export type SealablePage = {
+  slug: string;
+  type: string;
+  tier: string;
+  created: string;
+  updated: string;
+  title: string;
+  tags: string[];
+  sources: string[];
+  body: string;
+};
+
+export type UnsealedPage = SealablePage & {
+  sealed: "v1";
+};
+
+export type FrontmatterFields = {
+  sealed?: string;
+  type?: string;
+  tier?: string;
+  created?: string;
+  updated?: string;
+  title?: string;
+  tags: string[];
+  sources: string[];
+};
+
+function subtle(): SubtleCrypto {
+  const c = globalThis.crypto;
+  if (!c?.subtle) {
+    throw new Error("WebCrypto subtle is not available");
+  }
+  return c.subtle;
+}
+
+function utf8(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function fromUtf8(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+export function bytesToB64(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) {
+    bin += String.fromCharCode(bytes[i]);
+  }
+  return btoa(bin);
+}
+
+export function b64ToBytes(b64: string): Uint8Array {
+  const compact = b64.replace(/\s+/g, "");
+  const bin = atob(compact);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) {
+    out[i] = bin.charCodeAt(i);
+  }
+  return out;
+}
+
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i].toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+function wrap76(s: string): string {
+  const lines: string[] = [];
+  for (let i = 0; i < s.length; i += 76) {
+    lines.push(s.slice(i, i + 76));
+  }
+  return lines.join("\n");
+}
+
+export function todayDatePrefix(now: Date = new Date()): string {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function sessionStore(): Storage | null {
+  try {
+    if (typeof sessionStorage === "undefined") return null;
+    return sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function storeDek(dek: Uint8Array): void {
+  const s = sessionStore();
+  if (!s) return;
+  s.setItem(DEK_STORAGE_KEY, bytesToB64(dek));
+}
+
+export function loadDek(): Uint8Array | null {
+  const s = sessionStore();
+  if (!s) return null;
+  const raw = s.getItem(DEK_STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const bytes = b64ToBytes(raw);
+    return bytes.length === 32 ? bytes : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearDek(): void {
+  const s = sessionStore();
+  if (!s) return;
+  s.removeItem(DEK_STORAGE_KEY);
+}
+
+export async function deriveKek(
+  passphrase: string,
+  saltB64: string,
+  iterations: number,
+): Promise<CryptoKey> {
+  const keyMaterial = await subtle().importKey(
+    "raw",
+    utf8(passphrase),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  return subtle().deriveKey(
+    {
+      name: "PBKDF2",
+      salt: b64ToBytes(saltB64),
+      iterations,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+async function importAesKey(raw: Uint8Array): Promise<CryptoKey> {
+  return subtle().importKey("raw", raw, { name: "AES-GCM" }, false, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+async function encryptWithKey(
+  key: CryptoKey,
+  plaintext: Uint8Array,
+  aad: string,
+): Promise<string> {
+  const nonce = globalThis.crypto.getRandomValues(new Uint8Array(12));
+  const ct = new Uint8Array(
+    await subtle().encrypt(
+      { name: "AES-GCM", iv: nonce, additionalData: utf8(aad), tagLength: 128 },
+      key,
+      plaintext,
+    ),
+  );
+  const packed = new Uint8Array(12 + ct.length);
+  packed.set(nonce, 0);
+  packed.set(ct, 12);
+  return bytesToB64(packed);
+}
+
+async function decryptWithKey(
+  key: CryptoKey,
+  envelopeB64: string,
+  aad: string,
+): Promise<Uint8Array> {
+  const packed = b64ToBytes(envelopeB64);
+  if (packed.length < 28) {
+    throw new Error("envelope too short");
+  }
+  const nonce = packed.subarray(0, 12);
+  const ct = packed.subarray(12);
+  try {
+    const pt = await subtle().decrypt(
+      { name: "AES-GCM", iv: nonce, additionalData: utf8(aad), tagLength: 128 },
+      key,
+      ct,
+    );
+    return new Uint8Array(pt);
+  } catch {
+    throw new Error("decrypt failed");
+  }
+}
+
+async function encryptRaw(
+  dek: Uint8Array,
+  plaintext: Uint8Array,
+  aad: string,
+): Promise<string> {
+  return encryptWithKey(await importAesKey(dek), plaintext, aad);
+}
+
+async function decryptRaw(
+  dek: Uint8Array,
+  envelopeB64: string,
+  aad: string,
+): Promise<Uint8Array> {
+  return decryptWithKey(await importAesKey(dek), envelopeB64, aad);
+}
+
+export function parseKeyring(raw: unknown): SealingKeyring {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new Error("invalid keyring");
+  }
+  const o = raw as Record<string, unknown>;
+  if (o.v !== 1) throw new Error("invalid keyring version");
+  if (o.kdf !== KDF_NAME) throw new Error("invalid keyring kdf");
+  if (typeof o.iterations !== "number" || o.iterations < 100_000) {
+    throw new Error("invalid keyring iterations");
+  }
+  if (typeof o.salt !== "string" || !o.salt) throw new Error("invalid keyring salt");
+  if (typeof o.wrapped_dek !== "string" || !o.wrapped_dek) {
+    throw new Error("invalid keyring wrapped_dek");
+  }
+  if (typeof o.check !== "string" || !o.check) throw new Error("invalid keyring check");
+  if (typeof o.created !== "string" || !o.created) {
+    throw new Error("invalid keyring created");
+  }
+  if (!Array.isArray(o.tiers) || o.tiers.length === 0) {
+    throw new Error("invalid keyring tiers");
+  }
+  const tiers: string[] = [];
+  for (const t of o.tiers) {
+    if (typeof t !== "string" || t === "public" || !SEALABLE_TIERS.has(t)) {
+      throw new Error("invalid keyring tier");
+    }
+    tiers.push(t);
+  }
+  return {
+    v: 1,
+    tiers,
+    kdf: "pbkdf2-sha256",
+    iterations: o.iterations,
+    salt: o.salt,
+    wrapped_dek: o.wrapped_dek,
+    check: o.check,
+    created: o.created,
+  };
+}
+
+export async function verifyDek(
+  dek: Uint8Array,
+  keyring: SealingKeyring,
+): Promise<void> {
+  let plain: Uint8Array;
+  try {
+    plain = await decryptRaw(dek, keyring.check, CHECK_AAD);
+  } catch {
+    throw new WrongPassphraseError();
+  }
+  if (fromUtf8(plain) !== CHECK_PLAINTEXT) {
+    throw new WrongPassphraseError();
+  }
+}
+
+export async function unwrapDek(
+  keyring: SealingKeyring,
+  passphrase: string,
+): Promise<Uint8Array> {
+  const kek = await deriveKek(passphrase, keyring.salt, keyring.iterations);
+  let dek: Uint8Array;
+  try {
+    dek = await decryptWithKey(kek, keyring.wrapped_dek, WRAP_AAD);
+  } catch {
+    throw new WrongPassphraseError();
+  }
+  if (dek.length !== 32) {
+    throw new WrongPassphraseError();
+  }
+  await verifyDek(dek, keyring);
+  return dek;
+}
+
+export async function encryptEnvelope(
+  dek: Uint8Array,
+  slug: string,
+  plaintextJson: string,
+): Promise<string> {
+  return encryptRaw(dek, utf8(plaintextJson), slug);
+}
+
+export async function decryptEnvelope(
+  dek: Uint8Array,
+  slug: string,
+  envelopeB64: string,
+): Promise<string> {
+  const pt = await decryptRaw(dek, envelopeB64, slug);
+  return fromUtf8(pt);
+}
+
+export function parseEnvelopePayload(json: string): EnvelopePayload {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    throw new Error("invalid envelope json");
+  }
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new Error("invalid envelope payload");
+  }
+  const o = raw as Record<string, unknown>;
+  if (o.v !== 1) throw new Error("invalid envelope version");
+  if (typeof o.title !== "string") throw new Error("invalid envelope title");
+  if (typeof o.body !== "string") throw new Error("invalid envelope body");
+  if (!Array.isArray(o.tags) || !o.tags.every((t) => typeof t === "string")) {
+    throw new Error("invalid envelope tags");
+  }
+  if (!Array.isArray(o.sources) || !o.sources.every((t) => typeof t === "string")) {
+    throw new Error("invalid envelope sources");
+  }
+  return {
+    v: 1,
+    title: o.title,
+    tags: o.tags as string[],
+    sources: o.sources as string[],
+    body: o.body,
+  };
+}
+
+export async function opaqueSlug(
+  dek: Uint8Array,
+  title: string,
+  section: string,
+  sourceSlug?: string,
+): Promise<string> {
+  if (sourceSlug && ROOT_SLUGS.has(sourceSlug)) {
+    return sourceSlug;
+  }
+  const key = await subtle().importKey(
+    "raw",
+    dek,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const mac = new Uint8Array(
+    await subtle().sign("HMAC", key, utf8(title.toLowerCase().trim())),
+  );
+  const digest = `s-${toHex(mac.subarray(0, 8))}`;
+  if (section === "decisions") {
+    const kept = sourceSlug?.match(DATE_PREFIX_RE)?.[1];
+    const date = kept ?? todayDatePrefix();
+    return `${date}-${digest}`;
+  }
+  return digest;
+}
+
+export async function generateKeyring(
+  passphrase: string,
+  tiers: string[],
+): Promise<SealingKeyring> {
+  const cleaned = tiers.filter((t) => t !== "public" && SEALABLE_TIERS.has(t));
+  if (cleaned.length === 0) {
+    throw new Error("at least one non-public tier is required");
+  }
+  const salt = globalThis.crypto.getRandomValues(new Uint8Array(16));
+  const dek = globalThis.crypto.getRandomValues(new Uint8Array(32));
+  const saltB64 = bytesToB64(salt);
+  const kek = await deriveKek(passphrase, saltB64, KDF_ITERATIONS);
+  const wrapped_dek = await encryptWithKey(kek, dek, WRAP_AAD);
+  const check = await encryptRaw(dek, utf8(CHECK_PLAINTEXT), CHECK_AAD);
+  return {
+    v: 1,
+    tiers: cleaned,
+    kdf: "pbkdf2-sha256",
+    iterations: KDF_ITERATIONS,
+    salt: saltB64,
+    wrapped_dek,
+    check,
+    created: new Date().toISOString(),
+  };
+}
+
+function parseScalarList(raw: string): string[] {
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed === "[]") return [];
+  let inner = trimmed;
+  if (inner.startsWith("[") && inner.endsWith("]")) {
+    inner = inner.slice(1, -1);
+  }
+  if (!inner.trim()) return [];
+  return inner
+    .split(",")
+    .map((s) => s.trim().replace(/^['"]|['"]$/g, ""))
+    .filter(Boolean);
+}
+
+function unquote(value: string): string {
+  const v = value.trim();
+  if (
+    (v.startsWith('"') && v.endsWith('"')) ||
+    (v.startsWith("'") && v.endsWith("'"))
+  ) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+export function parseWikiFrontmatter(markdown: string): {
+  fields: FrontmatterFields;
+  body: string;
+} {
+  const fields: FrontmatterFields = { tags: [], sources: [] };
+  const text = markdown.replace(/^\uFEFF/, "");
+  if (!text.startsWith("---")) {
+    return { fields, body: text };
+  }
+  const lines = text.split(/\r?\n/);
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) {
+    return { fields, body: text };
+  }
+  const fm = lines.slice(1, end);
+  for (const line of fm) {
+    const m = line.match(/^([A-Za-z_]+):\s*(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    const value = m[2] ?? "";
+    switch (key) {
+      case "sealed":
+        fields.sealed = unquote(value);
+        break;
+      case "type":
+        fields.type = unquote(value);
+        break;
+      case "tier":
+        fields.tier = unquote(value);
+        break;
+      case "created":
+        fields.created = unquote(value);
+        break;
+      case "updated":
+        fields.updated = unquote(value);
+        break;
+      case "title":
+        fields.title = unquote(value);
+        break;
+      case "tags":
+        fields.tags = parseScalarList(value);
+        break;
+      case "sources":
+        fields.sources = parseScalarList(value);
+        break;
+      default:
+        break;
+    }
+  }
+  return { fields, body: lines.slice(end + 1).join("\n") };
+}
+
+export async function sealMarkdown(
+  dek: Uint8Array,
+  page: SealablePage,
+): Promise<string> {
+  const payload: EnvelopePayload = {
+    v: 1,
+    title: page.title,
+    tags: page.tags,
+    sources: page.sources,
+    body: page.body,
+  };
+  const envelope = await encryptEnvelope(
+    dek,
+    page.slug,
+    JSON.stringify(payload),
+  );
+  const fm = [
+    "---",
+    "sealed: v1",
+    `type: ${page.type}`,
+    `tier: ${page.tier}`,
+    `created: ${page.created}`,
+    `updated: ${page.updated}`,
+    "---",
+    wrap76(envelope),
+    "",
+  ];
+  return fm.join("\n");
+}
+
+export async function unsealMarkdown(
+  dek: Uint8Array,
+  slug: string,
+  markdown: string,
+): Promise<UnsealedPage> {
+  const { fields, body } = parseWikiFrontmatter(markdown);
+  if (fields.sealed !== "v1") {
+    throw new Error("not a sealed document");
+  }
+  const envelope = body.replace(/\s+/g, "");
+  const json = await decryptEnvelope(dek, slug, envelope);
+  const payload = parseEnvelopePayload(json);
+  return {
+    slug,
+    type: fields.type ?? "",
+    tier: fields.tier ?? "",
+    created: fields.created ?? "",
+    updated: fields.updated ?? "",
+    title: payload.title,
+    tags: payload.tags,
+    sources: payload.sources,
+    body: payload.body,
+    sealed: "v1",
+  };
+}
+
+export type LocalSearchHit = {
+  slug: string;
+  title: string;
+  section: string;
+  tier: string;
+  updated: string;
+  score: number;
+  excerpt: string;
+};
+
+export function scoreSealedSearch(
+  query: string,
+  title: string,
+  body: string,
+): number {
+  const q = query.toLowerCase().trim();
+  if (!q) return 0;
+  const words = q.split(/\s+/).filter(Boolean);
+  const t = title.toLowerCase();
+  const b = body.toLowerCase();
+  let score = 0;
+  if (t === q) score += 10;
+  else if (t.includes(q)) score += 6;
+  if (b.includes(q)) score += 2;
+  for (const w of words) {
+    if (t.includes(w)) score += 3;
+    if (b.includes(w)) score += 1;
+  }
+  return score;
+}
+
+export function excerptAround(body: string, query: string, width = 140): string {
+  const q = query.trim();
+  if (!q) return body.slice(0, width);
+  const idx = body.toLowerCase().indexOf(q.toLowerCase());
+  if (idx < 0) return body.slice(0, width);
+  const start = Math.max(0, idx - 40);
+  const end = Math.min(body.length, idx + q.length + width - 40);
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < body.length ? "…" : "";
+  return `${prefix}${body.slice(start, end)}${suffix}`;
+}
+
+export function invertTitles(
+  titles: Map<string, string> | null,
+): Map<string, string> | undefined {
+  if (!titles) return undefined;
+  const out = new Map<string, string>();
+  for (const [slug, title] of titles) {
+    out.set(title.toLowerCase().trim(), slug);
+  }
+  return out;
+}
+
+export function displayPageTitle(
+  slug: string,
+  fallback: string,
+  titles: Map<string, string> | null,
+): string {
+  return titles?.get(slug) ?? fallback;
+}

--- a/frontend/lib/sealing.ts
+++ b/frontend/lib/sealing.ts
@@ -117,10 +117,7 @@ function wrap76(s: string): string {
 }
 
 export function todayDatePrefix(now: Date = new Date()): string {
-  const y = now.getFullYear();
-  const m = String(now.getMonth() + 1).padStart(2, "0");
-  const d = String(now.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
+  return now.toISOString().slice(0, 10);
 }
 
 function sessionStore(): Storage | null {

--- a/frontend/lib/useSealing.ts
+++ b/frontend/lib/useSealing.ts
@@ -1,0 +1,279 @@
+"use client";
+
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+
+import {
+  fetchManifest,
+  fetchSealedBundle,
+  fetchSealingKeyring,
+  type SealedBundlePage,
+} from "./api";
+import { useTenant } from "./useTenant";
+import {
+  clearDek,
+  decryptEnvelope,
+  excerptAround,
+  loadDek,
+  parseEnvelopePayload,
+  scoreSealedSearch,
+  storeDek,
+  unwrapDek,
+  verifyDek,
+  WrongPassphraseError,
+  type EnvelopePayload,
+  type LocalSearchHit,
+} from "./sealing";
+
+export type SealingStatus = "not_enabled" | "locked" | "unlocked";
+
+export type SealingApi = {
+  status: SealingStatus;
+  tiers: string[];
+  dek: Uint8Array | null;
+  titles: Map<string, string> | null;
+  sealedCount: number;
+  unlock: (passphrase: string) => Promise<void>;
+  lock: () => void;
+  decryptPage: (slug: string, envelope: string) => Promise<EnvelopePayload>;
+  refresh: () => Promise<void>;
+  searchLocal: (query: string) => LocalSearchHit[];
+};
+
+type Snapshot = {
+  status: SealingStatus;
+  tiers: string[];
+  dek: Uint8Array | null;
+  titles: Map<string, string> | null;
+  sealedCount: number;
+};
+
+const UNBOUND = Symbol("unbound");
+
+const EMPTY: Snapshot = {
+  status: "not_enabled",
+  tiers: [],
+  dek: null,
+  titles: null,
+  sealedCount: 0,
+};
+
+let snapshot: Snapshot = EMPTY;
+let boundTenant: string | undefined | typeof UNBOUND = UNBOUND;
+let bundle: SealedBundlePage[] = [];
+let cache = new Map<string, EnvelopePayload>();
+let hydrateGen = 0;
+const listeners = new Set<() => void>();
+
+function emit(next: Snapshot): void {
+  snapshot = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): Snapshot {
+  return snapshot;
+}
+
+function tenantOf(): string | undefined {
+  return boundTenant === UNBOUND ? undefined : boundTenant;
+}
+
+async function decryptBundle(
+  tenant: string | undefined,
+  dek: Uint8Array,
+  tiers: string[],
+): Promise<void> {
+  const fetched = await fetchSealedBundle(tenant);
+  bundle = fetched.pages;
+  cache = new Map();
+  const titles = new Map<string, string>();
+  for (const page of fetched.pages) {
+    try {
+      const payload = parseEnvelopePayload(
+        await decryptEnvelope(dek, page.slug, page.envelope),
+      );
+      cache.set(page.slug, payload);
+      titles.set(page.slug, payload.title);
+    } catch {
+      /* skip a corrupt page; others still unlock */
+    }
+  }
+  emit({
+    status: "unlocked",
+    tiers,
+    dek,
+    titles,
+    sealedCount: fetched.count,
+  });
+}
+
+async function hydrate(tenant: string | undefined): Promise<void> {
+  const gen = ++hydrateGen;
+  boundTenant = tenant;
+  try {
+    const manifest = await fetchManifest(tenant);
+    if (gen !== hydrateGen) return;
+    const sealing = manifest.sealing;
+    if (!sealing) {
+      bundle = [];
+      cache = new Map();
+      emit(EMPTY);
+      return;
+    }
+    const stored = loadDek();
+    if (stored) {
+      try {
+        const keyring = await fetchSealingKeyring(tenant);
+        if (gen !== hydrateGen) return;
+        await verifyDek(stored, keyring);
+        await decryptBundle(tenant, stored, sealing.tiers);
+        return;
+      } catch {
+        clearDek();
+      }
+    }
+    if (gen !== hydrateGen) return;
+    bundle = [];
+    cache = new Map();
+    emit({
+      status: "locked",
+      tiers: sealing.tiers,
+      dek: null,
+      titles: null,
+      sealedCount: 0,
+    });
+  } catch {
+    if (gen !== hydrateGen) return;
+    emit(EMPTY);
+  }
+}
+
+async function unlock(passphrase: string): Promise<void> {
+  const tenant = tenantOf();
+  const keyring = await fetchSealingKeyring(tenant);
+  const dek = await unwrapDek(keyring, passphrase);
+  storeDek(dek);
+  await decryptBundle(tenant, dek, keyring.tiers);
+}
+
+function lock(): void {
+  clearDek();
+  bundle = [];
+  cache = new Map();
+  if (snapshot.status === "not_enabled") {
+    emit(EMPTY);
+    return;
+  }
+  emit({
+    status: "locked",
+    tiers: snapshot.tiers,
+    dek: null,
+    titles: null,
+    sealedCount: 0,
+  });
+}
+
+async function decryptPage(
+  slug: string,
+  envelope: string,
+): Promise<EnvelopePayload> {
+  const cached = cache.get(slug);
+  if (cached) return cached;
+  const dek = snapshot.dek ?? loadDek();
+  if (!dek) {
+    throw new WrongPassphraseError();
+  }
+  const payload = parseEnvelopePayload(await decryptEnvelope(dek, slug, envelope));
+  cache.set(slug, payload);
+  return payload;
+}
+
+async function refresh(): Promise<void> {
+  const tenant = tenantOf();
+  if (snapshot.status === "unlocked" && snapshot.dek) {
+    await decryptBundle(tenant, snapshot.dek, snapshot.tiers);
+    return;
+  }
+  await hydrate(tenant);
+}
+
+function searchLocal(query: string): LocalSearchHit[] {
+  const hits: LocalSearchHit[] = [];
+  for (const page of bundle) {
+    const payload = cache.get(page.slug);
+    if (!payload) continue;
+    const score = scoreSealedSearch(query, payload.title, payload.body);
+    if (score <= 0) continue;
+    hits.push({
+      slug: page.slug,
+      title: payload.title,
+      section: page.section,
+      tier: page.tier,
+      updated: page.updated,
+      score,
+      excerpt: excerptAround(payload.body, query),
+    });
+  }
+  hits.sort((a, b) => b.score - a.score);
+  return hits;
+}
+
+export function useSealing(tenantOverride?: string): SealingApi {
+  const routeTenant = useTenant();
+  const tenant = tenantOverride ?? routeTenant;
+  const current = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  useEffect(() => {
+    void hydrate(tenant);
+  }, [tenant]);
+
+  const unlockBound = useCallback(async (passphrase: string) => {
+    await unlock(passphrase);
+  }, []);
+
+  const lockBound = useCallback(() => {
+    lock();
+  }, []);
+
+  const decryptBound = useCallback((slug: string, envelope: string) => {
+    return decryptPage(slug, envelope);
+  }, []);
+
+  const refreshBound = useCallback(async () => {
+    await refresh();
+  }, []);
+
+  const searchBound = useCallback((query: string) => {
+    return searchLocal(query);
+  }, []);
+
+  return {
+    status: current.status,
+    tiers: current.tiers,
+    dek: current.dek,
+    titles: current.titles,
+    sealedCount: current.sealedCount,
+    unlock: unlockBound,
+    lock: lockBound,
+    decryptPage: decryptBound,
+    refresh: refreshBound,
+    searchLocal: searchBound,
+  };
+}
+
+/** Test helper — reset module state between cases. */
+export function __resetSealingStore(): void {
+  snapshot = EMPTY;
+  boundTenant = UNBOUND;
+  bundle = [];
+  cache = new Map();
+  hydrateGen += 1;
+  clearDek();
+  for (const listener of listeners) listener();
+}

--- a/frontend/tests/Markdown.test.tsx
+++ b/frontend/tests/Markdown.test.tsx
@@ -58,6 +58,12 @@ describe("preprocessWikilinks", () => {
     expect(out).toContain("/wiki/page/2026-05-20-postpone-series-a");
   });
 
+  it("resolves sealed wikilink targets via the decrypted titles map", () => {
+    const titles = new Map([["hidden notes", "s-deadbeefcafebabe"]]);
+    const out = preprocessWikilinks("See [[Hidden Notes]] please", titles);
+    expect(out).toBe("See [Hidden Notes](/wiki/page/s-deadbeefcafebabe) please");
+  });
+
   it("drops punctuation in titles while preserving readable display text", () => {
     const out = preprocessWikilinks("[[Provenance: Citations]]");
     // Display text keeps the colon, slug drops it.

--- a/frontend/tests/PageView.sealed.test.tsx
+++ b/frontend/tests/PageView.sealed.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { PageFull } from "@/lib/api";
+
+vi.mock("@/lib/useTenant", () => ({
+  useTenant: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/useIsOwner", () => ({
+  useIsOwnerOf: vi.fn(() => ({ ready: true, isOwner: false })),
+}));
+
+const mockFetchPage = vi.fn();
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    fetchPage: (...args: unknown[]) => mockFetchPage(...args),
+    ownerSetTier: vi.fn(),
+    ownerGetPageRaw: vi.fn(),
+    ownerReplacePage: vi.fn(),
+  };
+});
+
+const sealing = {
+  status: "locked" as "locked" | "unlocked" | "not_enabled",
+  tiers: ["private"],
+  dek: new Uint8Array(32) as Uint8Array | null,
+  titles: new Map<string, string>([["s-abc", "Hidden Notes"]]),
+  sealedCount: 1,
+  unlock: vi.fn(),
+  lock: vi.fn(),
+  decryptPage: vi.fn(),
+  refresh: vi.fn(),
+  searchLocal: vi.fn(() => []),
+};
+
+vi.mock("@/lib/useSealing", () => ({
+  useSealing: () => sealing,
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ slug: "s-abc" }),
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/page/s-abc",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import PageView from "@/app/page/[slug]/page";
+
+const SEALED_PAGE: PageFull = {
+  slug: "s-abc",
+  title: "Sealed page",
+  section: "concepts",
+  tier: "private",
+  type: "concept",
+  body: "",
+  rendered_body: "",
+  tags: [],
+  excerpt: "",
+  links_out: [],
+  links_in: [],
+  links_out_resolved: [],
+  links_in_resolved: [],
+  sources: [],
+  word_count: 0,
+  rel_path: "wiki/concepts/s-abc.md",
+  created: "2026-09-12",
+  updated: "2026-09-12",
+  sealed: true,
+  envelope: "dGVzdA==",
+};
+
+describe("PageView sealed", () => {
+  beforeEach(() => {
+    mockFetchPage.mockReset();
+    mockFetchPage.mockResolvedValue(SEALED_PAGE);
+    sealing.status = "locked";
+    sealing.decryptPage.mockReset();
+    sealing.decryptPage.mockResolvedValue({
+      v: 1,
+      title: "Hidden Notes",
+      tags: ["secret"],
+      sources: ["raw/x.md"],
+      body: "See [[Other Secret]] inside.",
+    });
+  });
+
+  it("renders the locked sealed-page state with an unlock control", async () => {
+    render(<PageView />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Sealed page" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText(/unlock to read/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /unlock/i })).toBeInTheDocument();
+    expect(screen.queryByText("Hidden Notes")).not.toBeInTheDocument();
+  });
+
+  it("decrypts and renders title, tags, and body when unlocked", async () => {
+    sealing.status = "unlocked";
+    render(<PageView />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Hidden Notes" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("#secret")).toBeInTheDocument();
+    expect(screen.getByText(/inside/)).toBeInTheDocument();
+    expect(sealing.decryptPage).toHaveBeenCalledWith("s-abc", "dGVzdA==");
+  });
+});

--- a/frontend/tests/SealedUnlock.test.tsx
+++ b/frontend/tests/SealedUnlock.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const unlock = vi.fn();
+const lock = vi.fn();
+const sealing = {
+  status: "locked" as "locked" | "unlocked" | "not_enabled",
+  tiers: ["private"],
+  dek: null as Uint8Array | null,
+  titles: null as Map<string, string> | null,
+  sealedCount: 0,
+  unlock,
+  lock,
+  decryptPage: vi.fn(),
+  refresh: vi.fn(),
+  searchLocal: vi.fn(() => []),
+};
+
+vi.mock("@/lib/useSealing", () => ({
+  useSealing: () => sealing,
+}));
+
+import { SealedUnlock } from "@/components/SealedUnlock";
+import { WrongPassphraseError } from "@/lib/sealing";
+
+describe("SealedUnlock", () => {
+  beforeEach(() => {
+    unlock.mockReset();
+    lock.mockReset();
+    sealing.status = "locked";
+    sealing.dek = null;
+    sealing.titles = null;
+  });
+
+  it("returns nothing when sealing is not enabled", () => {
+    sealing.status = "not_enabled";
+    const { container } = render(<SealedUnlock />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("unlocks with the passphrase and shows locked error text", async () => {
+    unlock.mockRejectedValueOnce(new WrongPassphraseError());
+    const user = userEvent.setup();
+    render(<SealedUnlock />);
+
+    await user.type(screen.getByLabelText(/passphrase/i), "nope");
+    await user.click(screen.getByRole("button", { name: /unlock/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Wrong passphrase");
+    });
+    expect(unlock).toHaveBeenCalledWith("nope");
+  });
+
+  it("shows Lock when unlocked", async () => {
+    sealing.status = "unlocked";
+    const user = userEvent.setup();
+    render(<SealedUnlock />);
+    expect(screen.getByText("unlocked")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /lock/i }));
+    expect(lock).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/SealingPanel.test.tsx
+++ b/frontend/tests/SealingPanel.test.tsx
@@ -1,0 +1,210 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { Manifest, PageSummary } from "@/lib/api";
+
+const unlock = vi.fn();
+const lock = vi.fn();
+const refresh = vi.fn();
+const sealing = {
+  status: "not_enabled" as "not_enabled" | "locked" | "unlocked",
+  tiers: [] as string[],
+  dek: null as Uint8Array | null,
+  titles: null as Map<string, string> | null,
+  sealedCount: 0,
+  unlock,
+  lock,
+  decryptPage: vi.fn(),
+  refresh,
+  searchLocal: vi.fn(() => []),
+};
+
+vi.mock("@/lib/useSealing", () => ({
+  useSealing: () => sealing,
+}));
+
+vi.mock("@/lib/sealing", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sealing")>(
+    "@/lib/sealing",
+  );
+  return {
+    ...actual,
+    generateKeyring: vi.fn(async (_p: string, tiers: string[]) => ({
+      v: 1 as const,
+      tiers,
+      kdf: "pbkdf2-sha256" as const,
+      iterations: 600000,
+      salt: "c2FsdA==",
+      wrapped_dek: "d3JhcA==",
+      check: "Y2hlY2s=",
+      created: "2026-09-12T00:00:00.000Z",
+    })),
+    sealMarkdown: vi.fn(async () => "---\nsealed: v1\n---\nenvelope"),
+  };
+});
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchManifest: vi.fn(),
+    ownerPutSealing: vi.fn(),
+    ownerDeleteSealing: vi.fn(),
+    ownerGetPageRaw: vi.fn(),
+    ownerReplacePage: vi.fn(),
+  };
+});
+
+import {
+  fetchManifest,
+  ownerGetPageRaw,
+  ownerPutSealing,
+  ownerReplacePage,
+} from "@/lib/api";
+import { generateKeyring } from "@/lib/sealing";
+import { SealingPanel } from "@/components/SealingPanel";
+
+const ACK =
+  "If I lose this passphrase, nobody, including the site operator, can recover these pages.";
+
+function page(slug: string, sealed?: true): PageSummary {
+  return {
+    slug,
+    title: sealed ? "Sealed page" : slug,
+    section: "concepts",
+    type: "concept",
+    tier: "private",
+    created: "2026-01-01",
+    updated: "2026-01-02",
+    tags: [],
+    excerpt: "",
+    word_count: 10,
+    rel_path: `wiki/concepts/${slug}.md`,
+    sealed,
+  };
+}
+
+const BASE_MANIFEST: Manifest = {
+  wiki_title: "Test",
+  generated_at: "2026-09-12T00:00:00Z",
+  viewer_tier: "private",
+  viewer_is_owner: true,
+  page_count: 2,
+  sections: { concepts: 2 },
+  pages: [page("alpha"), page("beta")],
+};
+
+describe("SealingPanel", () => {
+  beforeEach(() => {
+    sealing.status = "not_enabled";
+    sealing.tiers = [];
+    sealing.dek = null;
+    unlock.mockReset().mockResolvedValue(undefined);
+    lock.mockReset();
+    refresh.mockReset().mockResolvedValue(undefined);
+    vi.mocked(fetchManifest).mockReset();
+    vi.mocked(ownerPutSealing).mockReset().mockResolvedValue({ ok: true });
+    vi.mocked(ownerGetPageRaw).mockReset();
+    vi.mocked(ownerReplacePage).mockReset();
+    vi.mocked(fetchManifest).mockResolvedValue(BASE_MANIFEST);
+  });
+
+  it("does not enable without matching confirm and acknowledgement", async () => {
+    const user = userEvent.setup();
+    render(<SealingPanel />);
+
+    await user.type(screen.getByPlaceholderText("passphrase"), "secret");
+    await user.click(screen.getByRole("button", { name: /enable sealing/i }));
+    expect(ownerPutSealing).not.toHaveBeenCalled();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /confirm do not match/i,
+    );
+
+    await user.type(screen.getByPlaceholderText("confirm passphrase"), "secret");
+    await user.click(screen.getByRole("button", { name: /enable sealing/i }));
+    expect(ownerPutSealing).not.toHaveBeenCalled();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /acknowledgement is required/i,
+    );
+  });
+
+  it("enables after confirm + acknowledgement and unlocks", async () => {
+    const user = userEvent.setup();
+    render(<SealingPanel />);
+
+    await user.type(screen.getByPlaceholderText("passphrase"), "secret");
+    await user.type(screen.getByPlaceholderText("confirm passphrase"), "secret");
+    await user.click(screen.getByLabelText(ACK));
+    await user.click(screen.getByRole("button", { name: /enable sealing/i }));
+
+    await waitFor(() => {
+      expect(generateKeyring).toHaveBeenCalledWith("secret", ["private"]);
+    });
+    await waitFor(() => {
+      expect(ownerPutSealing).toHaveBeenCalledWith(
+        expect.objectContaining({
+          force: false,
+          keyring: expect.objectContaining({ tiers: ["private"] }),
+        }),
+        undefined,
+      );
+    });
+    expect(unlock).toHaveBeenCalledWith("secret");
+  });
+
+  it("migrates plaintext pages sequentially and reports failures", async () => {
+    sealing.status = "unlocked";
+    sealing.tiers = ["private"];
+    sealing.dek = new Uint8Array(32);
+    vi.mocked(fetchManifest).mockResolvedValue({
+      ...BASE_MANIFEST,
+      sealing: {
+        enabled: true,
+        tiers: ["private"],
+        keyring_url: "/wiki/sealing",
+        bundle_url: "/wiki/sealed/bundle",
+      },
+    });
+
+    const order: string[] = [];
+    vi.mocked(ownerGetPageRaw).mockImplementation(async (slug) => {
+      order.push(`raw:${slug}`);
+      return {
+        slug,
+        rel_path: `wiki/concepts/${slug}.md`,
+        title: slug,
+        section: "concepts",
+        tier: "private",
+        markdown: `---\ntype: concept\ntier: private\ncreated: 2026-01-01\nupdated: 2026-01-02\ntitle: ${slug}\ntags: [x]\nsources: []\n---\nbody of ${slug}\n`,
+      };
+    });
+    vi.mocked(ownerReplacePage).mockImplementation(async (slug) => {
+      order.push(`put:${slug}`);
+      if (slug === "beta") throw new Error("disk full");
+      return {
+        ok: true,
+        slug,
+        rel_path: `wiki/concepts/${slug}.md`,
+        tier: "private",
+        title: "Sealed page",
+        size: 10,
+      };
+    });
+
+    const user = userEvent.setup();
+    render(<SealingPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/alpha · private/)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /seal existing pages/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/beta: disk full/)).toBeInTheDocument();
+    });
+    expect(order).toEqual(["raw:alpha", "put:alpha", "raw:beta", "put:beta"]);
+    expect(screen.getByRole("status")).toHaveTextContent(/sealed 2 of 2/);
+  });
+});

--- a/frontend/tests/api.test.ts
+++ b/frontend/tests/api.test.ts
@@ -10,7 +10,13 @@ import {
   getPreviewAs,
   setPreviewAs,
   fetchManifest,
+  fetchSealedBundle,
+  fetchSealingKeyring,
+  ownerDeleteSealing,
+  ownerGetPageRaw,
   ownerLint,
+  ownerPutSealing,
+  ownerReplacePage,
 } from "@/lib/api";
 import { setShareToken } from "@/lib/shareToken";
 
@@ -200,5 +206,165 @@ describe("preview-as vs owner bootstrap headers", () => {
     const hdrs = init.headers as Record<string, string>;
     expect(hdrs["Authorization"]).toBe("Bearer owner-secret");
     expect(hdrs["X-Share-Token"]).toBeUndefined();
+  });
+});
+
+describe("sealing fetchers", () => {
+  const keyring = {
+    v: 1 as const,
+    tiers: ["private"],
+    kdf: "pbkdf2-sha256" as const,
+    iterations: 600000,
+    salt: "c2FsdHNhbHRzYWx0c2FsdA==",
+    wrapped_dek: "d3JhcHBlZGRla3dyYXBwZWRkZWs=",
+    check: "Y2hlY2tjaGVja2NoZWNrY2hlY2s=",
+    created: "2026-09-12T00:00:00.000Z",
+  };
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetchSealingKeyring hits /wiki/sealing with browse headers", async () => {
+    setPreviewAs("friend");
+    setOwnerToken("owner-secret");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => keyring,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const got = await fetchSealingKeyring();
+    expect(got.tiers).toEqual(["private"]);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/backend/wiki/sealing");
+    const hdrs = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(hdrs["X-Preview-As"]).toBe("friend");
+    expect(hdrs["Authorization"]).toBe("Bearer owner-secret");
+  });
+
+  it("fetchSealedBundle hits /wiki/sealed/bundle with browse headers", async () => {
+    setPreviewAs("recruiter");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        count: 1,
+        pages: [
+          {
+            slug: "s-abc",
+            section: "concepts",
+            tier: "private",
+            updated: "2026-09-12",
+            envelope: "ZW52",
+          },
+        ],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const got = await fetchSealedBundle();
+    expect(got.count).toBe(1);
+    expect(got.pages[0].slug).toBe("s-abc");
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/backend/wiki/sealed/bundle");
+    const hdrs = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(hdrs["X-Preview-As"]).toBe("recruiter");
+  });
+
+  it("ownerPutSealing PUTs /owner/sealing without preview headers", async () => {
+    setPreviewAs("public");
+    setOwnerToken("owner-secret");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await ownerPutSealing({ keyring, force: true });
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/backend/owner/sealing");
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    const hdrs = init.headers as Record<string, string>;
+    expect(hdrs["Authorization"]).toBe("Bearer owner-secret");
+    expect(hdrs["X-Preview-As"]).toBeUndefined();
+    expect(JSON.parse(String(init.body))).toEqual({ keyring, force: true });
+  });
+
+  it("ownerDeleteSealing DELETEs /owner/sealing with owner headers", async () => {
+    setPreviewAs("friend");
+    setOwnerToken("owner-secret");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await ownerDeleteSealing();
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/backend/owner/sealing");
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("DELETE");
+    const hdrs = init.headers as Record<string, string>;
+    expect(hdrs["Authorization"]).toBe("Bearer owner-secret");
+    expect(hdrs["X-Preview-As"]).toBeUndefined();
+  });
+
+  it("ownerGetPageRaw GETs /owner/page/{slug}/raw with owner headers", async () => {
+    setPreviewAs("public");
+    setOwnerToken("owner-secret");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        slug: "alpha",
+        rel_path: "wiki/concepts/alpha.md",
+        title: "Alpha",
+        section: "concepts",
+        tier: "private",
+        markdown: "---\n---\n",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await ownerGetPageRaw("alpha");
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/backend/owner/page/alpha/raw");
+    const hdrs = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(hdrs["Authorization"]).toBe("Bearer owner-secret");
+    expect(hdrs["X-Preview-As"]).toBeUndefined();
+  });
+
+  it("ownerReplacePage PUTs /owner/page/{slug} with owner headers", async () => {
+    setPreviewAs("friend");
+    setOwnerToken("owner-secret");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        slug: "alpha",
+        rel_path: "wiki/concepts/alpha.md",
+        tier: "private",
+        title: "Alpha",
+        size: 12,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await ownerReplacePage("alpha", "---\n---\nbody");
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/backend/owner/page/alpha");
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(String(init.body))).toEqual({ markdown: "---\n---\nbody" });
+    const hdrs = init.headers as Record<string, string>;
+    expect(hdrs["X-Preview-As"]).toBeUndefined();
   });
 });

--- a/frontend/tests/sealing.test.ts
+++ b/frontend/tests/sealing.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  WrongPassphraseError,
+  decryptEnvelope,
+  encryptEnvelope,
+  generateKeyring,
+  opaqueSlug,
+  sealMarkdown,
+  unsealMarkdown,
+  unwrapDek,
+} from "@/lib/sealing";
+
+const PAGE = {
+  slug: "secret-notes",
+  type: "concept",
+  tier: "private",
+  created: "2026-09-01",
+  updated: "2026-09-12",
+  title: "Secret Notes",
+  tags: ["alpha", "beta"],
+  sources: ["raw/conversations/x.md"],
+  body: "Keep [[Other Page]] private.\n\nMore body.",
+};
+
+describe("sealing crypto", () => {
+  it(
+    "generateKeyring unwraps with the passphrase and rejects a wrong one",
+    async () => {
+      const keyring = await generateKeyring("correct horse", ["private"]);
+      expect(keyring.v).toBe(1);
+      expect(keyring.kdf).toBe("pbkdf2-sha256");
+      expect(keyring.iterations).toBe(600000);
+      expect(keyring.tiers).toEqual(["private"]);
+
+      const dek = await unwrapDek(keyring, "correct horse");
+      expect(dek).toBeInstanceOf(Uint8Array);
+      expect(dek.length).toBe(32);
+
+      await expect(unwrapDek(keyring, "wrong phrase")).rejects.toBeInstanceOf(
+        WrongPassphraseError,
+      );
+    },
+    30_000,
+  );
+
+  it("round-trips envelope encrypt/decrypt", async () => {
+    const dek = globalThis.crypto.getRandomValues(new Uint8Array(32));
+    const json = JSON.stringify({
+      v: 1,
+      title: PAGE.title,
+      tags: PAGE.tags,
+      sources: PAGE.sources,
+      body: PAGE.body,
+    });
+    const env = await encryptEnvelope(dek, PAGE.slug, json);
+    const back = await decryptEnvelope(dek, PAGE.slug, env);
+    expect(JSON.parse(back)).toEqual(JSON.parse(json));
+  });
+
+  it("binds the envelope to the slug AAD", async () => {
+    const dek = globalThis.crypto.getRandomValues(new Uint8Array(32));
+    const env = await encryptEnvelope(dek, "slug-a", '{"v":1}');
+    await expect(decryptEnvelope(dek, "slug-b", env)).rejects.toThrow(
+      /decrypt failed/,
+    );
+  });
+
+  it("opaqueSlug is deterministic and prefixes decisions", async () => {
+    const dek = globalThis.crypto.getRandomValues(new Uint8Array(32));
+    const a = await opaqueSlug(dek, "  Secret Notes ", "concepts");
+    const b = await opaqueSlug(dek, "secret notes", "concepts");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^s-[0-9a-f]{16}$/);
+
+    const other = await opaqueSlug(dek, "Different", "concepts");
+    expect(other).not.toBe(a);
+
+    const dated = await opaqueSlug(
+      dek,
+      "Ship it",
+      "decisions",
+      "2024-03-15-old-name",
+    );
+    expect(dated).toMatch(/^2024-03-15-s-[0-9a-f]{16}$/);
+
+    const fresh = await opaqueSlug(dek, "Ship it", "decisions");
+    expect(fresh).toMatch(/^\d{4}-\d{2}-\d{2}-s-[0-9a-f]{16}$/);
+
+    expect(await opaqueSlug(dek, "Home", "root", "index")).toBe("index");
+    expect(await opaqueSlug(dek, "Log", "root", "log")).toBe("log");
+    expect(await opaqueSlug(dek, "Overview", "root", "overview")).toBe(
+      "overview",
+    );
+  });
+
+  it("sealMarkdown / unsealMarkdown preserves title, tags, sources, body", async () => {
+    const dek = globalThis.crypto.getRandomValues(new Uint8Array(32));
+    const md = await sealMarkdown(dek, PAGE);
+    expect(md).toMatch(/^---\nsealed: v1\n/);
+    expect(md).toContain("type: concept");
+    expect(md).not.toContain("title: Secret Notes");
+    expect(md).not.toContain("Keep [[Other Page]]");
+
+    const plain = await unsealMarkdown(dek, PAGE.slug, md);
+    expect(plain.title).toBe(PAGE.title);
+    expect(plain.tags).toEqual(PAGE.tags);
+    expect(plain.sources).toEqual(PAGE.sources);
+    expect(plain.body).toBe(PAGE.body);
+    expect(plain.type).toBe("concept");
+    expect(plain.tier).toBe("private");
+    expect(plain.sealed).toBe("v1");
+  });
+});

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -2,8 +2,17 @@
  * Vitest setup file. Wires `@testing-library/jest-dom` matchers and mocks
  * the bits of Next.js that don't work in a plain jsdom environment.
  */
+import { webcrypto } from "node:crypto";
 import "@testing-library/jest-dom/vitest";
 import { vi, beforeEach } from "vitest";
+import { __resetSealingStore } from "@/lib/useSealing";
+
+if (!globalThis.crypto?.subtle) {
+  Object.defineProperty(globalThis, "crypto", {
+    value: webcrypto,
+    configurable: true,
+  });
+}
 
 // next/link in this codebase only uses `href` + children, so the simplest
 // possible passthrough is enough.
@@ -53,4 +62,6 @@ export function __setPathname(p: string) {
 beforeEach(() => {
   globalThis.__TEST_PATHNAME = "/";
   window.localStorage.clear();
+  window.sessionStorage.clear();
+  __resetSealingStore();
 });

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -241,6 +241,13 @@ Slugs are opaque (`s-<hmac>`) except root pages `index`, `log`, and
 If you lose the passphrase, nobody can recover the pages — not you,
 not the server operator.
 
+Sealing does not rewrite git history: pages that were plaintext before
+`seal_page` remain plaintext in earlier commits until that history is
+rotated. `seal_page` keeps the existing file name; only pages created
+through `write_pages` after sealing get opaque slugs. `raw/` captures
+are not sealed. After `seal_disable` the keyring stays on the server so
+leftover sealed pages can still be read and `unseal_page`d.
+
 ## Smoke test / unit tests
 
 No live credentials required (uses an embedded mock backend):

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -108,6 +108,7 @@ Recommended first call in any agent session: `connection_status`.
 |---|---|---|
 | `WIKI_BASE_URL` | Path prefix before `/wiki` and `/owner` (preferred). Hosted: `https://portablellm.wiki/<tenant>`. Local single-tenant: `http://localhost:8000`. | `http://localhost:8000` |
 | `WIKI_OWNER_TOKEN` | Optional bearer. May be owner-capable, share/read-only, or invalid — always verified via the manifest. Never logged. | (none) |
+| `WIKI_SEAL_PASSPHRASE` | Passphrase that unwraps the sealed-tier keyring in this process. Required to read or write sealed tiers. Never logged, never sent to the server. | (none) |
 | `WIKI_API_BASE` | Legacy alias for `WIKI_BASE_URL`. Still works if `WIKI_BASE_URL` is unset. | — |
 
 When pointing at the hosted Vercel demo, use the tenant-scoped base URL
@@ -136,7 +137,12 @@ API (`/wiki/manifest.json` returns 404).
 | `set_page_tier` | Change a page's visibility tier. | **yes** |
 | `delete_page` | Delete a page file and reload the index. | **yes** |
 | `writeback_spec` | Public schema text for `write_pages`. | no |
-| `lint_wiki` | Structural lint report (orphans, stale, broken provenance, etc.). | **yes** |
+| `lint_wiki` | Structural lint report (orphans, stale, broken provenance, etc.). Refused by the server when sealing is enabled. | **yes** |
+| `seal_status` | Whether sealing is enabled, which tiers, and whether this process is unlocked. | no |
+| `seal_init` | Generate a keyring from `WIKI_SEAL_PASSPHRASE` and enable sealed tiers. | **yes** |
+| `seal_disable` | Clear keyring tiers (already-sealed pages stay encrypted). | **yes** |
+| `seal_page` | Encrypt an existing plaintext page in place (same slug). | **yes** |
+| `unseal_page` | Decrypt a sealed page to a non-sealed tier in one PUT. | **yes** |
 
 ## Write tools
 
@@ -201,6 +207,37 @@ exposing the master `OWNER_TOKEN`, use the **Share Tokens** panel in the
 owner console at `/owner`. The plaintext token is shown once at mint
 time — paste it into the recipient's `WIKI_OWNER_TOKEN` env var. That
 recipient should expect `auth_mode=share_read_only`, not owner writes.
+
+## Sealed tiers
+
+Sealing is opt-in. When the owner runs `seal_init`, chosen tiers
+(typically `private`; optionally `friend` / `recruiter`) are stored on
+the hosted server as ciphertext. Encryption and decryption happen in
+this MCP process on the user's machine — or in the browser. `public`
+can never be sealed.
+
+Set `WIKI_SEAL_PASSPHRASE` in the MCP env (the same `env` block as
+`WIKI_OWNER_TOKEN`). Call `connection_status` or `seal_status` to see
+`sealing: {enabled, tiers, unlocked}`. If the passphrase is missing or
+wrong, the process is locked: reads of sealed pages return a
+placeholder, and writes that would send plaintext to a sealed tier are
+refused before anything is posted.
+
+When `private` is sealed and the process is unlocked, `write_pages`
+seals each page locally (opaque slug, `sealed: v1` frontmatter) and
+writes through `/owner/capture/verbatim` instead of posting plaintext
+to `/owner/capture/structured`. `append_to_page` decrypts, appends,
+and re-seals. `search_wiki` / `query_wiki` merge local hits over the
+decrypted bundle (labelled "decrypted locally"); the MCP does not call
+an LLM. The server-side orchestrator is disabled on sealed wikis.
+
+What the server operator can see: tier, section, dates, page count,
+and ciphertext. Titles, tags, sources, and bodies are encrypted.
+Slugs are opaque (`s-<hmac>`) except root pages `index`, `log`, and
+`overview`.
+
+If you lose the passphrase, nobody can recover the pages — not you,
+not the server operator.
 
 ## Smoke test / unit tests
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -126,9 +126,42 @@ API (`/wiki/manifest.json` returns 404).
 | `search_wiki` | Fast keyword search across visible pages. | no |
 | `query_wiki` | The primary tool. Natural-language question → graph-aware retrieval → sourced answer with citations. | no |
 | `get_neighbors` | All pages within N hops of a slug along the wikilink graph. | no |
-| `ingest_source` | Save a new raw source + optionally kick off the ingest orchestrator. Fails closed if not owner-capable. | **yes** |
+| `ingest_source` | Save a new raw source. Default does not run the server-side orchestrator. Prefer `write_pages` for graph updates. Fails closed if not owner-capable. | **yes** |
 | `ingest_job_status` | Bounded polling of `GET /owner/jobs/{tracking_id}` (+ optional persistence). Verifies orchestrator outcome honestly. | **yes** |
+| `write_pages` | Structured multi-page writeback. Forces tier private. | **yes** |
+| `write_page_verbatim` | Write one authored markdown page; frontmatter tier is respected. | **yes** |
+| `read_page_raw` | Full markdown including frontmatter. | **yes** |
+| `replace_page` | Full-file replace including frontmatter. | **yes** |
+| `append_to_page` | Read raw + PUT with exactly one newline before the appended text. | **yes** |
+| `set_page_tier` | Change a page's visibility tier. | **yes** |
+| `delete_page` | Delete a page file and reload the index. | **yes** |
+| `writeback_spec` | Public schema text for `write_pages`. | no |
 | `lint_wiki` | Structural lint report (orphans, stale, broken provenance, etc.). | **yes** |
+
+## Write tools
+
+| Tool | Backend route | Notes |
+|---|---|---|
+| `write_pages` | `POST /owner/capture/structured` | Multi-page writeback. Forces tier private. Conflicts get a `-from-llm-<date>` suffix unless `force_overwrite`. Report lists only `written` rel_paths, plus conflicts, validation errors, and the durable sync verdict. |
+| `write_page_verbatim` | `POST /owner/capture/verbatim` | Full markdown with YAML frontmatter. Tier in frontmatter is respected. Decisions need a date-prefixed slug. |
+| `read_page_raw` | `GET /owner/page/{slug}/raw` | Full markdown including frontmatter. Owner-only. |
+| `replace_page` | `PUT /owner/page/{slug}` | Full-file replace including frontmatter. Works for root pages (`index`, `log`, `overview`). |
+| `append_to_page` | `GET /owner/page/{slug}/raw` then `PUT /owner/page/{slug}` | Client-side compose. Default separator is one newline between existing content and appended text. Primary use: dated line on `log`, new titles on `index`. |
+| `set_page_tier` | `PATCH /owner/page/{slug}/tier` | `public` / `recruiter` / `friend` / `private`. |
+| `delete_page` | `DELETE /owner/page/{slug}` | Removes the file, reloads the index, returns the durable sync verdict. |
+| `writeback_spec` | `GET /llm-writeback-spec` | Public. Schema for `write_pages`. No auth required. |
+
+### Ingest without a server-side LLM
+
+Preferred path when the client can draft pages itself:
+
+1. Optionally file the raw with `ingest_source` and `run_orchestrator=false` (the default) for provenance.
+2. Read the source you already have and draft pages following `writeback_spec` — specific, dated, `[[Wikilinks]]` to existing titles from `list_pages`, 150-400 words.
+3. Call `write_pages`.
+4. `append_to_page` slug `log` with one dated line summarising what was added, and `append_to_page` slug `index` listing the new page titles under their section.
+5. Verify with `list_pages` / `read_page`.
+
+`run_orchestrator=true` is the legacy path that runs the operator's server-side LLM over the content. Use it only when the client cannot draft pages itself.
 
 ### `auth_mode` values from `connection_status`
 
@@ -136,7 +169,7 @@ API (`/wiki/manifest.json` returns 404).
 |---|---|
 | `public` | No bearer configured. Public-tier reads. |
 | `share_read_only` | Bearer elevates reads (e.g. recruiter/friend) but is not owner-capable. |
-| `owner` | Backend granted `viewer_is_owner`. Write/lint available. |
+| `owner` | Backend granted `viewer_is_owner`. Write tools (`write_pages`, `replace_page`, `delete_page`, …) and lint available. |
 | `token_not_elevated` | Bearer present but backend left the viewer on public (invalid/revoked/wrong wiki). |
 
 ### Honest ingest / status flow

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portable-llm-wiki-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portable-llm-wiki-mcp",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.18.0",

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portable-llm-wiki-mcp",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portable-llm-wiki-mcp",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.18.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-llm-wiki-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "MCP server that exposes a Portable LLM Wiki to Cursor, Claude Desktop, or any MCP-aware LLM client.",
   "type": "module",
   "main": "dist/server.js",
@@ -41,7 +41,7 @@
     "build": "tsc",
     "start": "node dist/server.js",
     "dev": "tsx src/server.ts",
-    "test": "npm run build && node --test test/reliability.test.mjs",
+    "test": "npm run build && node --test test/reliability.test.mjs test/sealing.test.mjs",
     "smoke": "npm run build && node smoke-test.mjs",
     "prepublishOnly": "npm run build"
   },

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portable-llm-wiki-mcp",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "MCP server that exposes a Portable LLM Wiki to Cursor, Claude Desktop, or any MCP-aware LLM client.",
   "type": "module",
   "main": "dist/server.js",

--- a/mcp/src/sealing.ts
+++ b/mcp/src/sealing.ts
@@ -1,0 +1,658 @@
+/**
+ * Client-side sealed-tier crypto. Pure: Node stdlib only, no MCP imports.
+ *
+ * The hosted server stores ciphertext. This process encrypts before write
+ * and decrypts on read so the operator never sees plaintext for sealed tiers.
+ */
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHmac,
+  pbkdf2Sync,
+  randomBytes,
+} from "node:crypto";
+
+export const KEYRING_VERSION = 1;
+export const KDF_NAME = "pbkdf2-sha256";
+export const KDF_ITERATIONS = 600000;
+export const DEK_WRAP_AAD = "plw-dek-v1";
+export const CHECK_AAD = "plw-check-v1";
+export const CHECK_PLAINTEXT = "portable-llm-wiki-seal-check";
+export const ENVELOPE_WRAP_COLS = 76;
+export const ROOT_PAGE_SLUGS = ["index", "log", "overview"] as const;
+
+const GCM_NONCE_LEN = 12;
+const GCM_TAG_LEN = 16;
+const DEK_LEN = 32;
+const SALT_LEN = 16;
+const HASH_HEX_LEN = 16;
+
+export const SECTION_TO_TYPE: Record<string, string> = {
+  entities: "entity",
+  concepts: "concept",
+  decisions: "decision",
+  projects: "project",
+  queries: "query",
+  sources: "source",
+  root: "overview",
+};
+
+export const TYPE_TO_SECTION: Record<string, string> = {
+  entity: "entities",
+  concept: "concepts",
+  decision: "decisions",
+  project: "projects",
+  query: "queries",
+  source: "sources",
+};
+
+export interface Keyring {
+  v: 1;
+  tiers: string[];
+  kdf: "pbkdf2-sha256";
+  iterations: number;
+  salt: string;
+  wrapped_dek: string;
+  check: string;
+  created: string;
+}
+
+export type SealingState =
+  | { kind: "not_enabled" }
+  | { kind: "locked"; tiers: string[]; reason: string }
+  | { kind: "unlocked"; tiers: string[]; dek: Buffer };
+
+export interface EnvelopePayload {
+  v: 1;
+  title: string;
+  tags: string[];
+  sources: string[];
+  body: string;
+}
+
+export interface PageFields {
+  slug: string;
+  type: string;
+  tier: string;
+  created: string;
+  updated: string;
+  title: string;
+  tags: string[];
+  sources: string[];
+  body: string;
+}
+
+export interface UnsealedPage {
+  title: string;
+  tags: string[];
+  sources: string[];
+  body: string;
+  tier: string;
+  type: string;
+  created: string;
+  updated: string;
+}
+
+export interface PageFrontmatter {
+  sealed: string;
+  type: string;
+  tier: string;
+  title: string;
+  tags: string[];
+  sources: string[];
+  created: string;
+  updated: string;
+}
+
+export interface ParsedPageDocument {
+  fm: PageFrontmatter;
+  body: string;
+}
+
+export interface LocalSearchHit {
+  slug: string;
+  title: string;
+  snippet: string;
+  score: number;
+}
+
+export class WrongPassphraseError extends Error {
+  override readonly name = "WrongPassphraseError";
+  constructor(message = "wrong passphrase") {
+    super(message);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function unquote(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"') && value.length >= 2) ||
+    (value.startsWith("'") && value.endsWith("'") && value.length >= 2)
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function parseInlineList(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return [];
+  const inner = trimmed.slice(1, -1).trim();
+  if (!inner) return [];
+  const items: string[] = [];
+  let cur = "";
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (quote) {
+      if (ch === "\\" && i + 1 < inner.length) {
+        cur += inner[i + 1];
+        i += 1;
+        continue;
+      }
+      if (ch === quote) {
+        quote = null;
+        continue;
+      }
+      cur += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ",") {
+      const item = cur.trim();
+      if (item) items.push(item);
+      cur = "";
+      continue;
+    }
+    cur += ch;
+  }
+  const last = cur.trim();
+  if (last) items.push(last);
+  return items;
+}
+
+function emptyFrontmatter(): PageFrontmatter {
+  return {
+    sealed: "",
+    type: "",
+    tier: "",
+    title: "",
+    tags: [],
+    sources: [],
+    created: "",
+    updated: "",
+  };
+}
+
+export function parsePageDocument(markdown: string): ParsedPageDocument {
+  const text = markdown.replace(/^\uFEFF/, "");
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return { fm: emptyFrontmatter(), body: text };
+  }
+  const fm = emptyFrontmatter();
+  let listKey: "tags" | "sources" | null = null;
+  for (const line of match[1].split(/\r?\n/)) {
+    const listItem = line.match(/^\s+-\s+(.*)$/);
+    if (listItem && listKey) {
+      fm[listKey].push(unquote(listItem[1].trim()));
+      continue;
+    }
+    const kv = line.match(/^([A-Za-z0-9_]+)\s*:\s*(.*)$/);
+    if (!kv) {
+      listKey = null;
+      continue;
+    }
+    const key = kv[1];
+    const value = kv[2];
+    if (key === "tags" || key === "sources") {
+      if (value === "") {
+        listKey = key;
+        fm[key] = [];
+        continue;
+      }
+      listKey = null;
+      fm[key] = parseInlineList(value);
+      continue;
+    }
+    listKey = null;
+    const scalar = unquote(value);
+    switch (key) {
+      case "sealed":
+      case "type":
+      case "tier":
+      case "title":
+      case "created":
+      case "updated":
+        fm[key] = scalar;
+        break;
+      default:
+        break;
+    }
+  }
+  return { fm, body: text.slice(match[0].length) };
+}
+
+export function isSealedMarkdown(markdown: string): boolean {
+  return parsePageDocument(markdown).fm.sealed === "v1";
+}
+
+export function frontmatterTier(markdown: string): string {
+  return parsePageDocument(markdown).fm.tier;
+}
+
+export function parseKeyring(value: unknown): Keyring {
+  if (!isRecord(value)) {
+    throw new Error("keyring: expected an object");
+  }
+  if (value.v !== 1) {
+    throw new Error("keyring: v must be 1");
+  }
+  if (!Array.isArray(value.tiers) || !value.tiers.every((t) => typeof t === "string")) {
+    throw new Error("keyring: tiers must be an array of strings");
+  }
+  if (value.kdf !== KDF_NAME) {
+    throw new Error(`keyring: kdf must be ${KDF_NAME}`);
+  }
+  if (typeof value.iterations !== "number" || !Number.isFinite(value.iterations)) {
+    throw new Error("keyring: iterations must be a number");
+  }
+  if (value.iterations < 100000) {
+    throw new Error("keyring: iterations must be >= 100000");
+  }
+  for (const field of ["salt", "wrapped_dek", "check", "created"] as const) {
+    if (typeof value[field] !== "string" || value[field].length === 0) {
+      throw new Error(`keyring: ${field} must be a non-empty string`);
+    }
+  }
+  return {
+    v: 1,
+    tiers: value.tiers as string[],
+    kdf: KDF_NAME,
+    iterations: value.iterations,
+    salt: value.salt as string,
+    wrapped_dek: value.wrapped_dek as string,
+    check: value.check as string,
+    created: value.created as string,
+  };
+}
+
+export function deriveKek(
+  passphrase: string,
+  saltB64: string,
+  iterations: number
+): Buffer {
+  const salt = Buffer.from(saltB64, "base64");
+  if (salt.length === 0) {
+    throw new Error("deriveKek: salt is empty");
+  }
+  return pbkdf2Sync(passphrase, salt, iterations, DEK_LEN, "sha256");
+}
+
+function encryptAesGcm(key: Buffer, plaintext: Buffer, aad: Buffer): string {
+  const nonce = randomBytes(GCM_NONCE_LEN);
+  const cipher = createCipheriv("aes-256-gcm", key, nonce);
+  cipher.setAAD(aad);
+  const ct = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([nonce, ct, tag]).toString("base64");
+}
+
+function decryptAesGcm(key: Buffer, envelopeB64: string, aad: Buffer): Buffer {
+  const buf = Buffer.from(envelopeB64, "base64");
+  if (buf.length < GCM_NONCE_LEN + GCM_TAG_LEN) {
+    throw new Error("envelope too short");
+  }
+  const nonce = buf.subarray(0, GCM_NONCE_LEN);
+  const tag = buf.subarray(buf.length - GCM_TAG_LEN);
+  const ct = buf.subarray(GCM_NONCE_LEN, buf.length - GCM_TAG_LEN);
+  const decipher = createDecipheriv("aes-256-gcm", key, nonce);
+  decipher.setAAD(aad);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ct), decipher.final()]);
+}
+
+export function unwrapDek(keyring: Keyring, passphrase: string): Buffer {
+  const kek = deriveKek(passphrase, keyring.salt, keyring.iterations);
+  let dek: Buffer;
+  try {
+    dek = decryptAesGcm(
+      kek,
+      keyring.wrapped_dek,
+      Buffer.from(DEK_WRAP_AAD, "utf8")
+    );
+  } catch {
+    throw new WrongPassphraseError();
+  }
+  if (dek.length !== DEK_LEN) {
+    throw new WrongPassphraseError();
+  }
+  let check: Buffer;
+  try {
+    check = decryptAesGcm(dek, keyring.check, Buffer.from(CHECK_AAD, "utf8"));
+  } catch {
+    throw new WrongPassphraseError();
+  }
+  if (check.toString("utf8") !== CHECK_PLAINTEXT) {
+    throw new WrongPassphraseError();
+  }
+  return dek;
+}
+
+export function generateKeyring(passphrase: string, tiers: string[]): Keyring {
+  if (tiers.length === 0) {
+    throw new Error("generateKeyring: tiers must be non-empty");
+  }
+  if (tiers.includes("public")) {
+    throw new Error("generateKeyring: public can never be sealed");
+  }
+  const salt = randomBytes(SALT_LEN);
+  const dek = randomBytes(DEK_LEN);
+  const kek = pbkdf2Sync(passphrase, salt, KDF_ITERATIONS, DEK_LEN, "sha256");
+  const wrapped_dek = encryptAesGcm(
+    kek,
+    dek,
+    Buffer.from(DEK_WRAP_AAD, "utf8")
+  );
+  const check = encryptAesGcm(
+    dek,
+    Buffer.from(CHECK_PLAINTEXT, "utf8"),
+    Buffer.from(CHECK_AAD, "utf8")
+  );
+  return {
+    v: 1,
+    tiers: [...tiers],
+    kdf: KDF_NAME,
+    iterations: KDF_ITERATIONS,
+    salt: salt.toString("base64"),
+    wrapped_dek,
+    check,
+    created: new Date().toISOString(),
+  };
+}
+
+export function encryptEnvelope(
+  dek: Buffer,
+  slug: string,
+  plaintextJson: string
+): string {
+  return encryptAesGcm(
+    dek,
+    Buffer.from(plaintextJson, "utf8"),
+    Buffer.from(slug, "utf8")
+  );
+}
+
+export function decryptEnvelope(
+  dek: Buffer,
+  slug: string,
+  envelopeB64: string
+): string {
+  try {
+    return decryptAesGcm(
+      dek,
+      envelopeB64,
+      Buffer.from(slug, "utf8")
+    ).toString("utf8");
+  } catch {
+    throw new Error(
+      "envelope decrypt failed (AAD/slug mismatch or corrupt ciphertext)"
+    );
+  }
+}
+
+export function utcDateStamp(date?: string): string {
+  if (date && /^\d{4}-\d{2}-\d{2}/.test(date)) {
+    return date.slice(0, 10);
+  }
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function isRootPageSlug(slug: string): boolean {
+  return (ROOT_PAGE_SLUGS as readonly string[]).includes(slug);
+}
+
+export function opaqueSlug(
+  dek: Buffer,
+  title: string,
+  section: string,
+  date?: string
+): string {
+  const digest = createHmac("sha256", dek)
+    .update(title.toLowerCase().trim(), "utf8")
+    .digest("hex")
+    .slice(0, HASH_HEX_LEN);
+  const opaque = `s-${digest}`;
+  if (section === "decisions") {
+    return `${utcDateStamp(date)}-${opaque}`;
+  }
+  return opaque;
+}
+
+export function wrapAtColumns(text: string, columns: number): string {
+  if (columns < 1 || text.length <= columns) return text;
+  const lines: string[] = [];
+  for (let i = 0; i < text.length; i += columns) {
+    lines.push(text.slice(i, i + columns));
+  }
+  return lines.join("\n");
+}
+
+export function parseEnvelopePayload(value: unknown): EnvelopePayload {
+  let parsed = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value) as unknown;
+    } catch {
+      throw new Error("envelope payload: invalid JSON");
+    }
+  }
+  if (!isRecord(parsed) || parsed.v !== 1) {
+    throw new Error("envelope payload: v must be 1");
+  }
+  if (typeof parsed.title !== "string") {
+    throw new Error("envelope payload: title must be a string");
+  }
+  if (typeof parsed.body !== "string") {
+    throw new Error("envelope payload: body must be a string");
+  }
+  if (!isStringArray(parsed.tags)) {
+    throw new Error("envelope payload: tags must be an array of strings");
+  }
+  if (!isStringArray(parsed.sources)) {
+    throw new Error("envelope payload: sources must be an array of strings");
+  }
+  return {
+    v: 1,
+    title: parsed.title,
+    tags: parsed.tags,
+    sources: parsed.sources,
+    body: parsed.body,
+  };
+}
+
+export function encodeEnvelopePayload(fields: {
+  title: string;
+  tags: string[];
+  sources: string[];
+  body: string;
+}): string {
+  const payload: EnvelopePayload = {
+    v: 1,
+    title: fields.title,
+    tags: fields.tags,
+    sources: fields.sources,
+    body: fields.body,
+  };
+  return JSON.stringify(payload);
+}
+
+function formatYamlList(items: string[]): string {
+  if (items.length === 0) return "[]";
+  const escaped = items.map((item) => {
+    if (/[:#\[\]{},]|^\s|\s$/.test(item)) {
+      return JSON.stringify(item);
+    }
+    return item;
+  });
+  return `[${escaped.join(", ")}]`;
+}
+
+export function renderPlaintextPage(fields: {
+  type: string;
+  title: string;
+  tier: string;
+  created: string;
+  updated: string;
+  tags: string[];
+  sources: string[];
+  body: string;
+}): string {
+  const lines = [
+    "---",
+    `type: ${fields.type}`,
+    `title: ${fields.title}`,
+    `created: ${fields.created}`,
+    `updated: ${fields.updated}`,
+    `tier: ${fields.tier}`,
+    `sources: ${formatYamlList(fields.sources)}`,
+    `tags: ${formatYamlList(fields.tags)}`,
+    "---",
+    "",
+    fields.body.replace(/\n+$/, ""),
+    "",
+  ];
+  return lines.join("\n");
+}
+
+export function sealPage(dek: Buffer, page: PageFields): string {
+  const plaintextJson = encodeEnvelopePayload({
+    title: page.title,
+    tags: page.tags,
+    sources: page.sources,
+    body: page.body,
+  });
+  const envelope = encryptEnvelope(dek, page.slug, plaintextJson);
+  const wrapped = wrapAtColumns(envelope, ENVELOPE_WRAP_COLS);
+  return [
+    "---",
+    "sealed: v1",
+    `type: ${page.type}`,
+    `tier: ${page.tier}`,
+    `created: ${page.created}`,
+    `updated: ${page.updated}`,
+    "---",
+    wrapped,
+    "",
+  ].join("\n");
+}
+
+export function unsealPage(
+  dek: Buffer,
+  slug: string,
+  markdown: string
+): UnsealedPage {
+  const { fm, body } = parsePageDocument(markdown);
+  if (fm.sealed !== "v1") {
+    throw new Error("unsealPage: markdown is not a sealed v1 page");
+  }
+  const envelope = body.replace(/\s+/g, "");
+  const payload = parseEnvelopePayload(decryptEnvelope(dek, slug, envelope));
+  return {
+    title: payload.title,
+    tags: payload.tags,
+    sources: payload.sources,
+    body: payload.body,
+    tier: fm.tier,
+    type: fm.type,
+    created: fm.created,
+    updated: fm.updated,
+  };
+}
+
+export function oneLineExcerpt(body: string, max = 160): string {
+  const text = body.replace(/\s+/g, " ").trim();
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 3))}...`;
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((w) => w.length > 0);
+}
+
+function snippetAround(body: string, queryWords: string[], max = 160): string {
+  const lower = body.toLowerCase();
+  let idx = -1;
+  for (const word of queryWords) {
+    idx = lower.indexOf(word);
+    if (idx >= 0) break;
+  }
+  if (idx < 0) return oneLineExcerpt(body, max);
+  const start = Math.max(0, idx - Math.floor(max / 4));
+  const slice = body.slice(start, start + max).replace(/\s+/g, " ").trim();
+  const prefix = start > 0 ? "..." : "";
+  const suffix = start + max < body.length ? "..." : "";
+  return `${prefix}${slice}${suffix}`;
+}
+
+export function localSearch(
+  pages: Array<{ slug: string; title: string; body: string }>,
+  query: string,
+  limit: number
+): LocalSearchHit[] {
+  const q = query.toLowerCase().trim();
+  const qWords = [...new Set(tokenize(q))];
+  if (qWords.length === 0 || limit <= 0) return [];
+  const hits: LocalSearchHit[] = [];
+  for (const page of pages) {
+    const titleLower = page.title.toLowerCase();
+    const titleWords = new Set(tokenize(page.title));
+    let score = 0;
+    if (q && titleLower.includes(q)) score += 10;
+    for (const word of qWords) {
+      if (titleWords.has(word)) score += 3;
+      else if (titleLower.includes(word)) score += 2;
+      if (page.body.toLowerCase().includes(word)) score += 1;
+    }
+    if (score <= 0) continue;
+    hits.push({
+      slug: page.slug,
+      title: page.title,
+      snippet: snippetAround(page.body, qWords),
+      score,
+    });
+  }
+  hits.sort((a, b) => b.score - a.score || a.title.localeCompare(b.title));
+  return hits.slice(0, limit);
+}
+
+export function sealedTiersOf(state: SealingState): string[] {
+  switch (state.kind) {
+    case "not_enabled":
+      return [];
+    case "locked":
+    case "unlocked":
+      return state.tiers;
+    default: {
+      const _never: never = state;
+      return _never;
+    }
+  }
+}
+
+export function isSealedTier(state: SealingState, tier: string): boolean {
+  return sealedTiersOf(state).includes(tier);
+}

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -53,7 +53,7 @@ function asError(err: unknown): {
 const server = new McpServer(
   {
     name: "portable-llm-wiki",
-    version: "0.1.4",
+    version: "0.2.0",
   },
   {
     instructions: `You are connected to a Portable LLM Wiki via stdio MCP at ${wiki.baseUrl}.
@@ -70,8 +70,27 @@ Typical flow:
 2. For specific questions, call \`query_wiki\` — graph-aware retrieval with sources.
 3. For exploration, use \`search_wiki\` (keyword) or \`get_neighbors\` (graph walk).
 4. \`read_page\` returns the full body of a single page when you need quotes.
-5. Owner-only: \`ingest_source\` saves a raw file and may start an orchestrator job;
-   it does NOT mean wiki graph pages are updated. Use \`ingest_job_status\` to verify.
+5. Owner-only writes: prefer \`write_pages\` (then \`append_to_page\` on \`log\` and
+   \`index\`) so you draft pages yourself. See the preferred ingest section below.
+6. \`ingest_source\` only files a raw source. It does NOT update wiki graph pages
+   unless you set \`run_orchestrator=true\` (legacy). Use \`ingest_job_status\` to
+   verify that job if you take that path.
+
+Ingest without a server-side LLM (preferred)
+(a) Optionally file the raw with \`ingest_source\` and \`run_orchestrator=false\`
+    (default) for provenance.
+(b) YOU (the session LLM) read the source you already have and draft pages
+    following \`writeback_spec\` (specific, dated, [[Wikilinks]] to existing
+    titles from \`list_pages\`, 150-400 words).
+(c) Call \`write_pages\`.
+(d) \`append_to_page\` slug \`log\` with one dated line summarising what was
+    added, and \`append_to_page\` slug \`index\` listing the new page titles
+    under their section.
+(e) Verify with \`list_pages\` / \`read_page\`.
+
+\`run_orchestrator=true\` is the legacy path that runs the operator's
+server-side LLM over the content and should only be used when the client
+cannot draft pages itself.
 
 Every page has a tier (\`public\`/\`recruiter\`/\`friend\`/\`private\`). Pages above
 your tier are invisible — don't synthesize claims about them.`,
@@ -337,7 +356,7 @@ server.registerTool(
   {
     title: "Ingest a new source into the wiki (owner-only)",
     description:
-      "Owner-only. Probes owner capability BEFORE sending content (stdio has no browser cookies). Saves raw content under raw/<subdir>/YYYY-MM-DD-<slug>.md and optionally starts the ingest orchestrator. Reports raw_file vs orchestrator vs durable_sync separately — never claims graph pages are updated merely because a raw file was saved. Use ingest_job_status with the returned tracking_id to verify orchestrator progress.",
+      "Owner-only. Probes owner capability BEFORE sending content (stdio has no browser cookies). Saves raw content under raw/<subdir>/YYYY-MM-DD-<slug>.md. Prefer the no-server-LLM flow: file with run_orchestrator=false (default) for provenance, draft pages from writeback_spec, then write_pages and append_to_page on log/index. run_orchestrator=true is the legacy path that runs the operator's server-side LLM and should only be used when the client cannot draft pages itself. Reports raw_file vs orchestrator vs durable_sync separately — never claims graph pages are updated merely because a raw file was saved.",
     inputSchema: {
       slug: z
         .string()
@@ -354,7 +373,7 @@ server.registerTool(
         .boolean()
         .optional()
         .describe(
-          "If true, kick off the ingest orchestrator (costs LLM tokens). Default false. Graph updates only happen if/when that job completes."
+          "Legacy. If true, kick off the operator's server-side ingest orchestrator (costs their LLM tokens). Default false. Prefer write_pages after drafting locally. Graph updates from this flag only happen if/when that job completes."
         ),
     },
   },
@@ -403,6 +422,207 @@ server.registerTool(
     try {
       const report = await wiki.ingestJobStatus(args);
       return asText(report);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+const writePageSchema = z.object({
+  slug: z.string().min(1).describe("Page slug (filename stem)."),
+  title: z.string().min(1).describe("Page title."),
+  section: z
+    .enum(["entities", "concepts", "decisions", "projects", "queries"])
+    .describe("Wiki section."),
+  tags: z.array(z.string()).optional().describe("Optional tags."),
+  body: z.string().describe("Markdown body (no frontmatter)."),
+});
+
+server.registerTool(
+  "write_pages",
+  {
+    title: "Write structured wiki pages (owner-only)",
+    description:
+      "Owner-only. Probes owner capability BEFORE sending content. Commits one or more drafted pages via POST /owner/capture/structured. Forces tier private. Conflicts get a -from-llm-<date> suffix unless force_overwrite. The report lists only pages in `written`, plus conflicts, validation errors, and the durable sync verdict. Never claims a page was written unless it appears in `written`.",
+    inputSchema: {
+      session_label: z
+        .string()
+        .min(3)
+        .describe(
+          "Provenance label stored in each page's sources (e.g. 'chatgpt-2026-09-12-pricing')."
+        ),
+      pages: z
+        .array(writePageSchema)
+        .min(1)
+        .describe("Drafted pages matching writeback_spec."),
+      force_overwrite: z
+        .boolean()
+        .optional()
+        .describe("If true, overwrite an existing slug instead of suffixing."),
+    },
+  },
+  async (args) => {
+    try {
+      const { report } = await wiki.writePages(args);
+      return asText(report);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+server.registerTool(
+  "write_page_verbatim",
+  {
+    title: "Write one authored markdown page (owner-only)",
+    description:
+      "Owner-only. Probes owner capability BEFORE sending content. POST /owner/capture/verbatim. Input is a complete markdown file with YAML frontmatter; tier in frontmatter is respected. Reports the written page, any conflict suffix, and the durable sync verdict.",
+    inputSchema: {
+      content: z
+        .string()
+        .min(1)
+        .describe("Full markdown including YAML frontmatter."),
+      slug: z.string().min(1).optional().describe("Optional slug override."),
+      force_overwrite: z
+        .boolean()
+        .optional()
+        .describe("If true, overwrite an existing file instead of suffixing."),
+    },
+  },
+  async (args) => {
+    try {
+      const { report } = await wiki.writePageVerbatim(args);
+      return asText(report);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+server.registerTool(
+  "read_page_raw",
+  {
+    title: "Read a page's raw markdown including frontmatter (owner-only)",
+    description:
+      "Owner-only. Probes owner capability first. GET /owner/page/{slug}/raw. Returns the full markdown file including YAML frontmatter.",
+    inputSchema: {
+      slug: z.string().min(1).describe("Page slug."),
+    },
+  },
+  async ({ slug }) => {
+    try {
+      const page = await wiki.readPageRaw(slug);
+      return asText(page.markdown);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+server.registerTool(
+  "replace_page",
+  {
+    title: "Replace a page's full markdown (owner-only)",
+    description:
+      "Owner-only. Probes owner capability BEFORE sending content. PUT /owner/page/{slug}. Full-file replace including frontmatter. Works for root pages (slugs index, log, overview). Reports tier, title, size, and the durable sync verdict.",
+    inputSchema: {
+      slug: z.string().min(1).describe("Page slug."),
+      markdown: z
+        .string()
+        .min(1)
+        .describe("Full replacement markdown including YAML frontmatter."),
+    },
+  },
+  async (args) => {
+    try {
+      const { report } = await wiki.replacePage(args);
+      return asText(report);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+server.registerTool(
+  "append_to_page",
+  {
+    title: "Append text to a page (owner-only)",
+    description:
+      "Owner-only. Probes owner capability BEFORE sending content. Reads GET /owner/page/{slug}/raw, then PUT with the appended text. Default separator is a single newline; existing trailing newlines are collapsed so there is exactly one newline between the prior content and the appended text. Primary use: append a dated line to slug `log`, or list new titles on slug `index`. Reports old size -> new size.",
+    inputSchema: {
+      slug: z.string().min(1).describe("Page slug (often `log` or `index`)."),
+      text: z.string().min(1).describe("Text to append."),
+      separator: z
+        .string()
+        .optional()
+        .describe("Join string; default a single newline."),
+    },
+  },
+  async (args) => {
+    try {
+      const { report } = await wiki.appendToPage(args);
+      return asText(report);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+server.registerTool(
+  "set_page_tier",
+  {
+    title: "Change a page's visibility tier (owner-only)",
+    description:
+      "Owner-only. Probes owner capability BEFORE sending content. PATCH /owner/page/{slug}/tier.",
+    inputSchema: {
+      slug: z.string().min(1).describe("Page slug."),
+      tier: z
+        .enum(["public", "recruiter", "friend", "private"])
+        .describe("New visibility tier."),
+    },
+  },
+  async (args) => {
+    try {
+      const { report } = await wiki.setPageTier(args);
+      return asText(report);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+server.registerTool(
+  "delete_page",
+  {
+    title: "Delete a wiki page (owner-only)",
+    description:
+      "Owner-only. Probes owner capability first. DELETE /owner/page/{slug}. Removes the page file and reloads the index. Reports the deleted slug, rel_path, and durable sync verdict.",
+    inputSchema: {
+      slug: z.string().min(1).describe("Page slug to delete."),
+    },
+  },
+  async ({ slug }) => {
+    try {
+      const { report } = await wiki.deletePage(slug);
+      return asText(report);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+server.registerTool(
+  "writeback_spec",
+  {
+    title: "Fetch the structured writeback schema",
+    description:
+      "Public. GET /llm-writeback-spec (no auth). Returns the markdown schema a session LLM should follow when drafting pages for write_pages.",
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const spec = await wiki.writebackSpec();
+      return asText(spec);
     } catch (err) {
       return asError(err);
     }

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -33,7 +33,14 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolve } from "node:path";
-import { WikiClient, startupAuthLabel } from "./wikiClient.js";
+import {
+  WikiClient,
+  formatListPagesReport,
+  formatQueryWikiReport,
+  formatReadPageReport,
+  formatSearchWikiReport,
+  startupAuthLabel,
+} from "./wikiClient.js";
 
 const wiki = WikiClient.fromEnv();
 
@@ -53,7 +60,7 @@ function asError(err: unknown): {
 const server = new McpServer(
   {
     name: "portable-llm-wiki",
-    version: "0.2.0",
+    version: "0.3.0",
   },
   {
     instructions: `You are connected to a Portable LLM Wiki via stdio MCP at ${wiki.baseUrl}.
@@ -93,7 +100,28 @@ server-side LLM over the content and should only be used when the client
 cannot draft pages itself.
 
 Every page has a tier (\`public\`/\`recruiter\`/\`friend\`/\`private\`). Pages above
-your tier are invisible — don't synthesize claims about them.`,
+your tier are invisible — don't synthesize claims about them.
+
+Sealed tiers
+The owner can enable sealing so chosen tiers (typically private) are stored
+as ciphertext on the hosted server. Encryption and decryption happen in this
+MCP process. The server operator never sees titles, tags, or bodies for
+sealed pages — only tier, section, dates, and ciphertext.
+
+WIKI_SEAL_PASSPHRASE must be set in the MCP env to read or write sealed
+tiers. If sealing is enabled and the passphrase is missing or wrong, writes
+that would send plaintext to a sealed tier are refused. Losing the
+passphrase means nobody can recover those pages.
+
+The server-side orchestrator is disabled on sealed wikis. Do not use
+\`run_orchestrator=true\`; draft locally and call \`write_pages\`. When private
+is a sealed tier, \`write_pages\` automatically seals each page (opaque slug,
+ciphertext via verbatim capture) instead of posting plaintext structured
+pages.
+
+Call \`seal_status\` / \`connection_status\` to see whether sealing is enabled
+and unlocked. Owner tools: \`seal_init\`, \`seal_disable\`, \`seal_page\`,
+\`unseal_page\`.`,
   }
 );
 
@@ -104,7 +132,7 @@ server.registerTool(
   {
     title: "Diagnose MCP ↔ wiki connection and capabilities",
     description:
-      "Non-secret diagnostic: probes the backend manifest and reports base URL, whether a bearer token is configured (never the token value), viewer tier, page count, auth_mode (public / share_read_only / owner / token_not_elevated), and read/write/lint capability. Call this before owner-only writes.",
+      "Non-secret diagnostic: probes the backend manifest and reports base URL, whether a bearer token is configured (never the token value), viewer tier, page count, auth_mode (public / share_read_only / owner / token_not_elevated), read/write/lint capability, and sealing {enabled, tiers, unlocked, reason}. Call this before owner-only writes.",
     inputSchema: {},
   },
   async () => {
@@ -122,40 +150,13 @@ server.registerTool(
   {
     title: "List all visible wiki pages",
     description:
-      "Returns the manifest: every page the current viewer can see, with title, slug, section, tier, tags, and a one-line excerpt. Call this first to learn what's in the wiki before asking specific questions.",
+      "Returns the manifest: every page the current viewer can see, with title, slug, section, tier, tags, and a one-line excerpt. When sealed tiers are unlocked, placeholder 'Sealed page' titles are replaced from the locally decrypted bundle. Call this first to learn what's in the wiki before asking specific questions.",
     inputSchema: {},
   },
   async () => {
     try {
-      const m = (await wiki.apiGet("/wiki/manifest.json")) as {
-        page_count: number;
-        sections: Record<string, number>;
-        viewer_tier: string;
-        viewer_is_owner: boolean;
-        pages: Array<{
-          slug: string;
-          title: string;
-          section: string;
-          tier: string;
-          tags: string[];
-          excerpt: string;
-          updated: string | null;
-        }>;
-      };
-      const summary = `Wiki has ${m.page_count} page(s) visible at tier=${m.viewer_tier}${
-        m.viewer_is_owner ? " (owner)" : ""
-      }. Sections: ${Object.entries(m.sections)
-        .map(([k, v]) => `${k}=${v}`)
-        .join(", ")}.`;
-      const pages = m.pages
-        .map(
-          (p) =>
-            `- ${p.title} [${p.section}/${p.tier}] (slug: ${p.slug})${
-              p.updated ? ` — updated ${p.updated}` : ""
-            }${p.excerpt ? `\n  ${p.excerpt}` : ""}`
-        )
-        .join("\n");
-      return asText(`${summary}\n\n${pages}`);
+      const m = await wiki.listPages();
+      return asText(formatListPagesReport(m));
     } catch (err) {
       return asError(err);
     }
@@ -167,7 +168,7 @@ server.registerTool(
   {
     title: "Read a wiki page in full",
     description:
-      "Returns the full markdown body + frontmatter + cross-references for one page, identified by its slug. Use when you need to quote from a page or follow its `[[wikilinks]]` to other pages.",
+      "Returns the full markdown body + frontmatter + cross-references for one page, identified by its slug. Sealed pages are decrypted locally when WIKI_SEAL_PASSPHRASE unlocks the keyring (report includes decrypted_locally: true). If sealing is locked, returns the sealed placeholder and the locked reason. Use when you need to quote from a page or follow its `[[wikilinks]]` to other pages.",
     inputSchema: {
       slug: z
         .string()
@@ -177,38 +178,8 @@ server.registerTool(
   },
   async ({ slug }) => {
     try {
-      const p = (await wiki.apiGet(`/wiki/page/${encodeURIComponent(slug)}`)) as {
-        title: string;
-        section: string;
-        tier: string;
-        created: string | null;
-        updated: string | null;
-        tags: string[];
-        body: string;
-        sources: string[];
-        links_out_resolved: Array<{ slug: string; title: string }>;
-        links_in_resolved: Array<{ slug: string; title: string }>;
-      };
-      const header =
-        `# ${p.title}\n` +
-        `_section: ${p.section} · tier: ${p.tier}` +
-        `${p.created ? ` · created: ${p.created}` : ""}` +
-        `${p.updated ? ` · updated: ${p.updated}` : ""}` +
-        `${p.tags.length ? ` · tags: ${p.tags.join(", ")}` : ""}_\n\n`;
-      const linksOut = p.links_out_resolved.length
-        ? `\n\n---\n**Links out:** ${p.links_out_resolved
-            .map((l) => `[[${l.title}]] (slug: ${l.slug})`)
-            .join(", ")}`
-        : "";
-      const linksIn = p.links_in_resolved.length
-        ? `\n**Links in:** ${p.links_in_resolved
-            .map((l) => `[[${l.title}]] (slug: ${l.slug})`)
-            .join(", ")}`
-        : "";
-      const sources = p.sources.length
-        ? `\n**Sources:** ${p.sources.join(", ")}`
-        : "";
-      return asText(header + p.body + linksOut + linksIn + sources);
+      const page = await wiki.readPage(slug);
+      return asText(formatReadPageReport(page));
     } catch (err) {
       return asError(err);
     }
@@ -220,7 +191,7 @@ server.registerTool(
   {
     title: "Keyword search across visible pages",
     description:
-      "Fast keyword search across page titles, tags, and bodies. Returns ranked matches. Good for exploration. For natural-language questions with synthesis, use `query_wiki` instead.",
+      "Fast keyword search across page titles, tags, and bodies. Returns ranked matches. When sealed tiers are unlocked, merges a local keyword search over the decrypted bundle and labels those hits 'decrypted locally'. Good for exploration. For natural-language questions with synthesis, use `query_wiki` instead.",
     inputSchema: {
       query: z.string().min(1).describe("Keyword(s) to search for."),
       limit: z
@@ -234,27 +205,8 @@ server.registerTool(
   },
   async ({ query, limit }) => {
     try {
-      const r = (await wiki.apiGet(
-        `/wiki/search?q=${encodeURIComponent(query)}`
-      )) as {
-        results: Array<{
-          slug: string;
-          title: string;
-          section: string;
-          tier: string;
-          excerpt: string;
-          score: number;
-        }>;
-      };
-      const top = r.results.slice(0, limit ?? 10);
-      if (top.length === 0) return asText(`No matches for "${query}".`);
-      const out = top
-        .map(
-          (m) =>
-            `[score ${m.score}] ${m.title} (slug: ${m.slug}, ${m.section}/${m.tier})\n  ${m.excerpt}`
-        )
-        .join("\n\n");
-      return asText(out);
+      const r = await wiki.searchWiki(query, limit ?? 10);
+      return asText(formatSearchWikiReport(query, r.results));
     } catch (err) {
       return asError(err);
     }
@@ -266,7 +218,7 @@ server.registerTool(
   {
     title: "Ask a natural-language question, get a sourced answer",
     description:
-      "The primary tool. Does graph-aware retrieval (keyword anchors + 1-hop wikilink expansion, Index/Log catalogs omitted) and returns a synthesized answer grounded in wiki pages, with citations. Prefer this over `search_wiki` + manual stitching.",
+      "The primary tool. Does graph-aware retrieval (keyword anchors + 1-hop wikilink expansion, Index/Log catalogs omitted) and returns a synthesized answer grounded in wiki pages, with citations. Sealed pages are excluded from server retrieval; when unlocked this tool appends a 'Sealed context (decrypted locally)' section with the top local passages. Mentions sealed_excluded when the server reports it. No LLM call inside the MCP. Prefer this over `search_wiki` + manual stitching.",
     inputSchema: {
       question: z
         .string()
@@ -276,27 +228,8 @@ server.registerTool(
   },
   async ({ question }) => {
     try {
-      const r = (await wiki.apiPost("/wiki/query", { question })) as {
-        answer: string;
-        citations: Array<{ slug: string; title: string }>;
-        backend: string;
-        retrieval?: {
-          strategy: string;
-          anchors: Array<{ title: string; score: number }>;
-          expanded: Array<{ title: string }>;
-        };
-      };
-      const cites = r.citations.length
-        ? `\n\n---\nCitations: ${r.citations.map((c) => `[[${c.title}]]`).join(", ")}`
-        : "";
-      const retrieval = r.retrieval
-        ? `\n\n_Retrieval: ${r.retrieval.strategy}. Anchors: ${r.retrieval.anchors
-            .map((a) => a.title)
-            .join(", ")}. Expanded: ${
-            r.retrieval.expanded.map((e) => e.title).join(", ") || "(none)"
-          }._`
-        : "";
-      return asText(r.answer + cites + retrieval);
+      const r = await wiki.queryWiki(question);
+      return asText(formatQueryWikiReport(r));
     } catch (err) {
       return asError(err);
     }
@@ -356,7 +289,7 @@ server.registerTool(
   {
     title: "Ingest a new source into the wiki (owner-only)",
     description:
-      "Owner-only. Probes owner capability BEFORE sending content (stdio has no browser cookies). Saves raw content under raw/<subdir>/YYYY-MM-DD-<slug>.md. Prefer the no-server-LLM flow: file with run_orchestrator=false (default) for provenance, draft pages from writeback_spec, then write_pages and append_to_page on log/index. run_orchestrator=true is the legacy path that runs the operator's server-side LLM and should only be used when the client cannot draft pages itself. Reports raw_file vs orchestrator vs durable_sync separately — never claims graph pages are updated merely because a raw file was saved.",
+      "Owner-only. Probes owner capability BEFORE sending content (stdio has no browser cookies). Saves raw content under raw/<subdir>/YYYY-MM-DD-<slug>.md. Prefer the no-server-LLM flow: file with run_orchestrator=false (default) for provenance, draft pages from writeback_spec, then write_pages and append_to_page on log/index. run_orchestrator=true is the legacy path that runs the operator's server-side LLM and should only be used when the client cannot draft pages itself. On sealed wikis the server-side orchestrator is disabled (409). Reports raw_file vs orchestrator vs durable_sync separately — never claims graph pages are updated merely because a raw file was saved.",
     inputSchema: {
       slug: z
         .string()
@@ -443,7 +376,7 @@ server.registerTool(
   {
     title: "Write structured wiki pages (owner-only)",
     description:
-      "Owner-only. Probes owner capability BEFORE sending content. Commits one or more drafted pages via POST /owner/capture/structured. Forces tier private. Conflicts get a -from-llm-<date> suffix unless force_overwrite. The report lists only pages in `written`, plus conflicts, validation errors, and the durable sync verdict. Never claims a page was written unless it appears in `written`.",
+      "Owner-only. Probes owner capability BEFORE sending content. When sealing is not enabled, commits drafted pages via POST /owner/capture/structured (forces tier private). When private is a sealed tier and this process is unlocked, each page is sealed locally (opaque slug, ciphertext) and written via POST /owner/capture/verbatim — the request never contains plaintext title/body. If sealing is enabled but locked, the tool refuses before sending anything. Conflicts get a -from-llm-<date> suffix unless force_overwrite. The report lists only pages in `written`, plus conflicts, validation errors, and the durable sync verdict. Never claims a page was written unless it appears in `written`.",
     inputSchema: {
       session_label: z
         .string()
@@ -476,7 +409,7 @@ server.registerTool(
   {
     title: "Write one authored markdown page (owner-only)",
     description:
-      "Owner-only. Probes owner capability BEFORE sending content. POST /owner/capture/verbatim. Input is a complete markdown file with YAML frontmatter; tier in frontmatter is respected. Reports the written page, any conflict suffix, and the durable sync verdict.",
+      "Owner-only. Probes owner capability BEFORE sending content. POST /owner/capture/verbatim. Input is a complete markdown file with YAML frontmatter; tier in frontmatter is respected. If the document's tier is sealed and the markdown is plaintext, it is sealed client-side before sending (provided slug, or an opaque slug). If sealing is locked, the write is refused. Reports the written page, any conflict suffix, and the durable sync verdict.",
     inputSchema: {
       content: z
         .string()
@@ -504,7 +437,7 @@ server.registerTool(
   {
     title: "Read a page's raw markdown including frontmatter (owner-only)",
     description:
-      "Owner-only. Probes owner capability first. GET /owner/page/{slug}/raw. Returns the full markdown file including YAML frontmatter.",
+      "Owner-only. Probes owner capability first. GET /owner/page/{slug}/raw. Returns the full markdown file including YAML frontmatter. Sealed pages are decrypted locally when unlocked (decrypted_locally: true) into plaintext frontmatter (title/tags/sources). If locked, returns the sealed file plus the locked reason.",
     inputSchema: {
       slug: z.string().min(1).describe("Page slug."),
     },
@@ -512,6 +445,14 @@ server.registerTool(
   async ({ slug }) => {
     try {
       const page = await wiki.readPageRaw(slug);
+      if (page.decrypted_locally) {
+        return asText(`decrypted_locally: true\n\n${page.markdown}`);
+      }
+      if (page.locked_reason) {
+        return asText(
+          `sealed: locked (${page.locked_reason})\n\n${page.markdown}`
+        );
+      }
       return asText(page.markdown);
     } catch (err) {
       return asError(err);
@@ -524,7 +465,7 @@ server.registerTool(
   {
     title: "Replace a page's full markdown (owner-only)",
     description:
-      "Owner-only. Probes owner capability BEFORE sending content. PUT /owner/page/{slug}. Full-file replace including frontmatter. Works for root pages (slugs index, log, overview). Reports tier, title, size, and the durable sync verdict.",
+      "Owner-only. Probes owner capability BEFORE sending content. PUT /owner/page/{slug}. Full-file replace including frontmatter. Works for root pages (slugs index, log, overview). If the document's tier is sealed and the markdown is plaintext, it is sealed client-side before sending (slug kept). If sealing is locked, the write is refused. Reports tier, title, size, and the durable sync verdict.",
     inputSchema: {
       slug: z.string().min(1).describe("Page slug."),
       markdown: z
@@ -548,7 +489,7 @@ server.registerTool(
   {
     title: "Append text to a page (owner-only)",
     description:
-      "Owner-only. Probes owner capability BEFORE sending content. Reads GET /owner/page/{slug}/raw, then PUT with the appended text. Default separator is a single newline; existing trailing newlines are collapsed so there is exactly one newline between the prior content and the appended text. Primary use: append a dated line to slug `log`, or list new titles on slug `index`. Reports old size -> new size.",
+      "Owner-only. Probes owner capability BEFORE sending content. Reads GET /owner/page/{slug}/raw, then PUT with the appended text. Default separator is a single newline; existing trailing newlines are collapsed so there is exactly one newline between the prior content and the appended text. On sealed pages: decrypt, append to the body with the same one-newline rule, re-seal, PUT. If the page is still plaintext but its tier is sealed (not yet migrated), it is sealed on write. Primary use: append a dated line to slug `log`, or list new titles on slug `index`. Reports old size -> new size.",
     inputSchema: {
       slug: z.string().min(1).describe("Page slug (often `log` or `index`)."),
       text: z.string().min(1).describe("Text to append."),
@@ -573,7 +514,7 @@ server.registerTool(
   {
     title: "Change a page's visibility tier (owner-only)",
     description:
-      "Owner-only. Probes owner capability BEFORE sending content. PATCH /owner/page/{slug}/tier.",
+      "Owner-only. Probes owner capability BEFORE sending content. PATCH /owner/page/{slug}/tier. Cannot cross the seal boundary (sealed page to an unsealed tier, or plaintext to a sealed tier); use seal_page / unseal_page for those moves.",
     inputSchema: {
       slug: z.string().min(1).describe("Page slug."),
       tier: z
@@ -630,11 +571,117 @@ server.registerTool(
 );
 
 server.registerTool(
+  "seal_init",
+  {
+    title: "Enable sealed tiers (owner-only)",
+    description:
+      "Owner-only. Generates a keyring from WIKI_SEAL_PASSPHRASE and PUT /owner/sealing. Default tiers: [private]. public can never be sealed. force=true overwrites an existing keyring. Losing the passphrase means sealed pages cannot be recovered. Server-side orchestrator is disabled once sealing is enabled.",
+    inputSchema: {
+      tiers: z
+        .array(z.enum(["recruiter", "friend", "private"]))
+        .optional()
+        .describe("Tiers to seal (default [private]). public is never allowed."),
+      force: z
+        .boolean()
+        .optional()
+        .describe("If true, replace an existing keyring (409 otherwise)."),
+    },
+  },
+  async (args) => {
+    try {
+      const { report } = await wiki.sealInit(args);
+      return asText(report);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+server.registerTool(
+  "seal_disable",
+  {
+    title: "Disable sealed-tier gating (owner-only)",
+    description:
+      "Owner-only. DELETE /owner/sealing. Clears keyring tiers so new writes are no longer forced through sealing. Already-sealed pages stay encrypted and can still be opened with the passphrase.",
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const { report } = await wiki.sealDisable();
+      return asText(report);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+server.registerTool(
+  "seal_status",
+  {
+    title: "Report sealed-tier unlock state",
+    description:
+      "Reports whether sealing is enabled, which tiers are sealed, and whether this process is unlocked. Never returns the passphrase or DEK. Call connection_status for the same sealing block plus auth diagnostics.",
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const status = await wiki.sealStatus();
+      return asText(status);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+server.registerTool(
+  "seal_page",
+  {
+    title: "Encrypt an existing plaintext page in place (owner-only)",
+    description:
+      "Owner-only. Reads a plaintext page, seals it client-side, and PUTs ciphertext at the same slug. The page's current tier must already be a sealed tier.",
+    inputSchema: {
+      slug: z.string().min(1).describe("Page slug to seal in place."),
+    },
+  },
+  async ({ slug }) => {
+    try {
+      const { report } = await wiki.sealPageBySlug(slug);
+      return asText(report);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+server.registerTool(
+  "unseal_page",
+  {
+    title: "Decrypt a sealed page to a non-sealed tier (owner-only)",
+    description:
+      "Owner-only. Decrypts a sealed page locally and PUTs plaintext at a non-sealed tier (content and tier change together). Target tier must not be in the sealed set.",
+    inputSchema: {
+      slug: z.string().min(1).describe("Sealed page slug."),
+      tier: z
+        .enum(["public", "recruiter", "friend", "private"])
+        .describe("Destination tier (must not be a sealed tier)."),
+    },
+  },
+  async (args) => {
+    try {
+      const { report } = await wiki.unsealPageBySlug(args.slug, args.tier);
+      return asText(report);
+    } catch (err) {
+      return asError(err);
+    }
+  }
+);
+
+server.registerTool(
   "lint_wiki",
   {
     title: "Run the wiki lint (owner-only)",
     description:
-      "Owner-only. Probes owner capability first, then reports structural issues: orphan pages, stale pages, broken provenance, missing pages mentioned 3+ times, pages absent from index.md.",
+      "Owner-only. Probes owner capability first, then reports structural issues: orphan pages, stale pages, broken provenance, missing pages mentioned 3+ times, pages absent from index.md. The server refuses lint (409) when sealing is enabled.",
     inputSchema: {},
   },
   async () => {

--- a/mcp/src/wikiClient.ts
+++ b/mcp/src/wikiClient.ts
@@ -6,6 +6,30 @@
  * capability must be proven via the backend manifest — never inferred
  * from the mere presence of WIKI_OWNER_TOKEN.
  */
+import {
+  type Keyring,
+  type SealingState,
+  WrongPassphraseError,
+  decryptEnvelope,
+  frontmatterTier,
+  generateKeyring,
+  isRootPageSlug,
+  isSealedMarkdown,
+  isSealedTier,
+  localSearch,
+  oneLineExcerpt,
+  opaqueSlug,
+  parseEnvelopePayload,
+  parseKeyring,
+  parsePageDocument,
+  renderPlaintextPage,
+  sealPage,
+  unsealPage,
+  unwrapDek,
+  utcDateStamp,
+  SECTION_TO_TYPE,
+  TYPE_TO_SECTION,
+} from "./sealing.js";
 
 export type AuthMode =
   | "public"
@@ -22,11 +46,38 @@ export interface SyncVerdict {
   detail: string;
 }
 
+export interface ManifestSealing {
+  enabled: true;
+  tiers: string[];
+  keyring_url: string;
+  bundle_url: string;
+}
+
+export interface ManifestPage {
+  slug: string;
+  title: string;
+  section: string;
+  tier: string;
+  tags: string[];
+  excerpt: string;
+  updated: string | null;
+  sealed?: boolean;
+}
+
 export interface ManifestSnapshot {
   page_count: number;
   sections: Record<string, number>;
   viewer_tier: string;
   viewer_is_owner: boolean;
+  pages: ManifestPage[];
+  sealing?: ManifestSealing;
+}
+
+export interface ConnectionSealing {
+  enabled: boolean;
+  tiers: string[];
+  unlocked: boolean;
+  reason?: string;
 }
 
 export interface ConnectionStatus {
@@ -42,6 +93,59 @@ export interface ConnectionStatus {
     lint: boolean;
   };
   notes: string[];
+  sealing: ConnectionSealing;
+}
+
+export interface BundlePage {
+  slug: string;
+  title: string;
+  tags: string[];
+  sources: string[];
+  body: string;
+  tier: string;
+  section: string;
+  updated: string;
+}
+
+export interface PageView {
+  slug: string;
+  title: string;
+  section: string;
+  tier: string;
+  created: string | null;
+  updated: string | null;
+  tags: string[];
+  body: string;
+  sources: string[];
+  links_out_resolved: Array<{ slug: string; title: string }>;
+  links_in_resolved: Array<{ slug: string; title: string }>;
+  sealed: boolean;
+  envelope?: string;
+  decrypted_locally?: boolean;
+  locked_reason?: string;
+}
+
+export interface SearchHit {
+  slug: string;
+  title: string;
+  section: string;
+  tier: string;
+  excerpt: string;
+  score: number;
+  decrypted_locally?: boolean;
+}
+
+export interface QueryWikiResult {
+  answer: string;
+  citations: Array<{ slug: string; title: string }>;
+  backend: string;
+  retrieval?: {
+    strategy: string;
+    anchors: Array<{ title: string; score: number }>;
+    expanded: Array<{ title: string }>;
+  };
+  sealed_excluded?: number;
+  sealed_context: Array<{ title: string; snippet: string }>;
 }
 
 export interface IngestApiResult {
@@ -115,6 +219,8 @@ export interface PageRaw {
   section: string;
   tier: string;
   markdown: string;
+  decrypted_locally?: boolean;
+  locked_reason?: string;
 }
 
 export interface ReplacePageResult {
@@ -183,6 +289,34 @@ export function resolveToken(env: NodeJS.ProcessEnv = process.env): string {
   return (env.WIKI_OWNER_TOKEN ?? "").trim();
 }
 
+export function resolveSealPassphrase(
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  return (env.WIKI_SEAL_PASSPHRASE ?? "").trim();
+}
+
+export function connectionSealingFromState(
+  state: SealingState
+): ConnectionSealing {
+  switch (state.kind) {
+    case "not_enabled":
+      return { enabled: false, tiers: [], unlocked: false };
+    case "locked":
+      return {
+        enabled: true,
+        tiers: state.tiers,
+        unlocked: false,
+        reason: state.reason,
+      };
+    case "unlocked":
+      return { enabled: true, tiers: state.tiers, unlocked: true };
+    default: {
+      const _never: never = state;
+      return _never;
+    }
+  }
+}
+
 export function classifyAuthMode(
   tokenConfigured: boolean,
   manifest: Pick<ManifestSnapshot, "viewer_tier" | "viewer_is_owner">
@@ -198,11 +332,13 @@ export function classifyAuthMode(
 export function buildConnectionStatus(
   baseUrl: string,
   tokenConfigured: boolean,
-  manifest: ManifestSnapshot
+  manifest: ManifestSnapshot,
+  sealing: SealingState = { kind: "not_enabled" }
 ): ConnectionStatus {
   const auth_mode = classifyAuthMode(tokenConfigured, manifest);
   const isOwner = auth_mode === "owner";
   const notes: string[] = [];
+  const sealingStatus = connectionSealingFromState(sealing);
 
   switch (auth_mode) {
     case "public":
@@ -231,6 +367,25 @@ export function buildConnectionStatus(
     "Stdio MCP never receives browser OAuth cookies — owner elevation requires a headless-capable bearer token."
   );
 
+  switch (sealing.kind) {
+    case "not_enabled":
+      break;
+    case "locked":
+      notes.push(
+        `Sealed tiers enabled (${sealing.tiers.join(", ")}) but locked: ${sealing.reason}. Set WIKI_SEAL_PASSPHRASE in the MCP env to read and write sealed pages. The server operator cannot recover pages if the passphrase is lost.`
+      );
+      break;
+    case "unlocked":
+      notes.push(
+        `Sealed tiers unlocked locally (${sealing.tiers.join(", ")}). Titles and bodies for those tiers are decrypted in this process; the server stores ciphertext only.`
+      );
+      break;
+    default: {
+      const _never: never = sealing;
+      return _never;
+    }
+  }
+
   return {
     base_url: baseUrl,
     token_configured: tokenConfigured,
@@ -244,6 +399,7 @@ export function buildConnectionStatus(
       lint: isOwner,
     },
     notes,
+    sealing: sealingStatus,
   };
 }
 
@@ -411,6 +567,301 @@ export function formatJobStatusReport(payload: {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function parseManifestSealing(value: unknown): ManifestSealing | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!isRecord(value)) {
+    throw new Error("manifest.sealing: expected an object");
+  }
+  if (value.enabled !== true) {
+    throw new Error("manifest.sealing: enabled must be true when present");
+  }
+  if (!Array.isArray(value.tiers) || !value.tiers.every((t) => typeof t === "string")) {
+    throw new Error("manifest.sealing: tiers must be an array of strings");
+  }
+  if (typeof value.keyring_url !== "string" || value.keyring_url.length === 0) {
+    throw new Error("manifest.sealing: keyring_url must be a non-empty string");
+  }
+  if (typeof value.bundle_url !== "string" || value.bundle_url.length === 0) {
+    throw new Error("manifest.sealing: bundle_url must be a non-empty string");
+  }
+  if (value.tiers.length === 0) return undefined;
+  return {
+    enabled: true,
+    tiers: value.tiers,
+    keyring_url: value.keyring_url,
+    bundle_url: value.bundle_url,
+  };
+}
+
+function parseManifestPages(value: unknown): ManifestPage[] {
+  if (!Array.isArray(value)) return [];
+  const pages: ManifestPage[] = [];
+  for (const item of value) {
+    if (!isRecord(item) || typeof item.slug !== "string") continue;
+    pages.push({
+      slug: item.slug,
+      title: typeof item.title === "string" ? item.title : "",
+      section: typeof item.section === "string" ? item.section : "",
+      tier: typeof item.tier === "string" ? item.tier : "",
+      tags: asStringArray(item.tags),
+      excerpt: typeof item.excerpt === "string" ? item.excerpt : "",
+      updated: typeof item.updated === "string" ? item.updated : null,
+      sealed: item.sealed === true ? true : undefined,
+    });
+  }
+  return pages;
+}
+
+function parseSections(value: unknown): Record<string, number> {
+  if (!isRecord(value)) return {};
+  const out: Record<string, number> = {};
+  for (const [key, count] of Object.entries(value)) {
+    if (typeof count === "number") out[key] = count;
+  }
+  return out;
+}
+
+export function parseManifest(value: unknown): ManifestSnapshot {
+  if (!isRecord(value)) {
+    throw new Error("manifest: expected an object");
+  }
+  return {
+    page_count: typeof value.page_count === "number" ? value.page_count : 0,
+    sections: parseSections(value.sections),
+    viewer_tier: typeof value.viewer_tier === "string" ? value.viewer_tier : "public",
+    viewer_is_owner: Boolean(value.viewer_is_owner),
+    pages: parseManifestPages(value.pages),
+    sealing: parseManifestSealing(value.sealing),
+  };
+}
+
+function parseResolvedLinks(
+  value: unknown
+): Array<{ slug: string; title: string }> {
+  if (!Array.isArray(value)) return [];
+  const out: Array<{ slug: string; title: string }> = [];
+  for (const item of value) {
+    if (!isRecord(item) || typeof item.slug !== "string") continue;
+    out.push({
+      slug: item.slug,
+      title: typeof item.title === "string" ? item.title : "",
+    });
+  }
+  return out;
+}
+
+function parsePageView(value: unknown, fallbackSlug: string): PageView {
+  if (!isRecord(value)) {
+    throw new Error("read_page: unexpected response");
+  }
+  return {
+    slug: typeof value.slug === "string" ? value.slug : fallbackSlug,
+    title: typeof value.title === "string" ? value.title : "",
+    section: typeof value.section === "string" ? value.section : "",
+    tier: typeof value.tier === "string" ? value.tier : "",
+    created: typeof value.created === "string" ? value.created : null,
+    updated: typeof value.updated === "string" ? value.updated : null,
+    tags: asStringArray(value.tags),
+    body: typeof value.body === "string" ? value.body : "",
+    sources: asStringArray(value.sources),
+    links_out_resolved: parseResolvedLinks(value.links_out_resolved),
+    links_in_resolved: parseResolvedLinks(value.links_in_resolved),
+    sealed: value.sealed === true || typeof value.envelope === "string",
+    envelope: typeof value.envelope === "string" ? value.envelope : undefined,
+  };
+}
+
+function parseSearchResults(value: unknown): SearchHit[] {
+  if (!isRecord(value) || !Array.isArray(value.results)) return [];
+  const out: SearchHit[] = [];
+  for (const item of value.results) {
+    if (!isRecord(item) || typeof item.slug !== "string") continue;
+    out.push({
+      slug: item.slug,
+      title: typeof item.title === "string" ? item.title : "",
+      section: typeof item.section === "string" ? item.section : "",
+      tier: typeof item.tier === "string" ? item.tier : "",
+      excerpt: typeof item.excerpt === "string" ? item.excerpt : "",
+      score: typeof item.score === "number" ? item.score : 0,
+    });
+  }
+  return out;
+}
+
+function parseQueryWiki(value: unknown): QueryWikiResult {
+  if (!isRecord(value) || typeof value.answer !== "string") {
+    throw new Error("query_wiki: unexpected response");
+  }
+  let retrieval: QueryWikiResult["retrieval"];
+  if (isRecord(value.retrieval) && typeof value.retrieval.strategy === "string") {
+    const anchors: Array<{ title: string; score: number }> = [];
+    if (Array.isArray(value.retrieval.anchors)) {
+      for (const item of value.retrieval.anchors) {
+        if (!isRecord(item) || typeof item.title !== "string") continue;
+        anchors.push({
+          title: item.title,
+          score: typeof item.score === "number" ? item.score : 0,
+        });
+      }
+    }
+    const expanded: Array<{ title: string }> = [];
+    if (Array.isArray(value.retrieval.expanded)) {
+      for (const item of value.retrieval.expanded) {
+        if (!isRecord(item) || typeof item.title !== "string") continue;
+        expanded.push({ title: item.title });
+      }
+    }
+    retrieval = { strategy: value.retrieval.strategy, anchors, expanded };
+  }
+  return {
+    answer: value.answer,
+    citations: parseResolvedLinks(value.citations),
+    backend: typeof value.backend === "string" ? value.backend : "",
+    retrieval,
+    sealed_excluded:
+      typeof value.sealed_excluded === "number" ? value.sealed_excluded : undefined,
+    sealed_context: [],
+  };
+}
+
+function parseBundlePages(value: unknown): Array<{
+  slug: string;
+  section: string;
+  tier: string;
+  updated: string;
+  envelope: string;
+}> {
+  if (!isRecord(value) || !Array.isArray(value.pages)) return [];
+  const out: Array<{
+    slug: string;
+    section: string;
+    tier: string;
+    updated: string;
+    envelope: string;
+  }> = [];
+  for (const item of value.pages) {
+    if (
+      !isRecord(item) ||
+      typeof item.slug !== "string" ||
+      typeof item.envelope !== "string"
+    ) {
+      continue;
+    }
+    out.push({
+      slug: item.slug,
+      section: typeof item.section === "string" ? item.section : "",
+      tier: typeof item.tier === "string" ? item.tier : "",
+      updated: typeof item.updated === "string" ? item.updated : "",
+      envelope: item.envelope,
+    });
+  }
+  return out;
+}
+
+const SEALABLE_TIERS = new Set(["recruiter", "friend", "private"]);
+
+export function formatQueryWikiReport(result: QueryWikiResult): string {
+  let text = result.answer;
+  if (result.citations.length) {
+    text += `\n\n---\nCitations: ${result.citations
+      .map((c) => `[[${c.title}]]`)
+      .join(", ")}`;
+  }
+  if (result.retrieval) {
+    text += `\n\n_Retrieval: ${result.retrieval.strategy}. Anchors: ${result.retrieval.anchors
+      .map((a) => a.title)
+      .join(", ")}. Expanded: ${
+      result.retrieval.expanded.map((e) => e.title).join(", ") || "(none)"
+    }._`;
+  }
+  if (result.sealed_excluded != null && result.sealed_excluded > 0) {
+    text += `\n\nServer retrieval omitted ${result.sealed_excluded} sealed page(s) (sealed_excluded=${result.sealed_excluded}).`;
+  }
+  if (result.sealed_context.length > 0) {
+    text += "\n\nSealed context (decrypted locally)";
+    for (const passage of result.sealed_context) {
+      text += `\n\n## ${passage.title}\n${passage.snippet}`;
+    }
+  }
+  return text;
+}
+
+export function formatSearchWikiReport(
+  query: string,
+  results: SearchHit[]
+): string {
+  if (results.length === 0) return `No matches for "${query}".`;
+  return results
+    .map((m) => {
+      const local = m.decrypted_locally ? " [decrypted locally]" : "";
+      return `[score ${m.score}] ${m.title} (slug: ${m.slug}, ${m.section}/${m.tier})${local}\n  ${m.excerpt}`;
+    })
+    .join("\n\n");
+}
+
+export function formatListPagesReport(manifest: ManifestSnapshot): string {
+  const summary = `Wiki has ${manifest.page_count} page(s) visible at tier=${manifest.viewer_tier}${
+    manifest.viewer_is_owner ? " (owner)" : ""
+  }. Sections: ${Object.entries(manifest.sections)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(", ")}.`;
+  const pages = manifest.pages
+    .map(
+      (p) =>
+        `- ${p.title} [${p.section}/${p.tier}] (slug: ${p.slug})${
+          p.updated ? ` — updated ${p.updated}` : ""
+        }${p.excerpt ? `\n  ${p.excerpt}` : ""}`
+    )
+    .join("\n");
+  return `${summary}\n\n${pages}`;
+}
+
+export function formatReadPageReport(page: PageView): string {
+  if (page.sealed && !page.decrypted_locally) {
+    const reason = page.locked_reason
+      ? ` Unlock to read (${page.locked_reason}).`
+      : " Unlock to read.";
+    return (
+      `# Sealed page\n` +
+      `_section: ${page.section} · tier: ${page.tier}_\n\n` +
+      `Sealed page.${reason}`
+    );
+  }
+  const header =
+    `# ${page.title}\n` +
+    `_section: ${page.section} · tier: ${page.tier}` +
+    `${page.created ? ` · created: ${page.created}` : ""}` +
+    `${page.updated ? ` · updated: ${page.updated}` : ""}` +
+    `${page.tags.length ? ` · tags: ${page.tags.join(", ")}` : ""}_\n\n`;
+  const linksOut = page.links_out_resolved.length
+    ? `\n\n---\n**Links out:** ${page.links_out_resolved
+        .map((l) => `[[${l.title}]] (slug: ${l.slug})`)
+        .join(", ")}`
+    : "";
+  const linksIn = page.links_in_resolved.length
+    ? `\n**Links in:** ${page.links_in_resolved
+        .map((l) => `[[${l.title}]] (slug: ${l.slug})`)
+        .join(", ")}`
+    : "";
+  const sources = page.sources.length
+    ? `\n**Sources:** ${page.sources.join(", ")}`
+    : "";
+  const local = page.decrypted_locally ? "\n\ndecrypted_locally: true" : "";
+  return header + page.body + linksOut + linksIn + sources + local;
+}
+
+function lockedSealedWriteError(reason: string, action: string): Error {
+  return new Error(
+    `Cannot ${action}: sealing is enabled but locked (${reason}). ` +
+      `Set WIKI_SEAL_PASSPHRASE in the MCP env. Never sending plaintext to a sealed tier.`
+  );
 }
 
 function parseSync(value: unknown): SyncVerdict | undefined {
@@ -700,21 +1151,36 @@ export function startupAuthLabel(status: ConnectionStatus): string {
 export type FetchLike = typeof fetch;
 
 export class WikiClient {
+  private cachedSealing: SealingState | null = null;
+  private bundleBySlug: Map<string, BundlePage> | null = null;
+  private decryptBySlugUpdated = new Map<string, BundlePage>();
+
   constructor(
     public readonly baseUrl: string,
     public readonly token: string,
-    private readonly fetchImpl: FetchLike = fetch
+    private readonly fetchImpl: FetchLike = fetch,
+    private readonly env: NodeJS.ProcessEnv = process.env
   ) {}
 
   static fromEnv(
     env: NodeJS.ProcessEnv = process.env,
     fetchImpl: FetchLike = fetch
   ): WikiClient {
-    return new WikiClient(resolveApiBase(env), resolveToken(env), fetchImpl);
+    return new WikiClient(resolveApiBase(env), resolveToken(env), fetchImpl, env);
   }
 
   get tokenConfigured(): boolean {
     return Boolean(this.token);
+  }
+
+  invalidateSealing(): void {
+    this.cachedSealing = null;
+    this.bundleBySlug = null;
+    this.decryptBySlugUpdated.clear();
+  }
+
+  invalidateBundle(): void {
+    this.bundleBySlug = null;
   }
 
   private async request(
@@ -747,18 +1213,125 @@ export class WikiClient {
   }
 
   async fetchManifest(): Promise<ManifestSnapshot> {
-    const m = (await this.apiGet("/wiki/manifest.json")) as ManifestSnapshot;
+    return parseManifest(await this.apiGet("/wiki/manifest.json"));
+  }
+
+  async sealingState(): Promise<SealingState> {
+    if (this.cachedSealing) return this.cachedSealing;
+    const manifest = await this.fetchManifest();
+    this.cachedSealing = await this.sealingFromManifest(manifest);
+    return this.cachedSealing;
+  }
+
+  private async sealingFromManifest(
+    manifest: ManifestSnapshot
+  ): Promise<SealingState> {
+    if (!manifest.sealing || manifest.sealing.tiers.length === 0) {
+      return { kind: "not_enabled" };
+    }
+    const tiers = manifest.sealing.tiers;
+    let keyring: Keyring;
+    try {
+      keyring = parseKeyring(await this.apiGet(manifest.sealing.keyring_url));
+    } catch (err) {
+      return {
+        kind: "locked",
+        tiers,
+        reason:
+          err instanceof Error
+            ? `keyring unavailable: ${err.message}`
+            : "keyring unavailable",
+      };
+    }
+    const passphrase = resolveSealPassphrase(this.env);
+    if (!passphrase) {
+      return { kind: "locked", tiers, reason: "WIKI_SEAL_PASSPHRASE not set" };
+    }
+    try {
+      const dek = unwrapDek(keyring, passphrase);
+      return { kind: "unlocked", tiers, dek };
+    } catch (err) {
+      if (err instanceof WrongPassphraseError) {
+        return { kind: "locked", tiers, reason: "wrong passphrase" };
+      }
+      return {
+        kind: "locked",
+        tiers,
+        reason: err instanceof Error ? err.message : "wrong passphrase",
+      };
+    }
+  }
+
+  async sealStatus(): Promise<{
+    kind: SealingState["kind"];
+    enabled: boolean;
+    tiers: string[];
+    unlocked: boolean;
+    reason?: string;
+  }> {
+    const state = await this.sealingState();
+    const publicStatus = connectionSealingFromState(state);
     return {
-      page_count: m.page_count ?? 0,
-      sections: m.sections ?? {},
-      viewer_tier: m.viewer_tier ?? "public",
-      viewer_is_owner: Boolean(m.viewer_is_owner),
+      kind: state.kind,
+      enabled: publicStatus.enabled,
+      tiers: publicStatus.tiers,
+      unlocked: publicStatus.unlocked,
+      reason: publicStatus.reason,
     };
+  }
+
+  async sealedBundle(): Promise<Map<string, BundlePage>> {
+    const state = await this.sealingState();
+    if (state.kind !== "unlocked") {
+      return new Map();
+    }
+    if (this.bundleBySlug) return this.bundleBySlug;
+    const manifest = await this.fetchManifest();
+    const url = manifest.sealing?.bundle_url ?? "/wiki/sealed/bundle";
+    const pages = parseBundlePages(await this.apiGet(url));
+    const result = new Map<string, BundlePage>();
+    for (const page of pages) {
+      const cacheKey = `${page.slug}\0${page.updated}`;
+      const cached = this.decryptBySlugUpdated.get(cacheKey);
+      if (cached) {
+        result.set(page.slug, cached);
+        continue;
+      }
+      try {
+        const payload = parseEnvelopePayload(
+          decryptEnvelope(state.dek, page.slug, page.envelope)
+        );
+        const entry: BundlePage = {
+          slug: page.slug,
+          title: payload.title,
+          tags: payload.tags,
+          sources: payload.sources,
+          body: payload.body,
+          tier: page.tier,
+          section: page.section,
+          updated: page.updated,
+        };
+        this.decryptBySlugUpdated.set(cacheKey, entry);
+        result.set(page.slug, entry);
+      } catch {
+        // Skip pages that cannot be decrypted with this DEK.
+      }
+    }
+    this.bundleBySlug = result;
+    return result;
   }
 
   async connectionStatus(): Promise<ConnectionStatus> {
     const manifest = await this.fetchManifest();
-    return buildConnectionStatus(this.baseUrl, this.tokenConfigured, manifest);
+    const sealing =
+      this.cachedSealing ??
+      (this.cachedSealing = await this.sealingFromManifest(manifest));
+    return buildConnectionStatus(
+      this.baseUrl,
+      this.tokenConfigured,
+      manifest,
+      sealing
+    );
   }
 
   /** Fail closed before any owner mutation. Never sends content on failure. */
@@ -868,6 +1441,15 @@ export class WikiClient {
     force_overwrite?: boolean;
   }): Promise<{ report: string; result: WritePagesResult }> {
     await this.requireOwnerCapability();
+    const state = await this.sealingState();
+    if (state.kind === "locked" && isSealedTier(state, "private")) {
+      throw lockedSealedWriteError(state.reason, "write_pages");
+    }
+    if (state.kind === "unlocked" && isSealedTier(state, "private")) {
+      const result = await this.writePagesSealed(state, args);
+      this.invalidateBundle();
+      return { report: formatWritePagesReport(result), result };
+    }
     const body: Record<string, unknown> = {
       session_label: args.session_label,
       pages: args.pages,
@@ -878,7 +1460,121 @@ export class WikiClient {
     const result = parseWritePagesResult(
       await this.request("POST", "/owner/capture/structured", body)
     );
+    this.invalidateBundle();
     return { report: formatWritePagesReport(result), result };
+  }
+
+  private async writePagesSealed(
+    state: Extract<SealingState, { kind: "unlocked" }>,
+    args: {
+      session_label: string;
+      pages: WritePageInput[];
+      force_overwrite?: boolean;
+    }
+  ): Promise<WritePagesResult> {
+    const written: WrittenPage[] = [];
+    const conflicts: Array<{ slug: string; wrote_as: string }> = [];
+    const errors: string[] = [];
+    let sync: WritePagesResult["sync"];
+    const today = utcDateStamp();
+    for (const page of args.pages) {
+      try {
+        const type = SECTION_TO_TYPE[page.section] ?? "concept";
+        const slug = isRootPageSlug(page.slug)
+          ? page.slug
+          : opaqueSlug(state.dek, page.title, page.section);
+        const markdown = sealPage(state.dek, {
+          slug,
+          type,
+          tier: "private",
+          created: today,
+          updated: today,
+          title: page.title,
+          tags: page.tags ?? [],
+          sources: [args.session_label],
+          body: page.body,
+        });
+        const body: Record<string, unknown> = {
+          content: markdown,
+          slug,
+        };
+        if (args.force_overwrite !== undefined) {
+          body.force_overwrite = args.force_overwrite;
+        }
+        const verbatim = parseWritePageVerbatimResult(
+          await this.request("POST", "/owner/capture/verbatim", body)
+        );
+        written.push({
+          rel_path: verbatim.written.rel_path,
+          title: page.title,
+          section: verbatim.written.section || page.section,
+          slug: verbatim.written.slug || slug,
+          tier: verbatim.written.tier || "private",
+        });
+        if (verbatim.conflict) {
+          conflicts.push({ slug, wrote_as: verbatim.conflict.wrote_as });
+        }
+        if (verbatim.sync) sync = verbatim.sync;
+      } catch (err) {
+        errors.push(
+          `${page.slug}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+    return {
+      ok: errors.length === 0 && written.length > 0,
+      written,
+      conflicts,
+      errors,
+      session_label: args.session_label,
+      page_count: written.length,
+      sync,
+    };
+  }
+
+  private maybeSealOutgoing(
+    state: SealingState,
+    markdown: string,
+    slug: string | undefined,
+    action: string
+  ): { content: string; slug?: string } {
+    if (state.kind === "not_enabled" || isSealedMarkdown(markdown)) {
+      return { content: markdown, slug };
+    }
+    const { fm, body } = parsePageDocument(markdown);
+    const tier = fm.tier;
+    if (!tier || !isSealedTier(state, tier)) {
+      return { content: markdown, slug };
+    }
+    if (state.kind !== "unlocked") {
+      throw lockedSealedWriteError(
+        state.kind === "locked" ? state.reason : "WIKI_SEAL_PASSPHRASE not set",
+        action
+      );
+    }
+    const type = fm.type || "concept";
+    const title = fm.title || slug || "untitled";
+    const section = TYPE_TO_SECTION[type] ?? "concepts";
+    const resolvedSlug =
+      slug ??
+      (isRootPageSlug(title.toLowerCase())
+        ? title.toLowerCase()
+        : opaqueSlug(state.dek, title, section));
+    const today = utcDateStamp();
+    return {
+      content: sealPage(state.dek, {
+        slug: resolvedSlug,
+        type,
+        tier,
+        created: fm.created || today,
+        updated: today,
+        title,
+        tags: fm.tags,
+        sources: fm.sources,
+        body,
+      }),
+      slug: resolvedSlug,
+    };
   }
 
   async writePageVerbatim(args: {
@@ -887,22 +1583,110 @@ export class WikiClient {
     force_overwrite?: boolean;
   }): Promise<{ report: string; result: WritePageVerbatimResult }> {
     await this.requireOwnerCapability();
-    const body: Record<string, unknown> = { content: args.content };
-    if (args.slug !== undefined) body.slug = args.slug;
+    const state = await this.sealingState();
+    const sealed = this.maybeSealOutgoing(
+      state,
+      args.content,
+      args.slug,
+      "write_page_verbatim"
+    );
+    const body: Record<string, unknown> = { content: sealed.content };
+    if (sealed.slug !== undefined) body.slug = sealed.slug;
     if (args.force_overwrite !== undefined) {
       body.force_overwrite = args.force_overwrite;
     }
     const result = parseWritePageVerbatimResult(
       await this.request("POST", "/owner/capture/verbatim", body)
     );
+    this.invalidateBundle();
     return { report: formatWritePageVerbatimReport(result), result };
   }
 
   async readPageRaw(slug: string): Promise<PageRaw> {
     await this.requireOwnerCapability();
-    return parsePageRaw(
+    const page = parsePageRaw(
       await this.request("GET", `/owner/page/${encodeURIComponent(slug)}/raw`)
     );
+    if (!isSealedMarkdown(page.markdown)) {
+      return page;
+    }
+    const state = await this.sealingState();
+    if (state.kind === "unlocked") {
+      const open = unsealPage(state.dek, slug, page.markdown);
+      return {
+        ...page,
+        title: open.title,
+        tier: open.tier || page.tier,
+        markdown: renderPlaintextPage({
+          type: open.type,
+          title: open.title,
+          tier: open.tier,
+          created: open.created,
+          updated: open.updated,
+          tags: open.tags,
+          sources: open.sources,
+          body: open.body,
+        }),
+        decrypted_locally: true,
+      };
+    }
+    const reason =
+      state.kind === "locked"
+        ? state.reason
+        : "WIKI_SEAL_PASSPHRASE not set";
+    return { ...page, locked_reason: reason };
+  }
+
+  async readPage(slug: string): Promise<PageView> {
+    const page = parsePageView(
+      await this.apiGet(`/wiki/page/${encodeURIComponent(slug)}`),
+      slug
+    );
+    if (!page.sealed) return page;
+    const state = await this.sealingState();
+    if (state.kind === "unlocked") {
+      try {
+        if (page.envelope) {
+          const payload = parseEnvelopePayload(
+            decryptEnvelope(state.dek, slug, page.envelope)
+          );
+          return {
+            ...page,
+            title: payload.title,
+            tags: payload.tags,
+            sources: payload.sources,
+            body: payload.body,
+            decrypted_locally: true,
+          };
+        }
+        const bundle = await this.sealedBundle();
+        const hit = bundle.get(slug);
+        if (hit) {
+          return {
+            ...page,
+            title: hit.title,
+            tags: hit.tags,
+            sources: hit.sources,
+            body: hit.body,
+            decrypted_locally: true,
+          };
+        }
+      } catch {
+        // Fall through to locked placeholder if decrypt fails.
+      }
+    }
+    const reason =
+      state.kind === "locked"
+        ? state.reason
+        : "WIKI_SEAL_PASSPHRASE not set";
+    return {
+      ...page,
+      title: "Sealed page",
+      body: "",
+      tags: [],
+      sources: [],
+      locked_reason: reason,
+    };
   }
 
   async replacePage(args: {
@@ -910,11 +1694,19 @@ export class WikiClient {
     markdown: string;
   }): Promise<{ report: string; result: ReplacePageResult }> {
     await this.requireOwnerCapability();
+    const state = await this.sealingState();
+    const sealed = this.maybeSealOutgoing(
+      state,
+      args.markdown,
+      args.slug,
+      "replace_page"
+    );
     const result = parseReplacePageResult(
       await this.request("PUT", `/owner/page/${encodeURIComponent(args.slug)}`, {
-        markdown: args.markdown,
+        markdown: sealed.content,
       })
     );
+    this.invalidateBundle();
     return { report: formatReplacePageReport(result), result };
   }
 
@@ -930,18 +1722,68 @@ export class WikiClient {
         `/owner/page/${encodeURIComponent(args.slug)}/raw`
       )
     );
-    const composed = joinAppendedText(raw.markdown, args.text, args.separator);
+    const state = await this.sealingState();
+    let outgoing = joinAppendedText(raw.markdown, args.text, args.separator);
+    let resultTitle = raw.title;
+    if (isSealedMarkdown(raw.markdown)) {
+      if (state.kind === "locked") {
+        throw lockedSealedWriteError(state.reason, "append_to_page");
+      }
+      if (state.kind === "not_enabled") {
+        throw new Error(
+          "Cannot append_to_page: page is sealed but sealing is not enabled on the manifest."
+        );
+      }
+      const open = unsealPage(state.dek, args.slug, raw.markdown);
+      const newBody = joinAppendedText(open.body, args.text, args.separator);
+      const today = utcDateStamp();
+      outgoing = sealPage(state.dek, {
+        slug: args.slug,
+        type: open.type || "overview",
+        tier: open.tier || raw.tier,
+        created: open.created || today,
+        updated: today,
+        title: open.title,
+        tags: open.tags,
+        sources: open.sources,
+        body: newBody,
+      });
+      resultTitle = open.title;
+    } else if (isSealedTier(state, raw.tier || frontmatterTier(raw.markdown))) {
+      if (state.kind === "locked") {
+        throw lockedSealedWriteError(state.reason, "append_to_page");
+      }
+      if (state.kind === "unlocked") {
+        const { fm, body } = parsePageDocument(raw.markdown);
+        const newBody = joinAppendedText(body, args.text, args.separator);
+        const today = utcDateStamp();
+        const type = fm.type || SECTION_TO_TYPE[raw.section] || "overview";
+        outgoing = sealPage(state.dek, {
+          slug: args.slug,
+          type,
+          tier: fm.tier || raw.tier,
+          created: fm.created || today,
+          updated: today,
+          title: fm.title || raw.title,
+          tags: fm.tags,
+          sources: fm.sources,
+          body: newBody,
+        });
+        resultTitle = fm.title || raw.title;
+      }
+    }
     const replaced = parseReplacePageResult(
       await this.request("PUT", `/owner/page/${encodeURIComponent(args.slug)}`, {
-        markdown: composed,
+        markdown: outgoing,
       })
     );
+    this.invalidateBundle();
     const result: AppendToPageResult = {
       slug: args.slug,
       old_size: raw.markdown.length,
       new_size: replaced.size,
       rel_path: replaced.rel_path,
-      title: replaced.title,
+      title: resultTitle || replaced.title,
       tier: replaced.tier,
       sync: replaced.sync,
     };
@@ -960,6 +1802,7 @@ export class WikiClient {
         { tier: args.tier }
       )
     );
+    this.invalidateBundle();
     return { report: formatSetPageTierReport(result), result };
   }
 
@@ -970,7 +1813,235 @@ export class WikiClient {
     const result = parseDeletePageResult(
       await this.request("DELETE", `/owner/page/${encodeURIComponent(slug)}`)
     );
+    this.invalidateBundle();
     return { report: formatDeletePageReport(result), result };
+  }
+
+  async listPages(): Promise<ManifestSnapshot> {
+    const manifest = await this.fetchManifest();
+    const state = await this.sealingState();
+    if (state.kind !== "unlocked") return manifest;
+    const bundle = await this.sealedBundle();
+    const pages = manifest.pages.map((page) => {
+      if (page.title !== "Sealed page" && page.sealed !== true) return page;
+      const hit = bundle.get(page.slug);
+      if (!hit) return page;
+      return {
+        ...page,
+        title: hit.title,
+        tags: hit.tags,
+        excerpt: oneLineExcerpt(hit.body),
+      };
+    });
+    return { ...manifest, pages };
+  }
+
+  async searchWiki(
+    query: string,
+    limit = 10
+  ): Promise<{ results: SearchHit[] }> {
+    const serverResults = parseSearchResults(
+      await this.apiGet(`/wiki/search?q=${encodeURIComponent(query)}`)
+    );
+    const state = await this.sealingState();
+    if (state.kind !== "unlocked") {
+      return { results: serverResults.slice(0, limit) };
+    }
+    const bundle = await this.sealedBundle();
+    const localPages = [...bundle.values()].map((p) => ({
+      slug: p.slug,
+      title: p.title,
+      body: p.body,
+    }));
+    const localHits = localSearch(localPages, query, limit);
+    const localMapped: SearchHit[] = localHits.map((hit) => {
+      const meta = bundle.get(hit.slug);
+      return {
+        slug: hit.slug,
+        title: hit.title,
+        section: meta?.section ?? "",
+        tier: meta?.tier ?? "",
+        excerpt: hit.snippet,
+        score: hit.score,
+        decrypted_locally: true,
+      };
+    });
+    const seen = new Set<string>();
+    const merged: SearchHit[] = [];
+    const combined = [...localMapped, ...serverResults].sort(
+      (a, b) => b.score - a.score
+    );
+    for (const hit of combined) {
+      if (seen.has(hit.slug)) continue;
+      seen.add(hit.slug);
+      merged.push(hit);
+      if (merged.length >= limit) break;
+    }
+    return { results: merged };
+  }
+
+  async queryWiki(question: string): Promise<QueryWikiResult> {
+    const result = parseQueryWiki(
+      await this.apiPost("/wiki/query", { question })
+    );
+    const state = await this.sealingState();
+    if (state.kind !== "unlocked") return result;
+    const bundle = await this.sealedBundle();
+    const localPages = [...bundle.values()].map((p) => ({
+      slug: p.slug,
+      title: p.title,
+      body: p.body,
+    }));
+    const localHits = localSearch(localPages, question, 3);
+    result.sealed_context = localHits.map((hit) => {
+      const body = bundle.get(hit.slug)?.body ?? hit.snippet;
+      return {
+        title: hit.title,
+        snippet: oneLineExcerpt(body, 400),
+      };
+    });
+    return result;
+  }
+
+  async sealInit(args: {
+    tiers?: string[];
+    force?: boolean;
+  }): Promise<{ report: string; keyring: Keyring }> {
+    await this.requireOwnerCapability();
+    const passphrase = resolveSealPassphrase(this.env);
+    if (!passphrase) {
+      throw new Error(
+        "seal_init requires WIKI_SEAL_PASSPHRASE in the MCP env. The passphrase never leaves this process; losing it means sealed pages cannot be recovered."
+      );
+    }
+    const tiers = args.tiers && args.tiers.length > 0 ? args.tiers : ["private"];
+    for (const tier of tiers) {
+      if (!SEALABLE_TIERS.has(tier)) {
+        throw new Error(
+          `seal_init: tier "${tier}" cannot be sealed (allowed: recruiter, friend, private)`
+        );
+      }
+    }
+    const keyring = generateKeyring(passphrase, tiers);
+    await this.request("PUT", "/owner/sealing", {
+      keyring,
+      force: Boolean(args.force),
+    });
+    this.invalidateSealing();
+    return {
+      report: `Sealing initialized for tiers: ${tiers.join(", ")}. Keyring stored on the server. Set WIKI_SEAL_PASSPHRASE in the MCP env to unlock. The server operator cannot recover pages if the passphrase is lost. Server-side orchestrator is disabled on sealed wikis.`,
+      keyring,
+    };
+  }
+
+  async sealDisable(): Promise<{ report: string }> {
+    await this.requireOwnerCapability();
+    await this.request("DELETE", "/owner/sealing");
+    this.invalidateSealing();
+    return {
+      report:
+        "Sealing disabled (keyring tiers cleared). Already-sealed pages stay encrypted and can still be opened with the passphrase. New writes to those tiers are no longer forced through sealing until seal_init is run again.",
+    };
+  }
+
+  async sealPageBySlug(slug: string): Promise<{ report: string; result: ReplacePageResult }> {
+    await this.requireOwnerCapability();
+    const state = await this.sealingState();
+    if (state.kind === "not_enabled") {
+      throw new Error("seal_page: sealing is not enabled. Call seal_init first.");
+    }
+    if (state.kind === "locked") {
+      throw lockedSealedWriteError(state.reason, "seal_page");
+    }
+    const raw = parsePageRaw(
+      await this.request("GET", `/owner/page/${encodeURIComponent(slug)}/raw`)
+    );
+    if (isSealedMarkdown(raw.markdown)) {
+      const result: ReplacePageResult = {
+        ok: true,
+        slug,
+        rel_path: raw.rel_path,
+        tier: raw.tier,
+        title: raw.title,
+        size: raw.markdown.length,
+      };
+      return { report: `Page ${slug} is already sealed.`, result };
+    }
+    const { fm, body } = parsePageDocument(raw.markdown);
+    const tier = fm.tier || raw.tier;
+    if (!isSealedTier(state, tier)) {
+      throw new Error(
+        `seal_page: page ${slug} is at tier=${tier}, which is not a sealed tier (${state.tiers.join(", ")}).`
+      );
+    }
+    const today = utcDateStamp();
+    const markdown = sealPage(state.dek, {
+      slug,
+      type: fm.type || SECTION_TO_TYPE[raw.section] || "overview",
+      tier,
+      created: fm.created || today,
+      updated: today,
+      title: fm.title || raw.title || slug,
+      tags: fm.tags,
+      sources: fm.sources,
+      body,
+    });
+    const result = parseReplacePageResult(
+      await this.request("PUT", `/owner/page/${encodeURIComponent(slug)}`, {
+        markdown,
+      })
+    );
+    this.invalidateBundle();
+    return {
+      report: `Sealed page ${slug} locally (slug unchanged) and PUT ciphertext.`,
+      result,
+    };
+  }
+
+  async unsealPageBySlug(
+    slug: string,
+    tier: WikiTier
+  ): Promise<{ report: string; result: ReplacePageResult }> {
+    await this.requireOwnerCapability();
+    const state = await this.sealingState();
+    if (state.kind === "not_enabled") {
+      throw new Error("unseal_page: sealing is not enabled.");
+    }
+    if (state.kind === "locked") {
+      throw lockedSealedWriteError(state.reason, "unseal_page");
+    }
+    if (isSealedTier(state, tier)) {
+      throw new Error(
+        `unseal_page: target tier ${tier} is still sealed. Choose a non-sealed tier.`
+      );
+    }
+    const raw = parsePageRaw(
+      await this.request("GET", `/owner/page/${encodeURIComponent(slug)}/raw`)
+    );
+    if (!isSealedMarkdown(raw.markdown)) {
+      throw new Error(`unseal_page: page ${slug} is not sealed.`);
+    }
+    const open = unsealPage(state.dek, slug, raw.markdown);
+    const markdown = renderPlaintextPage({
+      type: open.type,
+      title: open.title,
+      tier,
+      created: open.created,
+      updated: utcDateStamp(),
+      tags: open.tags,
+      sources: open.sources,
+      body: open.body,
+    });
+    const result = parseReplacePageResult(
+      await this.request("PUT", `/owner/page/${encodeURIComponent(slug)}`, {
+        markdown,
+      })
+    );
+    this.invalidateBundle();
+    return {
+      report: `Unsealed page ${slug} to tier=${tier} as plaintext.`,
+      result,
+    };
   }
 
   async writebackSpec(): Promise<string> {

--- a/mcp/src/wikiClient.ts
+++ b/mcp/src/wikiClient.ts
@@ -47,7 +47,7 @@ export interface SyncVerdict {
 }
 
 export interface ManifestSealing {
-  enabled: true;
+  enabled: boolean;
   tiers: string[];
   keyring_url: string;
   bundle_url: string;
@@ -312,13 +312,13 @@ export function connectionSealingFromState(
       return { enabled: false, tiers: [], unlocked: false };
     case "locked":
       return {
-        enabled: true,
+        enabled: state.tiers.length > 0,
         tiers: state.tiers,
         unlocked: false,
         reason: state.reason,
       };
     case "unlocked":
-      return { enabled: true, tiers: state.tiers, unlocked: true };
+      return { enabled: state.tiers.length > 0, tiers: state.tiers, unlocked: true };
     default: {
       const _never: never = state;
       return _never;
@@ -381,12 +381,16 @@ export function buildConnectionStatus(
       break;
     case "locked":
       notes.push(
-        `Sealed tiers enabled (${sealing.tiers.join(", ")}) but locked: ${sealing.reason}. Set WIKI_SEAL_PASSPHRASE in the MCP env to read and write sealed pages. The server operator cannot recover pages if the passphrase is lost.`
+        sealing.tiers.length > 0
+          ? `Sealed tiers enabled (${sealing.tiers.join(", ")}) but locked: ${sealing.reason}. Set WIKI_SEAL_PASSPHRASE in the MCP env to read and write sealed pages. The server operator cannot recover pages if the passphrase is lost.`
+          : `Sealing is disabled but a keyring remains for leftover sealed pages; locked: ${sealing.reason}. Set WIKI_SEAL_PASSPHRASE to read or unseal them.`
       );
       break;
     case "unlocked":
       notes.push(
-        `Sealed tiers unlocked locally (${sealing.tiers.join(", ")}). Titles and bodies for those tiers are decrypted in this process; the server stores ciphertext only.`
+        sealing.tiers.length > 0
+          ? `Sealed tiers unlocked locally (${sealing.tiers.join(", ")}). Titles and bodies for those tiers are decrypted in this process; the server stores ciphertext only.`
+          : "Sealing is disabled; leftover sealed pages are decrypted locally with the remaining keyring. Use unseal_page to convert them to plaintext."
       );
       break;
     default: {
@@ -600,8 +604,8 @@ function parseManifestSealing(value: unknown): ManifestSealing | undefined {
   if (!isRecord(value)) {
     throw new Error("manifest.sealing: expected an object");
   }
-  if (value.enabled !== true) {
-    throw new Error("manifest.sealing: enabled must be true when present");
+  if (typeof value.enabled !== "boolean") {
+    throw new Error("manifest.sealing: enabled must be a boolean");
   }
   if (!Array.isArray(value.tiers) || !value.tiers.every((t) => typeof t === "string")) {
     throw new Error("manifest.sealing: tiers must be an array of strings");
@@ -612,10 +616,9 @@ function parseManifestSealing(value: unknown): ManifestSealing | undefined {
   if (typeof value.bundle_url !== "string" || value.bundle_url.length === 0) {
     throw new Error("manifest.sealing: bundle_url must be a non-empty string");
   }
-  if (value.tiers.length === 0) return undefined;
   return {
-    enabled: true,
-    tiers: value.tiers,
+    enabled: value.enabled && value.tiers.length > 0,
+    tiers: value.enabled ? value.tiers : [],
     keyring_url: value.keyring_url,
     bundle_url: value.bundle_url,
   };
@@ -1247,7 +1250,7 @@ export class WikiClient {
   private async sealingFromManifest(
     manifest: ManifestSnapshot
   ): Promise<SealingState> {
-    if (!manifest.sealing || manifest.sealing.tiers.length === 0) {
+    if (!manifest.sealing) {
       return { kind: "not_enabled" };
     }
     const tiers = manifest.sealing.tiers;
@@ -1968,7 +1971,7 @@ export class WikiClient {
   async sealPageBySlug(slug: string): Promise<{ report: string; result: ReplacePageResult }> {
     await this.requireOwnerCapability();
     const state = await this.sealingState();
-    if (state.kind === "not_enabled") {
+    if (state.kind === "not_enabled" || state.tiers.length === 0) {
       throw new Error("seal_page: sealing is not enabled. Call seal_init first.");
     }
     if (state.kind === "locked") {

--- a/mcp/src/wikiClient.ts
+++ b/mcp/src/wikiClient.ts
@@ -57,6 +57,100 @@ export interface IngestApiResult {
   sync?: SyncVerdict;
 }
 
+export type WikiSection =
+  | "entities"
+  | "concepts"
+  | "decisions"
+  | "projects"
+  | "queries";
+
+export type WikiTier = "public" | "recruiter" | "friend" | "private";
+
+export interface WritePageInput {
+  slug: string;
+  title: string;
+  section: WikiSection;
+  tags?: string[];
+  body: string;
+}
+
+export interface WrittenPage {
+  rel_path: string;
+  title: string;
+  section: string;
+  slug?: string;
+  tier?: string;
+}
+
+export interface WritePagesResult {
+  ok: boolean;
+  written: WrittenPage[];
+  conflicts: Array<{ slug: string; wrote_as: string }>;
+  errors: string[];
+  session_label: string;
+  page_count: number;
+  sync?: SyncVerdict;
+}
+
+export interface VerbatimWritten {
+  rel_path: string;
+  title: string;
+  section: string;
+  slug: string;
+  tier: string;
+  page_type: string;
+}
+
+export interface WritePageVerbatimResult {
+  ok: boolean;
+  written: VerbatimWritten;
+  conflict: { wrote_as: string } | null;
+  sync?: SyncVerdict;
+}
+
+export interface PageRaw {
+  slug: string;
+  rel_path: string;
+  title: string;
+  section: string;
+  tier: string;
+  markdown: string;
+}
+
+export interface ReplacePageResult {
+  ok: boolean;
+  slug: string;
+  rel_path: string;
+  tier: string;
+  title: string;
+  size: number;
+  sync?: SyncVerdict;
+}
+
+export interface AppendToPageResult {
+  slug: string;
+  old_size: number;
+  new_size: number;
+  rel_path: string;
+  title: string;
+  tier: string;
+  sync?: SyncVerdict;
+}
+
+export interface SetPageTierResult {
+  ok: boolean;
+  slug: string;
+  tier: string;
+  sync?: SyncVerdict;
+}
+
+export interface DeletePageResult {
+  ok: boolean;
+  slug: string;
+  rel_path: string;
+  sync?: SyncVerdict;
+}
+
 export interface JobSnapshot {
   tracking_id: string;
   kind?: string;
@@ -123,7 +217,7 @@ export function buildConnectionStatus(
       break;
     case "owner":
       notes.push(
-        "Bearer token is owner-capable. Read, write (ingest), and lint are available."
+        "Bearer token is owner-capable. Read, write tools (write_pages, replace_page, delete_page), and lint are available."
       );
       break;
     case "token_not_elevated":
@@ -156,24 +250,24 @@ export function buildConnectionStatus(
 export function ownerPreflightError(status: ConnectionStatus): string {
   if (!status.token_configured) {
     return (
-      `Ingest/lint require an owner-capable token, but WIKI_OWNER_TOKEN is not set. ${OWNER_STDIO_HINT} ` +
+      `Write/lint require an owner-capable token, but WIKI_OWNER_TOKEN is not set. ${OWNER_STDIO_HINT} ` +
       `Current auth_mode=${status.auth_mode}, viewer_tier=${status.viewer_tier}.`
     );
   }
   if (status.auth_mode === "share_read_only") {
     return (
-      `Ingest/lint refused: configured token is share/read-only (tier=${status.viewer_tier}), not owner-capable. ` +
+      `Write/lint refused: configured token is share/read-only (tier=${status.viewer_tier}), not owner-capable. ` +
       `${OWNER_STDIO_HINT}`
     );
   }
   if (status.auth_mode === "token_not_elevated") {
     return (
-      `Ingest/lint refused: a token is configured but the backend did not grant owner capability ` +
+      `Write/lint refused: a token is configured but the backend did not grant owner capability ` +
       `(viewer_tier=${status.viewer_tier}). ${OWNER_STDIO_HINT}`
     );
   }
   return (
-    `Ingest/lint refused: auth_mode=${status.auth_mode} is not owner-capable. ${OWNER_STDIO_HINT}`
+    `Write/lint refused: auth_mode=${status.auth_mode} is not owner-capable. ${OWNER_STDIO_HINT}`
   );
 }
 
@@ -315,6 +409,275 @@ export function formatJobStatusReport(payload: {
   return lines.join("\n");
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseSync(value: unknown): SyncVerdict | undefined {
+  if (!isRecord(value)) return undefined;
+  const mode = value.mode;
+  if (mode !== "global" && mode !== "tenant" && mode !== "local_only") {
+    return undefined;
+  }
+  if (typeof value.will_sync !== "boolean" || typeof value.detail !== "string") {
+    return undefined;
+  }
+  const remote = value.remote;
+  return {
+    will_sync: value.will_sync,
+    mode,
+    remote: typeof remote === "string" ? remote : null,
+    branch: typeof value.branch === "string" ? value.branch : undefined,
+    reason: typeof value.reason === "string" ? value.reason : undefined,
+    detail: value.detail,
+  };
+}
+
+export function joinAppendedText(
+  existing: string,
+  appended: string,
+  separator = "\n"
+): string {
+  return `${existing.replace(/\n+$/, "")}${separator}${appended}`;
+}
+
+export function formatWritePagesReport(result: WritePagesResult): string {
+  const writtenList =
+    result.written.length === 0
+      ? "(none)"
+      : result.written.map((p) => p.rel_path).join(", ");
+  const conflictList =
+    result.conflicts.length === 0
+      ? "(none)"
+      : result.conflicts.map((c) => `${c.slug} -> ${c.wrote_as}`).join(", ");
+  const errorList =
+    result.errors.length === 0 ? "(none)" : result.errors.join("; ");
+  const lines = [
+    "Write pages result:",
+    `- written: ${writtenList}`,
+    `- conflicts: ${conflictList}`,
+    `- errors: ${errorList}`,
+    `- page_count: ${result.written.length}`,
+  ];
+  if (result.sync) {
+    lines.push(
+      `- durable_sync: ${result.sync.will_sync ? "will_sync" : "local_only"} — ${result.sync.detail}`
+    );
+  }
+  const note = formatSyncNote(result.sync).trimEnd();
+  if (note) lines.push(note);
+  return lines.join("\n");
+}
+
+export function formatWritePageVerbatimReport(
+  result: WritePageVerbatimResult
+): string {
+  const w = result.written;
+  const conflict = result.conflict
+    ? `wrote_as=${result.conflict.wrote_as}`
+    : "(none)";
+  const lines = [
+    "Verbatim write result:",
+    `- written: ${w.rel_path} (title=${w.title}, section=${w.section}, slug=${w.slug}, tier=${w.tier}, page_type=${w.page_type})`,
+    `- conflict: ${conflict}`,
+  ];
+  if (result.sync) {
+    lines.push(
+      `- durable_sync: ${result.sync.will_sync ? "will_sync" : "local_only"} — ${result.sync.detail}`
+    );
+  }
+  const note = formatSyncNote(result.sync).trimEnd();
+  if (note) lines.push(note);
+  return lines.join("\n");
+}
+
+export function formatReplacePageReport(result: ReplacePageResult): string {
+  const lines = [
+    `Replaced page ${result.slug}:`,
+    `- title: ${result.title}`,
+    `- tier: ${result.tier}`,
+    `- size: ${result.size}`,
+    `- rel_path: ${result.rel_path}`,
+  ];
+  if (result.sync) {
+    lines.push(
+      `- durable_sync: ${result.sync.will_sync ? "will_sync" : "local_only"} — ${result.sync.detail}`
+    );
+  }
+  const note = formatSyncNote(result.sync).trimEnd();
+  if (note) lines.push(note);
+  return lines.join("\n");
+}
+
+export function formatAppendToPageReport(result: AppendToPageResult): string {
+  const lines = [
+    `Appended to ${result.slug}:`,
+    `- size: ${result.old_size} -> ${result.new_size}`,
+    `- rel_path: ${result.rel_path}`,
+    `- title: ${result.title}`,
+    `- tier: ${result.tier}`,
+  ];
+  if (result.sync) {
+    lines.push(
+      `- durable_sync: ${result.sync.will_sync ? "will_sync" : "local_only"} — ${result.sync.detail}`
+    );
+  }
+  const note = formatSyncNote(result.sync).trimEnd();
+  if (note) lines.push(note);
+  return lines.join("\n");
+}
+
+export function formatSetPageTierReport(result: SetPageTierResult): string {
+  const lines = [`Set tier of ${result.slug} to ${result.tier}.`];
+  if (result.sync) {
+    lines.push(
+      `- durable_sync: ${result.sync.will_sync ? "will_sync" : "local_only"} — ${result.sync.detail}`
+    );
+  }
+  const note = formatSyncNote(result.sync).trimEnd();
+  if (note) lines.push(note);
+  return lines.join("\n");
+}
+
+export function formatDeletePageReport(result: DeletePageResult): string {
+  const lines = [`Deleted page ${result.slug} (${result.rel_path}).`];
+  if (result.sync) {
+    lines.push(
+      `- durable_sync: ${result.sync.will_sync ? "will_sync" : "local_only"} — ${result.sync.detail}`
+    );
+  }
+  const note = formatSyncNote(result.sync).trimEnd();
+  if (note) lines.push(note);
+  return lines.join("\n");
+}
+
+function parseWritePagesResult(value: unknown): WritePagesResult {
+  if (!isRecord(value)) {
+    throw new Error("write_pages: unexpected response");
+  }
+  const written: WrittenPage[] = [];
+  if (Array.isArray(value.written)) {
+    for (const item of value.written) {
+      if (!isRecord(item) || typeof item.rel_path !== "string") continue;
+      written.push({
+        rel_path: item.rel_path,
+        title: typeof item.title === "string" ? item.title : "",
+        section: typeof item.section === "string" ? item.section : "",
+        slug: typeof item.slug === "string" ? item.slug : undefined,
+        tier: typeof item.tier === "string" ? item.tier : undefined,
+      });
+    }
+  }
+  const conflicts: Array<{ slug: string; wrote_as: string }> = [];
+  if (Array.isArray(value.conflicts)) {
+    for (const item of value.conflicts) {
+      if (
+        isRecord(item) &&
+        typeof item.slug === "string" &&
+        typeof item.wrote_as === "string"
+      ) {
+        conflicts.push({ slug: item.slug, wrote_as: item.wrote_as });
+      }
+    }
+  }
+  const errors: string[] = [];
+  if (Array.isArray(value.errors)) {
+    for (const item of value.errors) {
+      if (typeof item === "string") errors.push(item);
+    }
+  }
+  return {
+    ok: value.ok === true,
+    written,
+    conflicts,
+    errors,
+    session_label:
+      typeof value.session_label === "string" ? value.session_label : "",
+    page_count: written.length,
+    sync: parseSync(value.sync),
+  };
+}
+
+function parseWritePageVerbatimResult(value: unknown): WritePageVerbatimResult {
+  if (!isRecord(value) || !isRecord(value.written)) {
+    throw new Error("write_page_verbatim: unexpected response");
+  }
+  const w = value.written;
+  if (typeof w.rel_path !== "string") {
+    throw new Error("write_page_verbatim: written.rel_path missing");
+  }
+  let conflict: { wrote_as: string } | null = null;
+  if (isRecord(value.conflict) && typeof value.conflict.wrote_as === "string") {
+    conflict = { wrote_as: value.conflict.wrote_as };
+  }
+  return {
+    ok: value.ok === true,
+    written: {
+      rel_path: w.rel_path,
+      title: typeof w.title === "string" ? w.title : "",
+      section: typeof w.section === "string" ? w.section : "",
+      slug: typeof w.slug === "string" ? w.slug : "",
+      tier: typeof w.tier === "string" ? w.tier : "",
+      page_type: typeof w.page_type === "string" ? w.page_type : "",
+    },
+    conflict,
+    sync: parseSync(value.sync),
+  };
+}
+
+function parsePageRaw(value: unknown): PageRaw {
+  if (!isRecord(value) || typeof value.markdown !== "string") {
+    throw new Error("read_page_raw: unexpected response");
+  }
+  return {
+    slug: typeof value.slug === "string" ? value.slug : "",
+    rel_path: typeof value.rel_path === "string" ? value.rel_path : "",
+    title: typeof value.title === "string" ? value.title : "",
+    section: typeof value.section === "string" ? value.section : "",
+    tier: typeof value.tier === "string" ? value.tier : "",
+    markdown: value.markdown,
+  };
+}
+
+function parseReplacePageResult(value: unknown): ReplacePageResult {
+  if (!isRecord(value) || typeof value.size !== "number") {
+    throw new Error("replace_page: unexpected response");
+  }
+  return {
+    ok: value.ok === true,
+    slug: typeof value.slug === "string" ? value.slug : "",
+    rel_path: typeof value.rel_path === "string" ? value.rel_path : "",
+    tier: typeof value.tier === "string" ? value.tier : "",
+    title: typeof value.title === "string" ? value.title : "",
+    size: value.size,
+    sync: parseSync(value.sync),
+  };
+}
+
+function parseSetPageTierResult(value: unknown): SetPageTierResult {
+  if (!isRecord(value) || typeof value.tier !== "string") {
+    throw new Error("set_page_tier: unexpected response");
+  }
+  return {
+    ok: value.ok === true,
+    slug: typeof value.slug === "string" ? value.slug : "",
+    tier: value.tier,
+    sync: parseSync(value.sync),
+  };
+}
+
+function parseDeletePageResult(value: unknown): DeletePageResult {
+  if (!isRecord(value) || typeof value.slug !== "string") {
+    throw new Error("delete_page: unexpected response");
+  }
+  return {
+    ok: value.ok === true,
+    slug: value.slug,
+    rel_path: typeof value.rel_path === "string" ? value.rel_path : "",
+    sync: parseSync(value.sync),
+  };
+}
+
 export function authHeaders(token: string): Record<string, string> {
   const h: Record<string, string> = { "Content-Type": "application/json" };
   if (token) h["Authorization"] = `Bearer ${token}`;
@@ -354,7 +717,12 @@ export class WikiClient {
     return Boolean(this.token);
   }
 
-  private async request(method: string, path: string, body?: unknown): Promise<unknown> {
+  private async request(
+    method: string,
+    path: string,
+    body?: unknown,
+    options?: { responseType?: "json" | "text" }
+  ): Promise<unknown> {
     const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
       method,
       headers: authHeaders(this.token),
@@ -363,6 +731,9 @@ export class WikiClient {
     if (!res.ok) {
       const detail = await res.text();
       throw new Error(`${method} ${path} → ${res.status}: ${detail.slice(0, 400)}`);
+    }
+    if (options?.responseType === "text") {
+      return res.text();
     }
     return res.json();
   }
@@ -489,5 +860,126 @@ export class WikiClient {
       persistence,
       polls,
     });
+  }
+
+  async writePages(args: {
+    session_label: string;
+    pages: WritePageInput[];
+    force_overwrite?: boolean;
+  }): Promise<{ report: string; result: WritePagesResult }> {
+    await this.requireOwnerCapability();
+    const body: Record<string, unknown> = {
+      session_label: args.session_label,
+      pages: args.pages,
+    };
+    if (args.force_overwrite !== undefined) {
+      body.force_overwrite = args.force_overwrite;
+    }
+    const result = parseWritePagesResult(
+      await this.request("POST", "/owner/capture/structured", body)
+    );
+    return { report: formatWritePagesReport(result), result };
+  }
+
+  async writePageVerbatim(args: {
+    content: string;
+    slug?: string;
+    force_overwrite?: boolean;
+  }): Promise<{ report: string; result: WritePageVerbatimResult }> {
+    await this.requireOwnerCapability();
+    const body: Record<string, unknown> = { content: args.content };
+    if (args.slug !== undefined) body.slug = args.slug;
+    if (args.force_overwrite !== undefined) {
+      body.force_overwrite = args.force_overwrite;
+    }
+    const result = parseWritePageVerbatimResult(
+      await this.request("POST", "/owner/capture/verbatim", body)
+    );
+    return { report: formatWritePageVerbatimReport(result), result };
+  }
+
+  async readPageRaw(slug: string): Promise<PageRaw> {
+    await this.requireOwnerCapability();
+    return parsePageRaw(
+      await this.request("GET", `/owner/page/${encodeURIComponent(slug)}/raw`)
+    );
+  }
+
+  async replacePage(args: {
+    slug: string;
+    markdown: string;
+  }): Promise<{ report: string; result: ReplacePageResult }> {
+    await this.requireOwnerCapability();
+    const result = parseReplacePageResult(
+      await this.request("PUT", `/owner/page/${encodeURIComponent(args.slug)}`, {
+        markdown: args.markdown,
+      })
+    );
+    return { report: formatReplacePageReport(result), result };
+  }
+
+  async appendToPage(args: {
+    slug: string;
+    text: string;
+    separator?: string;
+  }): Promise<{ report: string; result: AppendToPageResult }> {
+    await this.requireOwnerCapability();
+    const raw = parsePageRaw(
+      await this.request(
+        "GET",
+        `/owner/page/${encodeURIComponent(args.slug)}/raw`
+      )
+    );
+    const composed = joinAppendedText(raw.markdown, args.text, args.separator);
+    const replaced = parseReplacePageResult(
+      await this.request("PUT", `/owner/page/${encodeURIComponent(args.slug)}`, {
+        markdown: composed,
+      })
+    );
+    const result: AppendToPageResult = {
+      slug: args.slug,
+      old_size: raw.markdown.length,
+      new_size: replaced.size,
+      rel_path: replaced.rel_path,
+      title: replaced.title,
+      tier: replaced.tier,
+      sync: replaced.sync,
+    };
+    return { report: formatAppendToPageReport(result), result };
+  }
+
+  async setPageTier(args: {
+    slug: string;
+    tier: WikiTier;
+  }): Promise<{ report: string; result: SetPageTierResult }> {
+    await this.requireOwnerCapability();
+    const result = parseSetPageTierResult(
+      await this.request(
+        "PATCH",
+        `/owner/page/${encodeURIComponent(args.slug)}/tier`,
+        { tier: args.tier }
+      )
+    );
+    return { report: formatSetPageTierReport(result), result };
+  }
+
+  async deletePage(
+    slug: string
+  ): Promise<{ report: string; result: DeletePageResult }> {
+    await this.requireOwnerCapability();
+    const result = parseDeletePageResult(
+      await this.request("DELETE", `/owner/page/${encodeURIComponent(slug)}`)
+    );
+    return { report: formatDeletePageReport(result), result };
+  }
+
+  async writebackSpec(): Promise<string> {
+    const text = await this.request("GET", "/llm-writeback-spec", undefined, {
+      responseType: "text",
+    });
+    if (typeof text !== "string") {
+      throw new Error("writeback_spec: response was not text");
+    }
+    return text;
   }
 }

--- a/mcp/test/reliability.test.mjs
+++ b/mcp/test/reliability.test.mjs
@@ -189,6 +189,9 @@ test("connection_status owner-capable", async () => {
   assert.equal(status.auth_mode, "owner");
   assert.equal(status.capabilities.write, true);
   assert.equal(status.capabilities.lint, true);
+  assert.match(status.notes.join(" "), /write_pages/);
+  assert.match(status.notes.join(" "), /replace_page/);
+  assert.match(status.notes.join(" "), /delete_page/);
   assert.equal(JSON.stringify(status).includes("owner-secret"), false);
 });
 
@@ -488,6 +491,14 @@ test("MCP handshake + tools/list includes diagnostics (mock HTTP backend)", asyn
       "ingest_source",
       "list_pages",
       "query_wiki",
+      "write_pages",
+      "write_page_verbatim",
+      "read_page_raw",
+      "replace_page",
+      "append_to_page",
+      "set_page_tier",
+      "delete_page",
+      "writeback_spec",
     ]) {
       assert.ok(names.includes(required), `missing tool ${required}`);
     }
@@ -509,4 +520,369 @@ test("MCP handshake + tools/list includes diagnostics (mock HTTP backend)", asyn
     proc.kill();
     await new Promise((r) => backend.close(r));
   }
+});
+
+const localOnlySync = {
+  will_sync: false,
+  mode: "local_only",
+  remote: null,
+  detail: "No git remote configured.",
+};
+
+function ownerManifestResponse() {
+  return jsonResponse({
+    page_count: 5,
+    sections: {},
+    viewer_tier: "private",
+    viewer_is_owner: true,
+  });
+}
+
+test("owner write methods fail closed when not owner (no content request)", async () => {
+  const sent = [];
+  const fetchImpl = mockFetchRouter({
+    "GET /wiki/manifest.json": () =>
+      jsonResponse({
+        page_count: 4,
+        sections: {},
+        viewer_tier: "recruiter",
+        viewer_is_owner: false,
+      }),
+    "POST /owner/capture/structured": () => {
+      sent.push("structured");
+      return jsonResponse({ ok: true }, 201);
+    },
+    "POST /owner/capture/verbatim": () => {
+      sent.push("verbatim");
+      return jsonResponse({ ok: true }, 201);
+    },
+    "GET /owner/page/x/raw": () => {
+      sent.push("raw");
+      return jsonResponse({ markdown: "SECRET" });
+    },
+    "PUT /owner/page/x": () => {
+      sent.push("put");
+      return jsonResponse({ ok: true });
+    },
+    "PATCH /owner/page/x/tier": () => {
+      sent.push("tier");
+      return jsonResponse({ ok: true });
+    },
+    "DELETE /owner/page/x": () => {
+      sent.push("del");
+      return jsonResponse({ ok: true });
+    },
+  });
+  const client = new WikiClient("http://mock.wiki", "share-token", fetchImpl);
+  const calls = [
+    () =>
+      client.writePages({
+        session_label: "should-not-send",
+        pages: [
+          {
+            slug: "x",
+            title: "X",
+            section: "concepts",
+            body: "SENSITIVE",
+          },
+        ],
+      }),
+    () => client.writePageVerbatim({ content: "SENSITIVE FRONTMATTER" }),
+    () => client.readPageRaw("x"),
+    () => client.replacePage({ slug: "x", markdown: "SENSITIVE REPLACE" }),
+    () => client.appendToPage({ slug: "x", text: "SENSITIVE APPEND" }),
+    () => client.setPageTier({ slug: "x", tier: "private" }),
+    () => client.deletePage("x"),
+  ];
+  for (const call of calls) {
+    await assert.rejects(call, (err) => {
+      assert.match(String(err.message), /share\/read-only|owner-capable|stdio/i);
+      return true;
+    });
+  }
+  assert.deepEqual(sent, [], "must fail closed before any owner content request");
+});
+
+test("writePages happy path request shape and honest written report", async () => {
+  let captured;
+  const fetchImpl = mockFetchRouter({
+    "GET /wiki/manifest.json": ownerManifestResponse,
+    "POST /owner/capture/structured": (_u, init) => {
+      captured = { method: init.method, body: JSON.parse(init.body) };
+      return jsonResponse(
+        {
+          ok: true,
+          written: [
+            {
+              rel_path: "wiki/concepts/real.md",
+              title: "Real",
+              section: "concepts",
+              slug: "real",
+              tier: "private",
+            },
+          ],
+          conflicts: [{ slug: "ghost", wrote_as: "ghost-from-llm-2026-09-12.md" }],
+          errors: ["skipped unknown section"],
+          session_label: "chatgpt-2026-09-12",
+          page_count: 1,
+          sync: localOnlySync,
+        },
+        201
+      );
+    },
+  });
+  const client = new WikiClient("http://mock.wiki", "owner", fetchImpl);
+  const { report, result } = await client.writePages({
+    session_label: "chatgpt-2026-09-12",
+    pages: [
+      {
+        slug: "real",
+        title: "Real",
+        section: "concepts",
+        tags: ["test"],
+        body: "A drafted page.",
+      },
+    ],
+    force_overwrite: true,
+  });
+  assert.equal(captured.method, "POST");
+  assert.equal(captured.body.session_label, "chatgpt-2026-09-12");
+  assert.equal(captured.body.force_overwrite, true);
+  assert.equal(captured.body.pages[0].slug, "real");
+  assert.equal(captured.body.pages[0].section, "concepts");
+  assert.deepEqual(result.written.map((p) => p.rel_path), [
+    "wiki/concepts/real.md",
+  ]);
+  assert.match(report, /written: wiki\/concepts\/real\.md/);
+  assert.match(report, /conflicts: ghost -> ghost-from-llm-2026-09-12\.md/);
+  assert.match(report, /errors: skipped unknown section/);
+  assert.match(report, /durable_sync: local_only/);
+  assert.doesNotMatch(report, /written:.*ghost-from-llm/);
+});
+
+test("writePageVerbatim happy path request shape and report", async () => {
+  let captured;
+  const fetchImpl = mockFetchRouter({
+    "GET /wiki/manifest.json": ownerManifestResponse,
+    "POST /owner/capture/verbatim": (_u, init) => {
+      captured = { method: init.method, body: JSON.parse(init.body) };
+      return jsonResponse(
+        {
+          ok: true,
+          written: {
+            rel_path: "wiki/concepts/verbatim-note.md",
+            title: "Verbatim Note",
+            section: "concepts",
+            slug: "verbatim-note",
+            tier: "friend",
+            page_type: "concept",
+          },
+          conflict: null,
+          sync: localOnlySync,
+        },
+        201
+      );
+    },
+  });
+  const client = new WikiClient("http://mock.wiki", "owner", fetchImpl);
+  const content = "---\ntype: concept\ntitle: Verbatim Note\ntier: friend\n---\n\nBody.\n";
+  const { report } = await client.writePageVerbatim({
+    content,
+    slug: "verbatim-note",
+    force_overwrite: false,
+  });
+  assert.equal(captured.method, "POST");
+  assert.equal(captured.body.content, content);
+  assert.equal(captured.body.slug, "verbatim-note");
+  assert.equal(captured.body.force_overwrite, false);
+  assert.match(report, /wiki\/concepts\/verbatim-note\.md/);
+  assert.match(report, /tier=friend/);
+  assert.match(report, /conflict: \(none\)/);
+  assert.match(report, /durable_sync: local_only/);
+});
+
+test("readPageRaw happy path returns full markdown", async () => {
+  let capturedPath = "";
+  let capturedMethod = "";
+  const markdown = "---\ntitle: Log\n---\n\n# Log\n";
+  const fetchImpl = mockFetchRouter({
+    "GET /wiki/manifest.json": ownerManifestResponse,
+    "GET /owner/page/log/raw": (_u, init) => {
+      capturedPath = _u.pathname;
+      capturedMethod = init.method ?? "GET";
+      return jsonResponse({
+        slug: "log",
+        rel_path: "wiki/log.md",
+        title: "Log",
+        section: "overview",
+        tier: "private",
+        markdown,
+      });
+    },
+  });
+  const client = new WikiClient("http://mock.wiki", "owner", fetchImpl);
+  const page = await client.readPageRaw("log");
+  assert.equal(capturedMethod, "GET");
+  assert.equal(capturedPath, "/owner/page/log/raw");
+  assert.equal(page.markdown, markdown);
+  assert.equal(page.slug, "log");
+});
+
+test("replacePage happy path request shape and report", async () => {
+  let captured;
+  const markdown = "---\ntitle: Log\n---\n\n# Log\n\n- 2026-09-12 note\n";
+  const fetchImpl = mockFetchRouter({
+    "GET /wiki/manifest.json": ownerManifestResponse,
+    "PUT /owner/page/log": (_u, init) => {
+      captured = {
+        method: init.method,
+        path: _u.pathname,
+        body: JSON.parse(init.body),
+      };
+      return jsonResponse({
+        ok: true,
+        slug: "log",
+        rel_path: "wiki/log.md",
+        tier: "private",
+        title: "Log",
+        size: markdown.length,
+        sync: localOnlySync,
+      });
+    },
+  });
+  const client = new WikiClient("http://mock.wiki", "owner", fetchImpl);
+  const { report } = await client.replacePage({ slug: "log", markdown });
+  assert.equal(captured.method, "PUT");
+  assert.equal(captured.path, "/owner/page/log");
+  assert.equal(captured.body.markdown, markdown);
+  assert.match(report, /tier: private/);
+  assert.match(report, /title: Log/);
+  assert.match(report, new RegExp(`size: ${markdown.length}`));
+  assert.match(report, /durable_sync: local_only/);
+});
+
+test("appendToPage composes read+PUT with exactly one newline separator", async () => {
+  const existing = "---\ntitle: Log\n---\n\n# Log\n";
+  const appended = "- 2026-09-12 added [[Real]]";
+  const expected = "---\ntitle: Log\n---\n\n# Log\n- 2026-09-12 added [[Real]]";
+  const calls = [];
+  const fetchImpl = mockFetchRouter({
+    "GET /wiki/manifest.json": ownerManifestResponse,
+    "GET /owner/page/log/raw": (_u, init) => {
+      calls.push({ method: init.method ?? "GET", path: _u.pathname });
+      return jsonResponse({
+        slug: "log",
+        rel_path: "wiki/log.md",
+        title: "Log",
+        section: "overview",
+        tier: "private",
+        markdown: existing,
+      });
+    },
+    "PUT /owner/page/log": (_u, init) => {
+      calls.push({
+        method: init.method,
+        path: _u.pathname,
+        body: JSON.parse(init.body),
+      });
+      return jsonResponse({
+        ok: true,
+        slug: "log",
+        rel_path: "wiki/log.md",
+        tier: "private",
+        title: "Log",
+        size: expected.length,
+        sync: localOnlySync,
+      });
+    },
+  });
+  const client = new WikiClient("http://mock.wiki", "owner", fetchImpl);
+  const { report } = await client.appendToPage({ slug: "log", text: appended });
+  const contentCalls = calls.filter((c) => c.path !== "/wiki/manifest.json");
+  assert.equal(contentCalls.length, 2);
+  assert.equal(contentCalls[0].method, "GET");
+  assert.equal(contentCalls[0].path, "/owner/page/log/raw");
+  assert.equal(contentCalls[1].method, "PUT");
+  assert.equal(contentCalls[1].path, "/owner/page/log");
+  assert.equal(contentCalls[1].body.markdown, expected);
+  assert.equal(contentCalls[1].body.markdown.includes("\n\n- 2026-09-12"), false);
+  assert.match(report, new RegExp(`${existing.length} -> ${expected.length}`));
+});
+
+test("setPageTier happy path request shape and report", async () => {
+  let captured;
+  const fetchImpl = mockFetchRouter({
+    "GET /wiki/manifest.json": ownerManifestResponse,
+    "PATCH /owner/page/public-entity/tier": (_u, init) => {
+      captured = {
+        method: init.method,
+        path: _u.pathname,
+        body: JSON.parse(init.body),
+      };
+      return jsonResponse({
+        ok: true,
+        slug: "public-entity",
+        tier: "friend",
+        sync: localOnlySync,
+      });
+    },
+  });
+  const client = new WikiClient("http://mock.wiki", "owner", fetchImpl);
+  const { report } = await client.setPageTier({
+    slug: "public-entity",
+    tier: "friend",
+  });
+  assert.equal(captured.method, "PATCH");
+  assert.equal(captured.path, "/owner/page/public-entity/tier");
+  assert.deepEqual(captured.body, { tier: "friend" });
+  assert.match(report, /Set tier of public-entity to friend/);
+  assert.match(report, /durable_sync: local_only/);
+});
+
+test("deletePage happy path request shape and report", async () => {
+  let captured;
+  const fetchImpl = mockFetchRouter({
+    "GET /wiki/manifest.json": ownerManifestResponse,
+    "DELETE /owner/page/delete-me": (_u, init) => {
+      captured = {
+        method: init.method,
+        path: _u.pathname,
+        body: init.body,
+      };
+      return jsonResponse({
+        ok: true,
+        slug: "delete-me",
+        rel_path: "wiki/concepts/delete-me.md",
+        sync: localOnlySync,
+      });
+    },
+  });
+  const client = new WikiClient("http://mock.wiki", "owner", fetchImpl);
+  const { report } = await client.deletePage("delete-me");
+  assert.equal(captured.method, "DELETE");
+  assert.equal(captured.path, "/owner/page/delete-me");
+  assert.equal(captured.body, undefined);
+  assert.match(report, /Deleted page delete-me \(wiki\/concepts\/delete-me\.md\)/);
+  assert.match(report, /durable_sync: local_only/);
+});
+
+test("writebackSpec returns text without requiring a token", async () => {
+  const paths = [];
+  const fetchImpl = async (url, init = {}) => {
+    const u = new URL(url);
+    paths.push(u.pathname);
+    const headers = init.headers ?? {};
+    assert.equal(Boolean(headers.Authorization), false);
+    if (u.pathname === "/llm-writeback-spec") {
+      return new Response("# writeback spec\nsession_label\n", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+    return jsonResponse({ detail: `no mock for ${u.pathname}` }, 404);
+  };
+  const client = new WikiClient("http://mock.wiki", "", fetchImpl);
+  const text = await client.writebackSpec();
+  assert.equal(text, "# writeback spec\nsession_label\n");
+  assert.deepEqual(paths, ["/llm-writeback-spec"]);
 });

--- a/mcp/test/reliability.test.mjs
+++ b/mcp/test/reliability.test.mjs
@@ -499,6 +499,11 @@ test("MCP handshake + tools/list includes diagnostics (mock HTTP backend)", asyn
       "set_page_tier",
       "delete_page",
       "writeback_spec",
+      "seal_init",
+      "seal_disable",
+      "seal_status",
+      "seal_page",
+      "unseal_page",
     ]) {
       assert.ok(names.includes(required), `missing tool ${required}`);
     }

--- a/mcp/test/sealing.test.mjs
+++ b/mcp/test/sealing.test.mjs
@@ -1,0 +1,492 @@
+#!/usr/bin/env node
+/**
+ * Sealed-tier crypto + WikiClient behaviour. HTTP is mocked.
+ */
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distWiki = join(__dirname, "../dist/wikiClient.js");
+const distSeal = join(__dirname, "../dist/sealing.js");
+
+const { WikiClient } = await import(pathToFileURL(distWiki).href);
+const {
+  WrongPassphraseError,
+  decryptEnvelope,
+  encryptEnvelope,
+  generateKeyring,
+  isSealedMarkdown,
+  localSearch,
+  opaqueSlug,
+  parseKeyring,
+  parsePageDocument,
+  sealPage,
+  unsealPage,
+  unwrapDek,
+} = await import(pathToFileURL(distSeal).href);
+
+function envelopeOf(markdown) {
+  return parsePageDocument(markdown).body.replace(/\s+/g, "");
+}
+
+const PASSPHRASE = "correct-horse-battery";
+const WRONG = "incorrect-horse";
+const keyring = generateKeyring(PASSPHRASE, ["private"]);
+const dek = unwrapDek(keyring, PASSPHRASE);
+
+function mockFetchRouter(routes) {
+  return async (url, init = {}) => {
+    const u = new URL(url);
+    const method = (init.method ?? "GET").toUpperCase();
+    const key = `${method} ${u.pathname}`;
+    const handler = routes[key] ?? routes[`* ${u.pathname}`];
+    if (!handler) {
+      return new Response(JSON.stringify({ detail: `no mock for ${key}` }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return handler(u, init);
+  };
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function sealingManifest(extra = {}) {
+  return {
+    page_count: 5,
+    sections: { concepts: 2 },
+    viewer_tier: "private",
+    viewer_is_owner: true,
+    pages: extra.pages ?? [],
+    sealing: {
+      enabled: true,
+      tiers: extra.tiers ?? ["private"],
+      keyring_url: "/wiki/sealing",
+      bundle_url: "/wiki/sealed/bundle",
+    },
+  };
+}
+
+function ownerUnlockedClient(routes, passphrase = PASSPHRASE) {
+  const fetchImpl = mockFetchRouter({
+    "GET /wiki/manifest.json": () => jsonResponse(sealingManifest()),
+    "GET /wiki/sealing": () => jsonResponse(keyring),
+    ...routes,
+  });
+  return new WikiClient("http://mock.wiki", "owner", fetchImpl, {
+    WIKI_SEAL_PASSPHRASE: passphrase,
+  });
+}
+
+const localOnlySync = {
+  will_sync: false,
+  mode: "local_only",
+  remote: null,
+  detail: "No git remote configured.",
+};
+
+test("crypto envelope round trip", () => {
+  const json = JSON.stringify({
+    v: 1,
+    title: "T",
+    tags: ["a"],
+    sources: [],
+    body: "hello [[Wiki]]",
+  });
+  const env = encryptEnvelope(dek, "my-slug", json);
+  assert.equal(decryptEnvelope(dek, "my-slug", env), json);
+});
+
+test("wrong passphrase throws WrongPassphraseError", () => {
+  assert.throws(() => unwrapDek(keyring, WRONG), (err) => {
+    assert.ok(err instanceof WrongPassphraseError);
+    return true;
+  });
+});
+
+test("AAD binding: decrypt under another slug fails", () => {
+  const json = '{"v":1,"title":"T","tags":[],"sources":[],"body":"x"}';
+  const env = encryptEnvelope(dek, "slug-a", json);
+  assert.throws(() => decryptEnvelope(dek, "slug-b", env));
+});
+
+test("opaque slug is deterministic and decisions get a date prefix", () => {
+  const a = opaqueSlug(dek, "My Decision", "decisions", "2026-09-12");
+  const b = opaqueSlug(dek, "My Decision", "decisions", "2026-09-12");
+  assert.equal(a, b);
+  assert.match(a, /^2026-09-12-s-[0-9a-f]{16}$/);
+  const c = opaqueSlug(dek, "My Concept", "concepts");
+  const d = opaqueSlug(dek, "  My Concept ", "concepts");
+  assert.equal(c, d);
+  assert.match(c, /^s-[0-9a-f]{16}$/);
+});
+
+test("sealPage / unsealPage round trip", () => {
+  const md = sealPage(dek, {
+    slug: "s-abc",
+    type: "concept",
+    tier: "private",
+    created: "2026-09-12",
+    updated: "2026-09-12",
+    title: "Hidden Title",
+    tags: ["secret"],
+    sources: ["session-1"],
+    body: "Body with [[Link]]",
+  });
+  assert.equal(isSealedMarkdown(md), true);
+  assert.match(md, /sealed: v1/);
+  assert.doesNotMatch(md, /Hidden Title/);
+  const open = unsealPage(dek, "s-abc", md);
+  assert.equal(open.title, "Hidden Title");
+  assert.deepEqual(open.tags, ["secret"]);
+  assert.deepEqual(open.sources, ["session-1"]);
+  assert.equal(open.body, "Body with [[Link]]");
+  assert.equal(open.tier, "private");
+  assert.equal(open.type, "concept");
+});
+
+test("generateKeyring then unwrapDek", () => {
+  const kr = parseKeyring(keyring);
+  assert.equal(kr.v, 1);
+  assert.deepEqual(kr.tiers, ["private"]);
+  assert.equal(kr.kdf, "pbkdf2-sha256");
+  assert.equal(kr.iterations, 600000);
+  assert.equal(unwrapDek(kr, PASSPHRASE).length, 32);
+  assert.throws(() => parseKeyring({}), /keyring/);
+  assert.throws(() => generateKeyring(PASSPHRASE, ["public"]), /public/);
+});
+
+test("localSearch scores title substring and word overlap", () => {
+  const hits = localSearch(
+    [
+      { slug: "a", title: "Secret Plan", body: "details about launch window" },
+      { slug: "b", title: "Public Note", body: "nothing relevant" },
+    ],
+    "secret launch",
+    10
+  );
+  assert.equal(hits[0].slug, "a");
+  assert.ok(hits[0].score > 0);
+  assert.match(hits[0].snippet, /launch|details/i);
+});
+
+test("sealingState not_enabled when manifest has no sealing key", async () => {
+  const fetchImpl = mockFetchRouter({
+    "GET /wiki/manifest.json": () =>
+      jsonResponse({
+        page_count: 1,
+        sections: {},
+        viewer_tier: "public",
+        viewer_is_owner: false,
+      }),
+  });
+  const client = new WikiClient("http://mock.wiki", "", fetchImpl, {});
+  const state = await client.sealingState();
+  assert.equal(state.kind, "not_enabled");
+  const status = await client.connectionStatus();
+  assert.equal(status.sealing.enabled, false);
+  assert.equal(status.sealing.unlocked, false);
+});
+
+test("sealingState locked when WIKI_SEAL_PASSPHRASE is not set", async () => {
+  const fetchImpl = mockFetchRouter({
+    "GET /wiki/manifest.json": () => jsonResponse(sealingManifest()),
+    "GET /wiki/sealing": () => jsonResponse(keyring),
+  });
+  const client = new WikiClient("http://mock.wiki", "owner", fetchImpl, {});
+  const state = await client.sealingState();
+  assert.equal(state.kind, "locked");
+  assert.equal(state.reason, "WIKI_SEAL_PASSPHRASE not set");
+  const status = await client.connectionStatus();
+  assert.equal(status.sealing.enabled, true);
+  assert.equal(status.sealing.unlocked, false);
+  assert.match(status.notes.join(" "), /WIKI_SEAL_PASSPHRASE/);
+});
+
+test("sealingState locked on wrong passphrase", async () => {
+  const client = ownerUnlockedClient({}, WRONG);
+  const state = await client.sealingState();
+  assert.equal(state.kind, "locked");
+  assert.equal(state.reason, "wrong passphrase");
+});
+
+test("sealingState unlocked with correct passphrase", async () => {
+  const client = ownerUnlockedClient();
+  const state = await client.sealingState();
+  assert.equal(state.kind, "unlocked");
+  assert.deepEqual(state.tiers, ["private"]);
+  assert.equal(state.dek.length, 32);
+  const status = await client.connectionStatus();
+  assert.equal(status.sealing.unlocked, true);
+});
+
+test("writePages routes to verbatim with sealed content when unlocked", async () => {
+  const title = "Secret Title";
+  const bodyText = "hidden body text that must not be posted";
+  let structuredCalls = 0;
+  let captured;
+  const expectedSlug = opaqueSlug(dek, title, "concepts");
+  const client = ownerUnlockedClient({
+    "POST /owner/capture/structured": () => {
+      structuredCalls += 1;
+      return jsonResponse({ ok: true }, 201);
+    },
+    "POST /owner/capture/verbatim": (_u, init) => {
+      captured = JSON.parse(init.body);
+      return jsonResponse(
+        {
+          ok: true,
+          written: {
+            rel_path: `wiki/concepts/${expectedSlug}.md`,
+            title: "Sealed page",
+            section: "concepts",
+            slug: expectedSlug,
+            tier: "private",
+            page_type: "concept",
+          },
+          conflict: null,
+          sync: localOnlySync,
+        },
+        201
+      );
+    },
+  });
+  const { result } = await client.writePages({
+    session_label: "chatgpt-2026-09-12",
+    pages: [
+      {
+        slug: "secret-title",
+        title,
+        section: "concepts",
+        body: bodyText,
+      },
+    ],
+    force_overwrite: true,
+  });
+  assert.equal(structuredCalls, 0);
+  assert.ok(captured);
+  assert.equal(captured.slug, expectedSlug);
+  assert.equal(captured.force_overwrite, true);
+  assert.match(captured.content, /sealed: v1/);
+  assert.equal(captured.content.includes(title), false);
+  assert.equal(captured.content.includes(bodyText), false);
+  assert.deepEqual(result.written.map((p) => p.rel_path), [
+    `wiki/concepts/${expectedSlug}.md`,
+  ]);
+  assert.equal(result.written[0].title, title);
+});
+
+test("writePages refuses when locked without sending", async () => {
+  let sent = 0;
+  const fetchImpl = mockFetchRouter({
+    "GET /wiki/manifest.json": () => jsonResponse(sealingManifest()),
+    "GET /wiki/sealing": () => jsonResponse(keyring),
+    "POST /owner/capture/structured": () => {
+      sent += 1;
+      return jsonResponse({ ok: true }, 201);
+    },
+    "POST /owner/capture/verbatim": () => {
+      sent += 1;
+      return jsonResponse({ ok: true }, 201);
+    },
+  });
+  const client = new WikiClient("http://mock.wiki", "owner", fetchImpl, {});
+  await assert.rejects(
+    () =>
+      client.writePages({
+        session_label: "chatgpt-2026-09-12",
+        pages: [
+          {
+            slug: "x",
+            title: "X",
+            section: "concepts",
+            body: "SENSITIVE",
+          },
+        ],
+      }),
+    (err) => {
+      assert.match(String(err.message), /locked|WIKI_SEAL_PASSPHRASE/i);
+      return true;
+    }
+  );
+  assert.equal(sent, 0);
+});
+
+test("appendToPage on a sealed page re-seals", async () => {
+  const slug = "log";
+  const sealedMd = sealPage(dek, {
+    slug,
+    type: "overview",
+    tier: "private",
+    created: "2026-09-01",
+    updated: "2026-09-01",
+    title: "Log",
+    tags: [],
+    sources: [],
+    body: "# Log\n",
+  });
+  let putBody;
+  const client = ownerUnlockedClient({
+    "GET /owner/page/log/raw": () =>
+      jsonResponse({
+        slug,
+        rel_path: "wiki/log.md",
+        title: "Sealed page",
+        section: "root",
+        tier: "private",
+        markdown: sealedMd,
+      }),
+    "PUT /owner/page/log": (_u, init) => {
+      putBody = JSON.parse(init.body);
+      return jsonResponse({
+        ok: true,
+        slug,
+        rel_path: "wiki/log.md",
+        tier: "private",
+        title: "Sealed page",
+        size: putBody.markdown.length,
+        sync: localOnlySync,
+      });
+    },
+  });
+  await client.appendToPage({ slug, text: "- 2026-09-12 added [[Real]]" });
+  assert.ok(putBody);
+  assert.equal(isSealedMarkdown(putBody.markdown), true);
+  const open = unsealPage(dek, slug, putBody.markdown);
+  assert.match(open.body, /# Log/);
+  assert.match(open.body, /2026-09-12 added \[\[Real\]\]/);
+  assert.doesNotMatch(putBody.markdown, /added \[\[Real\]\]/);
+});
+
+test("readPageRaw decrypts sealed markdown", async () => {
+  const slug = "s-hidden";
+  const sealedMd = sealPage(dek, {
+    slug,
+    type: "concept",
+    tier: "private",
+    created: "2026-09-12",
+    updated: "2026-09-12",
+    title: "Hidden Title",
+    tags: ["t"],
+    sources: ["src"],
+    body: "classified body",
+  });
+  const client = ownerUnlockedClient({
+    [`GET /owner/page/${slug}/raw`]: () =>
+      jsonResponse({
+        slug,
+        rel_path: `wiki/concepts/${slug}.md`,
+        title: "Sealed page",
+        section: "concepts",
+        tier: "private",
+        markdown: sealedMd,
+      }),
+  });
+  const page = await client.readPageRaw(slug);
+  assert.equal(page.decrypted_locally, true);
+  assert.match(page.markdown, /title: Hidden Title/);
+  assert.match(page.markdown, /classified body/);
+  assert.doesNotMatch(page.markdown, /sealed: v1/);
+});
+
+test("searchWiki merges local decrypted hits", async () => {
+  const slug = opaqueSlug(dek, "Hidden Launch", "concepts");
+  const sealedMd = sealPage(dek, {
+    slug,
+    type: "concept",
+    tier: "private",
+    created: "2026-09-12",
+    updated: "2026-09-12",
+    title: "Hidden Launch",
+    tags: [],
+    sources: [],
+    body: "details about the sealed launch window",
+  });
+  const envelope = envelopeOf(sealedMd);
+  const client = ownerUnlockedClient({
+    "GET /wiki/search": () =>
+      jsonResponse({
+        results: [
+          {
+            slug: "public-note",
+            title: "Public Note",
+            section: "concepts",
+            tier: "public",
+            excerpt: "visible",
+            score: 1,
+          },
+        ],
+      }),
+    "GET /wiki/sealed/bundle": () =>
+      jsonResponse({
+        count: 1,
+        pages: [
+          {
+            slug,
+            section: "concepts",
+            tier: "private",
+            updated: "2026-09-12",
+            envelope,
+          },
+        ],
+      }),
+  });
+  const { results } = await client.searchWiki("launch", 10);
+  const local = results.find((r) => r.decrypted_locally);
+  assert.ok(local);
+  assert.equal(local.title, "Hidden Launch");
+  assert.equal(local.slug, slug);
+});
+
+test("queryWiki appends sealed context and mentions sealed_excluded", async () => {
+  const slug = opaqueSlug(dek, "Hidden Launch", "concepts");
+  const sealedMd = sealPage(dek, {
+    slug,
+    type: "concept",
+    tier: "private",
+    created: "2026-09-12",
+    updated: "2026-09-12",
+    title: "Hidden Launch",
+    tags: [],
+    sources: [],
+    body: "details about the sealed launch window",
+  });
+  const envelope = envelopeOf(sealedMd);
+  const client = ownerUnlockedClient({
+    "POST /wiki/query": () =>
+      jsonResponse({
+        answer: "Server answer from public pages.",
+        citations: [{ slug: "public-note", title: "Public Note" }],
+        backend: "keyword",
+        sealed_excluded: 2,
+      }),
+    "GET /wiki/sealed/bundle": () =>
+      jsonResponse({
+        count: 1,
+        pages: [
+          {
+            slug,
+            section: "concepts",
+            tier: "private",
+            updated: "2026-09-12",
+            envelope,
+          },
+        ],
+      }),
+  });
+  const { formatQueryWikiReport } = await import(pathToFileURL(distWiki).href);
+  const result = await client.queryWiki("launch window");
+  assert.equal(result.sealed_excluded, 2);
+  assert.equal(result.sealed_context[0]?.title, "Hidden Launch");
+  const report = formatQueryWikiReport(result);
+  assert.match(report, /Sealed context \(decrypted locally\)/);
+  assert.match(report, /sealed_excluded=2/);
+});


### PR DESCRIPTION
## What

- **MCP write tools (0.2.0 -> 0.3.0)**: `write_pages`, `write_page_verbatim`, `read_page_raw`, `replace_page`, `append_to_page`, `set_page_tier`, `delete_page`, `writeback_spec`. The user's own LLM session drafts and writes the graph; the server-side orchestrator becomes the legacy path.
- **Sealed tiers**: opt-in client-side encryption of `private` / `friend` / `recruiter` pages. PBKDF2-SHA256 (600k) passphrase -> wrapped DEK; AES-256-GCM per page with AAD = slug; opaque `s-<hmac>` slugs. The hosted server stores ciphertext and sees tier, section, dates, count. MCP and browser both encrypt/decrypt; interop verified both ways.
- Backend: keyring at `wiki/.sealed/keyring.json`, `GET /wiki/sealing`, `GET /wiki/sealed/bundle`, `PUT`/`DELETE /owner/sealing`, `DELETE /owner/page/{slug}`; 409 guards on every server-side LLM path and on plaintext writes into sealed tiers.
- Frontend: nav unlock, decrypted rendering, owner Sealing panel.
- Merges the 0.2.4 hosted direct-drafter fallback from `main`; the two reingest routes are now also guarded.

## Proof

- backend 540 pass, mcp 42 pass + tsc, frontend 229 pass + tsc + `next build`.
- Live round trip against a scratch backend through the built MCP client: ciphertext on disk, server search/raw/bundle blind, MCP and browser decrypt, all guards fire, disable keeps leftovers unlockable. Cross-implementation keyring/envelope interop.
- Security review (Puppetmaster, Grok 4.6): SHIP WITH FIXES; all must-fix items closed in `e09e7fb`.
- **Zero regression for unsealed wikis**: baseline vs this tree served the same 2632-page corpus side by side. `/wiki/page/*`, `/wiki/search`, `/llm`, `/llms.txt` byte-identical; manifest identical apart from `generated_at`; manifest p50 13.19 vs 13.47 ms, reload 596 vs 585 ms.